### PR TITLE
Add missing "def" in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install using `pip`:
 Create an application, in `app.py`:
 
 ```python
-async hello_world(message, channels):
+async def hello_world(message, channels):
     content = b'Hello, world'
     response = {
         'status': 200,


### PR DESCRIPTION
The example in README fails to run with:

```
    async hello_world(message, channels):
                    ^
SyntaxError: invalid syntax
```
FIx: Add missing "def" in the example:

```
async def hello_world(message, channels):
    content = b'Hello, world'
    response = {
        'status': 200,
        'headers': [
            [b'content-type', b'text/plain'],
        ],
        'content': content
    }
    await channels['reply'].send(response)
```
