### PR TITLE
Fix pipelining behavior

### DIFF
--- a/uvicorn/protocols/http.py
+++ b/uvicorn/protocols/http.py
@@ -123,9 +123,7 @@ class HttpProtocol(asyncio.Protocol):
     __slots__ = [
         'consumer', 'loop', 'request_parser',
         'base_message', 'base_channels',
-        'message', 'channels',
-        'headers', 'transport',
-        'upgrade',
+        'transport', 'message', 'channels', 'headers', 'upgrade',
         'read_paused', 'write_paused',
         'buffer_size', 'high_water_limit', 'low_water_limit',
         'has_active_request', 'max_pipelined_requests', 'pipeline_queue'
@@ -148,6 +146,7 @@ class HttpProtocol(asyncio.Protocol):
 
         self.transport = None
         self.message = None
+        self.channels = None
         self.headers = None
         self.upgrade = None
 

--- a/uvicorn/protocols/http.py
+++ b/uvicorn/protocols/http.py
@@ -38,33 +38,30 @@ STATUS_LINE = {
     status_code: get_status_line(status_code) for status_code in range(100, 600)
 }
 
-(LOW_WATER_LIMIT, HIGH_WATER_LIMIT) = (16384, 65536)
+LOW_WATER_LIMIT = 16384
+HIGH_WATER_LIMIT = 65536
+MAX_PIPELINED_REQUESTS = 20
 
 set_time_and_date()
 
 
 class BodyChannel(object):
-    __slots__ = ['_queue', '_low_water_limit', '_high_water_limit', '_buffer_size', '_protocol', 'name']
+    __slots__ = ['_queue', '_protocol', 'name']
 
-    def __init__(self, protocol, low_water_limit=LOW_WATER_LIMIT, high_water_limit=HIGH_WATER_LIMIT):
+    def __init__(self, protocol):
         self._queue = asyncio.Queue()
-        self._low_water_limit = low_water_limit
-        self._high_water_limit = high_water_limit
-        self._buffer_size = 0
         self._protocol = protocol
         self.name = 'body:%d' % id(self)
 
     def _put(self, message):
         self._queue.put_nowait(message)
-        self._buffer_size += len(message['content'])
-        if not self._protocol.read_paused and self._buffer_size > self._high_water_limit:
-            self._protocol.pause_reading()
+        self._protocol.buffer_size += len(message['content'])
+        self._protocol.check_pause_reading()
 
     async def receive(self):
         message = await self._queue.get()
-        self._buffer_size -= len(message['content'])
-        if self._protocol.read_paused and self._buffer_size < self._low_water_limit:
-            self._protocol.resume_reading()
+        self._protocol.buffer_size -= len(message['content'])
+        self._protocol.check_resume_reading()
 
 
 class ReplyChannel(object):
@@ -112,12 +109,14 @@ class ReplyChannel(object):
             transport.write(content)
 
         if not more_content:
-            protocol.concurrent_requests -= 1
             if (not status) or (not self._protocol.request_parser.should_keep_alive()):
                 transport.close()
-            elif protocol.request_queue:
-                message, channels = protocol.request_queue.popleft()
+            elif protocol.pipeline_queue:
+                message, channels = protocol.pipeline_queue.popleft()
                 protocol.loop.create_task(protocol.consumer(message, channels))
+                protocol.check_resume_reading()
+            else:
+                protocol.has_active_request = False
 
 
 class HttpProtocol(asyncio.Protocol):
@@ -128,7 +127,8 @@ class HttpProtocol(asyncio.Protocol):
         'headers', 'transport',
         'upgrade',
         'read_paused', 'write_paused',
-        'concurrent_requests', 'request_queue'
+        'buffer_size', 'high_water_limit', 'low_water_limit',
+        'has_active_request', 'max_pipelined_requests', 'pipeline_queue'
     ]
 
     def __init__(self, consumer, loop, sock, cfg):
@@ -154,8 +154,13 @@ class HttpProtocol(asyncio.Protocol):
         self.read_paused = False
         self.write_paused = False
 
-        self.concurrent_requests = 0
-        self.request_queue = collections.deque()
+        self.buffer_size = 0
+        self.high_water_limit = HIGH_WATER_LIMIT
+        self.low_water_limit = LOW_WATER_LIMIT
+
+        self.has_active_request = False
+        self.max_pipelined_requests = MAX_PIPELINED_REQUESTS
+        self.pipeline_queue = collections.deque()
 
     # The asyncio.Protocol hooks...
     def connection_made(self, transport):
@@ -180,15 +185,21 @@ class HttpProtocol(asyncio.Protocol):
     def resume_writing(self):
         self.write_paused = False
 
-    def pause_reading(self):
-        if self.transport is not None:
+    def check_pause_reading(self):
+        if self.transport is None or self.read_paused:
+            return
+        if (self.buffer_size > self.high_water_limit or
+            len(self.pipeline_queue) >= self.max_pipelined_requests):
             self.transport.pause_reading()
-        self.read_paused = True
+            self.read_paused = True
 
-    def resume_reading(self):
-        if self.transport is not None:
+    def check_resume_reading(self):
+        if self.transport is None or not self.read_paused:
+            return
+        if (self.buffer_size < self.low_water_limit and
+            len(self.pipeline_queue) < self.max_pipelined_requests):
             self.transport.resume_reading()
-        self.read_paused = False
+            self.read_paused = False
 
     # Event hooks called back into by HttpRequestParser...
     def on_message_begin(self):
@@ -219,11 +230,12 @@ class HttpProtocol(asyncio.Protocol):
     def on_body(self, body: bytes):
         if 'body' not in self.channels:
             self.channels['body'] = BodyChannel(self.transport)
-            if self.concurrent_requests:
-                self.request_queue.append((self.message, self.channels))
-            else:
+            if not self.has_active_request:
                 self.loop.create_task(self.consumer(self.message, self.channels))
-                self.concurrent_requests += 1
+                self.has_active_request = True
+            else:
+                self.pipeline_queue.append((self.message, self.channels))
+                self.check_pause_reading()
         message = {
             'content': body,
             'more_content': True
@@ -235,11 +247,12 @@ class HttpProtocol(asyncio.Protocol):
             return
 
         if 'body' not in self.channels:
-            if self.concurrent_requests:
-                self.request_queue.append((self.message, self.channels))
-            else:
+            if not self.has_active_request:
                 self.loop.create_task(self.consumer(self.message, self.channels))
-                self.concurrent_requests += 1
+                self.has_active_request = True
+            else:
+                self.pipeline_queue.append((self.message, self.channels))
+                self.check_pause_reading()
         else:
             message = {
                 'content': b'',


### PR DESCRIPTION
Behavior when requests are pipelined is currently buggy, as responses may not necessarily come back in order.

- [x] Ensure tasks run sequentially.
- [x] Ensure read buffer watermarks are applied to the protocol as a whole, not per-request.
- [x] Ensure transport pauses against a high number of pipelined requests.

Closes #19