### PR TITLE
Add BodyChannel.close()

### DIFF
--- a/uvicorn/protocols/http.py
+++ b/uvicorn/protocols/http.py
@@ -58,6 +58,9 @@ class BodyChannel(object):
         self._protocol.buffer_size += len(message['content'])
         self._protocol.check_pause_reading()
 
+    def close(self):
+        self._protocol.transport.close()
+
     async def receive(self):
         message = await self._queue.get()
         self._protocol.buffer_size -= len(message['content'])


### PR DESCRIPTION
When `keep alive` is enabled, user can not stop  incoming data of `request body chunks`.
I think a function of  stopping incoming data is necessary.