### PR TITLE
support py3 wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+python-tag = py3


### PR DESCRIPTION
will need to be run with "python3 setup.py sdist bdist_wheel upload"

And because you're only supporting brand new Python 3 installs it might even not be worth uploading the sdist at all:

will need to be run with "python3 setup.py bdist_wheel upload"