### PR TITLE
Allow load_app() to resolve dot notated modules

### DIFF
--- a/tests/fixtures/a/b.py
+++ b/tests/fixtures/a/b.py
@@ -1,0 +1,1 @@
+def c(): pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,18 @@
-from uvicorn.main import Server
+from uvicorn.main import Server, load_app
 
 
 def test_server():
     server = Server(None)
     server.should_exit = True
     server.run()
+
+
+def test_load_app():
+    assert callable(
+        load_app("tests.fixtures.a.b:c")
+    ), "should resolve dot notated module paths"
+
+    def fn():
+        pass
+
+    assert callable(load_app(fn)), "should load callables directly"

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -3,9 +3,10 @@ from uvicorn.protocols.http import H11Protocol, HttpToolsProtocol
 import asyncio
 import click
 import importlib
-import signal
-import os
 import logging
+import os
+import pathlib
+import signal
 import sys
 
 
@@ -69,11 +70,14 @@ def load_app(app):
         message = 'Invalid app string "{app}". Must be in format "<module>:<app>".'
         raise click.UsageError(message.format(app=app))
 
-    module_str, _, attr = app.partition(":")
+    module_str, attr = app.split(":", 1)
+    module_path = pathlib.Path(module_str).resolve()
+    sys.path.insert(0, str(module_path.parent))
+
     try:
-        module = importlib.import_module(module_str)
+        module = importlib.import_module(module_path.name)
     except ModuleNotFoundError:
-        message = 'Error loading ASGI app. Could not import module "{module_str}".'
+        message = 'Error loading ASGI app. Could not find module "{module_str}".'
         raise click.UsageError(message.format(module_str=module_str))
 
     try:


### PR DESCRIPTION
This is an attempt to fix #106. At least its working in my usecase, where I was experiencing the same behaviour as reported there.

I also added a testcase with some fixtures files - dunno if you'd like to introduce these here?
Funny thing about the testcase is, that its also passing with the previous code, haha.
That however I _think_ is due to the testscript setting `PYTHONPATH=.`