### PR TITLE
Module loading fixes

### DIFF
--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,4 +1,4 @@
 from uvicorn.main import main, run
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __all__ = ["main", "run"]


### PR DESCRIPTION
* Add "." to PYTHONPATH
* Support dot notation in second part of "path.to.module:App.callable"

(Previously only "path.to.module:App" style was supported)

Closes #107
Closes #106