### PR TITLE
Allow receipt of http.disconnect messages after body consumption

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -462,29 +462,6 @@ def test_early_response(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
-def test_read_past_end_of_stream(protocol_cls):
-    read_past_end_of_stream_error = False
-
-    class App:
-        def __init__(self, scope):
-            pass
-
-        async def __call__(self, receive, send):
-            nonlocal read_past_end_of_stream_error
-
-            message = await receive()
-            try:
-                message = await receive()
-            except:
-                read_past_end_of_stream_error = True
-
-    protocol = get_connected_protocol(App, protocol_cls)
-    protocol.data_received(SIMPLE_POST_REQUEST)
-    protocol.loop.run_one()
-    assert read_past_end_of_stream_error
-
-
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
 def test_read_after_response(protocol_cls):
     read_after_response_error = False
 

--- a/uvicorn/protocols/http/h11.py
+++ b/uvicorn/protocols/http/h11.py
@@ -183,7 +183,6 @@ class RequestResponseCycle:
         # Request state
         self.body = b""
         self.more_body = True
-        self.receive_finished = False
 
         # Response state
         self.response_started = False
@@ -322,12 +321,6 @@ class RequestResponseCycle:
             msg = "Response already sent. Receive channel no longer available."
             raise RuntimeError(msg)
 
-        # If a client calls recieve again once we've already sent either
-        # 'http.disconnect' or 'more_body=False' then raise an error.
-        if self.receive_finished:
-            msg = "Receive channel fully consumed."
-            raise RuntimeError(msg)
-
         protocol = self.protocol
         protocol.resume_reading()
 
@@ -337,14 +330,12 @@ class RequestResponseCycle:
 
         if self.disconnected:
             message = {"type": "http.disconnect"}
-            self.receive_finished = True
         else:
             message = {
                 "type": "http.request",
                 "body": self.body,
                 "more_body": self.more_body,
             }
-            self.receive_finished = not (self.more_body)
             self.body = b""
 
         return message

--- a/uvicorn/protocols/http/httptools.py
+++ b/uvicorn/protocols/http/httptools.py
@@ -190,7 +190,7 @@ class HttpToolsProtocol(asyncio.Protocol):
 class RequestResponseCycle:
     __slots__ = (
         'scope', 'protocol', 'disconnected', 'done_callback',
-        'body', 'more_body', 'receive_finished',
+        'body', 'more_body',
         'response_started', 'response_complete', 'keep_alive', 'chunked_encoding', 'expected_content_length'
     )
 
@@ -203,7 +203,6 @@ class RequestResponseCycle:
         # Request state
         self.body = b""
         self.more_body = True
-        self.receive_finished = False
 
         # Response state
         self.response_started = False
@@ -358,12 +357,6 @@ class RequestResponseCycle:
             msg = "Response already sent. Receive channel no longer available."
             raise RuntimeError(msg)
 
-        # If a client calls recieve again once we've already sent either
-        # 'http.disconnect' or 'more_body=False' then raise an error.
-        if self.receive_finished:
-            msg = "Receive channel fully consumed."
-            raise RuntimeError(msg)
-
         protocol = self.protocol
         protocol.resume_reading()
 
@@ -373,14 +366,12 @@ class RequestResponseCycle:
 
         if self.disconnected:
             message = {"type": "http.disconnect"}
-            self.receive_finished = True
         else:
             message = {
                 "type": "http.request",
                 "body": self.body,
                 "more_body": self.more_body,
             }
-            self.receive_finished = not (self.more_body)
             self.body = b""
 
         return message


### PR DESCRIPTION
This allows ASGI applications to know that the connection has
disconnected after consuming the entire request body. This is
important if the application is streaming a response as the send will
become a no-op and hence not indicate the connection has closed.