### PR TITLE
Improve windows support

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -124,11 +124,12 @@ class Server:
             signal.SIGTERM,      # Unix signal 15. Sent by `kill <pid>`.
         )
         try:
-            for signal_name in handled:
+            for sig in handled:
                 self.loop.add_signal_handler(sig, self.handle_exit, sig, None)
         except NotImplementedError:
             # Windows
-            signal.signal(sig, self.handle_exit)
+            for sig in handled:
+                signal.signal(sig, self.handle_exit)
 
     def run(self):
         self.set_signal_handlers()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -119,9 +119,16 @@ class Server:
         self.protocol_class = protocol_class
 
     def set_signal_handlers(self):
-        handled = (signal.SIGQUIT, signal.SIGTERM, signal.SIGINT, signal.SIGABRT)
-        for sig in handled:
-            self.loop.add_signal_handler(sig, self.handle_exit, sig, None)
+        handled = (
+            signal.SIGINT,       # Unix signal 2. Sent by Ctrl+C.
+            signal.SIGTERM,      # Unix signal 15. Sent by `kill <pid>`.
+        )
+        try:
+            for signal_name in handled:
+                self.loop.add_signal_handler(sig, self.handle_exit, sig, None)
+        except NotImplementedError:
+            # Windows
+            signal.signal(sig, self.handle_exit)
 
     def run(self):
         self.set_signal_handlers()


### PR DESCRIPTION
* Don't error when `add_signal_handler` is not supported.
* Use `signal.signal` to trap signals in that case.

See https://stackoverflow.com/questions/24774980/why-cant-i-catch-sigint-when-asyncio-event-loop-is-running/24775107#24775107

It's not clear to me if this will be sufficient to properly catch Ctrl-C events - possible we might want to start a separate thread in that case.
