### PR TITLE
Prevent erronous error logging on client disconnect

### DIFF
--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,4 +1,4 @@
 from uvicorn.main import main, run
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"
 __all__ = ["main", "run"]

--- a/uvicorn/protocols/http/h11.py
+++ b/uvicorn/protocols/http/h11.py
@@ -212,18 +212,19 @@ class RequestResponseCycle:
             else:
                 self.protocol.transport.close()
         else:
-            if not self.response_started:
-                msg = "ASGI callable returned without starting response."
-                self.protocol.logger.error(msg)
-                await self.send_500_response()
-            elif not self.response_complete:
-                msg = "ASGI callable returned without completing response."
-                self.protocol.logger.error(msg)
-                self.protocol.transport.close()
-            elif result is not None:
+            if result is not None:
                 msg = "ASGI callable should return None, but returned '%s'."
                 self.protocol.logger.error(msg, result)
                 self.protocol.transport.close()
+            elif not self.disconnected:
+                if not self.response_started:
+                    msg = "ASGI callable returned without starting response."
+                    self.protocol.logger.error(msg)
+                    await self.send_500_response()
+                elif not self.response_complete:
+                    msg = "ASGI callable returned without completing response."
+                    self.protocol.logger.error(msg)
+                    self.protocol.transport.close()
         finally:
             if self.done_callback is not None:
                 self.done_callback()

--- a/uvicorn/protocols/http/httptools.py
+++ b/uvicorn/protocols/http/httptools.py
@@ -225,18 +225,19 @@ class RequestResponseCycle:
             else:
                 self.protocol.transport.close()
         else:
-            if not self.response_started:
-                msg = "ASGI callable returned without starting response."
-                self.protocol.logger.error(msg)
-                await self.send_500_response()
-            elif not self.response_complete:
-                msg = "ASGI callable returned without completing response."
-                self.protocol.logger.error(msg)
-                self.protocol.transport.close()
-            elif result is not None:
+            if result is not None:
                 msg = "ASGI callable should return None, but returned '%s'."
                 self.protocol.logger.error(msg, result)
                 self.protocol.transport.close()
+            elif not self.disconnected:
+                if not self.response_started:
+                    msg = "ASGI callable returned without starting response."
+                    self.protocol.logger.error(msg)
+                    await self.send_500_response()
+                elif not self.response_complete:
+                    msg = "ASGI callable returned without completing response."
+                    self.protocol.logger.error(msg)
+                    self.protocol.transport.close()
         finally:
             self.protocol.state["total_requests"] += 1
             if self.done_callback is not None:


### PR DESCRIPTION
Uvicorn was logging "ASGI callable returned without starting response." on client disconnects.