### PR TITLE
Initial pass at '--metrics' flag

### DIFF
--- a/uvicorn/protocols/http/httptools.py
+++ b/uvicorn/protocols/http/httptools.py
@@ -1,9 +1,10 @@
 import asyncio
-from email.utils import formatdate
+import collections
 import http
 import logging
 import time
 import traceback
+from email.utils import formatdate
 from urllib.parse import unquote
 from uvicorn.protocols.websockets.websockets import websocket_upgrade
 
@@ -32,14 +33,18 @@ DEFAULT_HEADERS = _get_default_headers()
 
 HIGH_WATER_LIMIT = 65536
 
-
-default_state = {"total_requests": 0, "concurrent_requests": 0}
+INITIAL_STATE = {
+    "total_requests": 0,
+    "concurrent_requests": 0,
+    "concurrent_connections": 0,
+    "latency": collections.deque()
+}
 
 
 class HttpToolsProtocol(asyncio.Protocol):
     __slots__ = (
-        'app', 'loop', 'state', 'logger', 'access_logs', 'parser',
-        'transport', 'server', 'client', 'scheme',
+        'app', 'loop', 'state', 'logger', 'access_logs', 'metrics_logs',
+        'parser', 'transport', 'server', 'client', 'scheme',
         'scope', 'headers', 'cycle', 'client_event',
         'readable', 'writable', 'writable_event',
         'pipeline'
@@ -48,9 +53,10 @@ class HttpToolsProtocol(asyncio.Protocol):
     def __init__(self, app, loop=None, state=None, logger=None):
         self.app = app
         self.loop = loop or asyncio.get_event_loop()
-        self.state = default_state if state is None else state
+        self.state = INITIAL_STATE.copy() if state is None else state
         self.logger = logger or logging.getLogger()
         self.access_logs = self.logger.level >= logging.INFO
+        self.metrics_logs = getattr(self.logger, 'should_log_metrics', False)
         self.parser = httptools.HttpRequestParser(self)
 
         # Per-connection state
@@ -84,12 +90,17 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.server = transport.get_extra_info("sockname")
         self.client = transport.get_extra_info("peername")
         self.scheme = "https" if transport.get_extra_info("sslcontext") else "http"
+
         if self.access_logs:
             self.logger.debug("%s - Connected", self.server[0])
+        if self.metrics_logs:
+            self.state["concurrent_connections"] += 1
 
     def connection_lost(self, exc):
         if self.access_logs:
             self.logger.debug("%s - Disconnected", self.server[0])
+        if self.metrics_logs:
+            self.state["concurrent_connections"] -= 1
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True
@@ -216,8 +227,10 @@ class RequestResponseCycle:
 
     # ASGI exception wrapper
     async def run_asgi(self, app):
-        started = time.clock()
-        self.protocol.state["concurrent_requests"] += 1
+        if self.protocol.metrics_logs:
+            started = time.perf_counter()
+            self.protocol.state["concurrent_requests"] += 1
+
         try:
             asgi = app(self.scope)
             result = await asgi(self.receive, self.send)
@@ -244,11 +257,13 @@ class RequestResponseCycle:
                     self.protocol.logger.error(msg)
                     self.protocol.transport.close()
         finally:
-            complete = time.clock()
-            await asyncio.sleep(0)
             self.protocol.state["total_requests"] += 1
-            self.protocol.state["concurrent_requests"] -= 1
-            self.protocol.state["latency"] = complete - started
+            if self.protocol.metrics_logs:
+                complete = time.perf_counter()
+                await asyncio.sleep(0)
+                self.protocol.state["latency"].append((complete, complete - started))
+                self.protocol.state["concurrent_requests"] -= 1
+
             if self.done_callback is not None:
                 self.done_callback()
 

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -91,7 +91,7 @@ class UvicornWorker(Worker):
         ssl_ctx = self.create_ssl_context(self.cfg) if self.cfg.is_ssl else None
 
         for sock in self.sockets:
-            state = {"total_requests": 0}
+            state = {"total_requests": 0, "concurrent_requests": 0}
             protocol = functools.partial(
                 self.protocol_class, app=app, loop=loop, state=state, logger=self.log
             )


### PR DESCRIPTION
```shell
uvicorn$ venv/bin/uvicorn example:App --metrics --log-level error
* Uvicorn running on http://127.0.0.1:8000 🦄 (Press CTRL+C to quit)
PERF: App latency: 0.000013s. App concurrency: 192. Connections: 192.
PERF: App latency: 0.000014s. App concurrency: 192. Connections: 192.
PERF: App latency: 0.000014s. App concurrency: 192. Connections: 192.
PERF: App latency: 0.000013s. App concurrency: 192. Connections: 192.
PERF: App latency: 0.000013s. App concurrency: 192. Connections: 192.
PERF: App latency: 0.000014s. App concurrency: 133. Connections: 133.
PERF: App latency: 0.000013s. App concurrency: 106. Connections: 106.
PERF: App latency: 0.000013s. App concurrency: 146. Connections: 146.
PERF: App latency: 0.000013s. App concurrency: 124. Connections: 124.
PERF: App latency: 0.000013s. App concurrency: 133. Connections: 133.
PERF: App latency: 0.000013s. App concurrency: 0. Connections: 0.
^C```