### PR TITLE
Updates to the http receive functions

### DIFF
--- a/uvicorn/protocols/http/h11.py
+++ b/uvicorn/protocols/http/h11.py
@@ -325,20 +325,13 @@ class RequestResponseCycle:
             protocol.conn.start_next_cycle()
 
     async def receive(self):
-        # If a client calls recieve once they've already sent the response
-        # then raise an error. Allows us to stop buffering any more request
-        # body to memory once the response has been sent.
-        if self.response_complete:
-            msg = "Response already sent. Receive channel no longer available."
-            raise RuntimeError(msg)
-
         protocol = self.protocol
         protocol.resume_reading()
 
         await protocol.client_event.wait()
         protocol.client_event.clear()
 
-        if self.disconnected:
+        if self.disconnected or self.response_complete:
             message = {"type": "http.disconnect"}
         else:
             message = {

--- a/uvicorn/protocols/http/h11.py
+++ b/uvicorn/protocols/http/h11.py
@@ -335,9 +335,8 @@ class RequestResponseCycle:
         protocol = self.protocol
         protocol.resume_reading()
 
-        if self.more_body and not self.body and not self.disconnected:
-            await protocol.client_event.wait()
-            protocol.client_event.clear()
+        await protocol.client_event.wait()
+        protocol.client_event.clear()
 
         if self.disconnected:
             message = {"type": "http.disconnect"}

--- a/uvicorn/protocols/http/httptools.py
+++ b/uvicorn/protocols/http/httptools.py
@@ -361,9 +361,8 @@ class RequestResponseCycle:
         protocol = self.protocol
         protocol.resume_reading()
 
-        if self.more_body and not self.body and not self.disconnected:
-            await protocol.client_event.wait()
-            protocol.client_event.clear()
+        await protocol.client_event.wait()
+        protocol.client_event.clear()
 
         if self.disconnected:
             message = {"type": "http.disconnect"}

--- a/uvicorn/protocols/http/httptools.py
+++ b/uvicorn/protocols/http/httptools.py
@@ -351,20 +351,13 @@ class RequestResponseCycle:
             raise RuntimeError(msg % message_type)
 
     async def receive(self):
-        # If a client calls recieve once they've already sent the response
-        # then raise an error. Allows us to stop buffering any more request
-        # body to memory once the response has been sent.
-        if self.response_complete:
-            msg = "Response already sent. Receive channel no longer available."
-            raise RuntimeError(msg)
-
         protocol = self.protocol
         protocol.resume_reading()
 
         await protocol.client_event.wait()
         protocol.client_event.clear()
 
-        if self.disconnected:
+        if self.disconnected or self.response_complete:
             message = {"type": "http.disconnect"}
         else:
             message = {


### PR DESCRIPTION
These are required for Uvicorn to work with Quart, as Quart has a different interpretation of the ASGI specification. Firstly in a29ddab it assumes the request.body message with more_body equal to False should be received only once and then the receive should block until something else happens. Secondly in e23058d it assumes it can call the receive after sending the response and get a disconnect message. In think this is closer to the Daphne and Hypercorn interpretations.

I've suggested a clarification to the [ASGI spec](https://github.com/django/asgiref/pull/53) that is relevant to the second commit.