### PR TITLE
Updated subprotocols behaviour

### DIFF
--- a/uvicorn/protocols/websockets/websockets.py
+++ b/uvicorn/protocols/websockets/websockets.py
@@ -24,10 +24,12 @@ def websocket_upgrade(http):
         return
 
     # Retrieve any subprotocols to be negotiated with the consumer later
-    subprotocols = request_headers.get(b"sec-websocket-protocol", [])
-    if subprotocols:
-        subprotocols = [subprotocol.strip(b" ").decode("ascii")
-                        for subprotocol in subprotocols.split(b",")]
+    subprotocols = []
+    for header_key, header_value in http.headers:
+        if header_key != b"sec-websocket-protocol":
+            continue
+        for subprotocol in header_value.split(b","):
+            subprotocols.append(subprotocol.decode("ascii").strip(" "))
     http.scope.update({"type": "websocket", "subprotocols": subprotocols})
     asgi_instance = http.app(http.scope)
     request = WebSocketRequest(http, response_headers)

--- a/uvicorn/protocols/websockets/websockets.py
+++ b/uvicorn/protocols/websockets/websockets.py
@@ -29,7 +29,7 @@ def websocket_upgrade(http):
         if header_key != b"sec-websocket-protocol":
             continue
         for subprotocol in header_value.split(b","):
-            subprotocols.append(subprotocol.decode("ascii").strip(" "))
+            subprotocols.append(subprotocol.decode("ascii").strip())
     http.scope.update({"type": "websocket", "subprotocols": subprotocols})
     asgi_instance = http.app(http.scope)
     request = WebSocketRequest(http, response_headers)

--- a/uvicorn/protocols/websockets/websockets.py
+++ b/uvicorn/protocols/websockets/websockets.py
@@ -24,9 +24,10 @@ def websocket_upgrade(http):
         return
 
     # Retrieve any subprotocols to be negotiated with the consumer later
-    subprotocols = request_headers.get(b"sec-websocket-protocol", None)
+    subprotocols = request_headers.get(b"sec-websocket-protocol", [])
     if subprotocols:
-        subprotocols = subprotocols.split(b",")
+        subprotocols = [subprotocol.strip(b" ").decode("ascii")
+                        for subprotocol in subprotocols.split(b",")]
     http.scope.update({"type": "websocket", "subprotocols": subprotocols})
     asgi_instance = http.app(http.scope)
     request = WebSocketRequest(http, response_headers)


### PR DESCRIPTION
The websocket subprotocol header handling was a wee bit messy.

Things changed:
* Stripping spaces from each subprotocol name
* Changed default to list (as per ASGI specifications)
* Changed encoding to ascii to align with Daphne behaviour (was bytes before)
* Allow multiple `Sec-WebSocket-Protocol` headers as per https://tools.ietf.org/html/rfc6455#section-11.3.4

Things I can't seem to fix
* Test miltiple `Sec-WebSocket-Protocol` headers, the clients used seem to suffer from the same problem uvicorn does of making everything into a dict
