### PR TITLE
Improve PyPy and Windows support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 import os
 import re
 import sys
+import platform
 
 from setuptools import setup
 
@@ -32,6 +33,28 @@ def get_packages(package):
             if os.path.exists(os.path.join(dirpath, '__init__.py'))]
 
 
+if platform.python_implementation() == 'PyPy':
+    requirements = [
+        'click',
+        'h11',
+        'websockets'
+    ]
+elif platform.system() == 'Windows' or platform.system().startswith('CYGWIN'):
+    requirements = [
+        'click',
+        'h11',
+        'websockets'
+    ]
+else:
+    requirements = [
+        'click',
+        'h11',
+        'httptools',
+        'uvloop',
+        'websockets'
+    ]
+
+
 setup(
     name='uvicorn',
     version=get_version('uvicorn'),
@@ -43,13 +66,7 @@ setup(
     author='Tom Christie',
     author_email='tom@tomchristie.com',
     packages=get_packages('uvicorn'),
-    install_requires=[
-        'click',
-        'h11',
-        'httptools',
-        'uvloop',
-        'websockets'
-    ],
+    install_requires=requirements,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ def get_version(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    init_py = open(os.path.join(package, '__init__.py', encoding='utf8')).read()
+    path = os.path.join(package, '__init__.py')
+    init_py = open(path, 'r', encoding='utf8').read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def get_version(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    init_py = open(os.path.join(package, '__init__.py')).read()
+    init_py = open(os.path.join(package, '__init__.py', encoding='utf8')).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
@@ -21,7 +21,7 @@ def get_long_description():
     """
     Return the README.
     """
-    return open('README.md', 'r').read()
+    return open('README.md', 'r', encoding='utf8').read()
 
 
 def get_packages(package):

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,4 +1,4 @@
 from uvicorn.main import main, run
 
-__version__ = "0.2.12"
+__version__ = "0.2.13"
 __all__ = ["main", "run"]

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -66,9 +66,9 @@ def run(app, host="127.0.0.1", port=8000, log_level="info"):
     log_level = LOG_LEVELS[log_level]
     logging.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
 
-    loop = get_event_loop("uvloop")
+    loop = get_event_loop(DEFAULT_LOOP)
     logger = logging.getLogger()
-    protocol_class = HttpToolsProtocol
+    protocol_class = {'httptools': HttpToolsProtocol, 'h11': H11Protocol}[DEFAULT_PARSER]
 
     server = Server(app, host, port, loop, logger, protocol_class)
     server.run()


### PR DESCRIPTION
* Don't attempt to log `signal.name` under windows.
* Use explicit `encoding=` when opening files in `setup.py`
* Requirements depend on runtime/platform - PyPy and Windows should no longer install `httptools` and `uvloop`.
* Defaults depend on runtime/platform - PyPy and Windows should no longer run with `httptools` and `uvloop` by default.