### PR TITLE
Add support for --workers

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,0 @@
-from uvicorn.main import Server
-
-
-def test_server():
-    server = Server(None)
-    server.should_exit = True
-    server.run()

--- a/uvicorn/protocols/http/auto.py
+++ b/uvicorn/protocols/http/auto.py
@@ -1,11 +1,10 @@
-def AutoHTTPProtocol(*args, **kwargs):
-    try:
-        import httptools
-    except ImportError:  # pragma: no cover
-        from uvicorn.protocols.http.h11 import H11Protocol
+try:
+    import httptools
+except ImportError:  # pragma: no cover
+    from uvicorn.protocols.http.h11 import H11Protocol
 
-        return H11Protocol(*args, **kwargs)
-    else:
-        from uvicorn.protocols.http.httptools import HttpToolsProtocol
+    AutoHTTPProtocol = H11Protocol
+else:
+    from uvicorn.protocols.http.httptools import HttpToolsProtocol
 
-        return HttpToolsProtocol(*args, **kwargs)
+    AutoHTTPProtocol = HttpToolsProtocol


### PR DESCRIPTION
Switches uvicorn to run in a parent/worker style...

```
$ uvicorn example:App 
* Uvicorn running on http://127.0.0.1:8000 🦄 (Press CTRL+C to quit)
INFO: Started parent [2143]
INFO: Started worker [2144]
INFO: 127.0.0.1 - "GET / HTTP/1.1" 200
INFO: 127.0.0.1 - "GET /favicon.ico HTTP/1.1" 200
^CINFO: Got signal SIGINT. Shutting down.
INFO: Stopping worker [2144]
INFO: Stopping parent [2143]
```

And...

```shell
$ uvicorn example:App --workers 2
* Uvicorn running on http://127.0.0.1:8000 🦄 (Press CTRL+C to quit)
INFO: Started parent [2145]
INFO: Started worker [2146]
INFO: Started worker [2147]
INFO: 127.0.0.1 - "GET / HTTP/1.1" 200
INFO: 127.0.0.1 - "GET /favicon.ico HTTP/1.1" 200
^CINFO: Got signal SIGINT. Shutting down.
INFO: Stopping worker [2146]
INFO: Stopping worker [2147]
INFO: Stopping parent [2145]
```