### PR TITLE
Added --debug for in-browser tracebacks and autoreload.

### DIFF
--- a/uvicorn/debug.py
+++ b/uvicorn/debug.py
@@ -80,7 +80,7 @@ class _DebugResponder:
             accept = get_accept_header(self.scope)
             if "text/html" in accept:
                 exc_html = html.escape(traceback.format_exc())
-                content = f"<html><body><h1>500 Server Error</h1><pre>{exc_html}</pre></body></html>"
+                content = "<html><body><h1>500 Server Error</h1><pre>%s</pre></body></html>" % exc_html
                 response = HTMLResponse(content, status_code=500)
             else:
                 content = traceback.format_exc()

--- a/uvicorn/debug.py
+++ b/uvicorn/debug.py
@@ -1,0 +1,93 @@
+import html
+import traceback
+
+
+class HTMLResponse:
+    def __init__(self, content, status_code):
+        self.content = content
+        self.status_code = status_code
+
+    async def __call__(self, recieve, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.status_code,
+                "headers": [[b"content-type", b"text/html; charset=utf-8"]],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": self.content.encode("utf-8"),
+                "more_body": False,
+            }
+        )
+
+
+class PlainTextResponse:
+    def __init__(self, content, status_code):
+        self.content = content
+        self.status_code = status_code
+
+    async def __call__(self, recieve, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.status_code,
+                "headers": [[b"content-type", b"text/plain; charset=utf-8"]],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": self.content.encode("utf-8"),
+                "more_body": False,
+            }
+        )
+
+
+def get_accept_header(scope):
+    for key, value in scope.get("headers", []):
+        if key == b"accept":
+            return value.decode("latin-1")
+    return ""
+
+
+class DebugMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, scope):
+        if scope["type"] != "http":
+            return self.app(scope)
+        return _DebugResponder(self.app, scope)
+
+
+class _DebugResponder:
+    def __init__(self, app, scope):
+        self.app = app
+        self.scope = scope
+        self.response_started = False
+
+    async def __call__(self, receive, send):
+        self.raw_send = send
+        try:
+            asgi = self.app(self.scope)
+            await asgi(receive, self.send)
+        except:
+            if self.response_started:
+                raise
+            accept = get_accept_header(self.scope)
+            if "text/html" in accept:
+                exc_html = html.escape(traceback.format_exc())
+                content = f"<html><body><h1>500 Server Error</h1><pre>{exc_html}</pre></body></html>"
+                response = HTMLResponse(content, status_code=500)
+            else:
+                content = traceback.format_exc()
+                response = PlainTextResponse(content, status_code=500)
+            await response(receive, send)
+
+    async def send(self, message):
+        if message["type"] == "http.response.start":
+            self.response_started = True
+        await self.raw_send(message)

--- a/uvicorn/reloaders/noreload.py
+++ b/uvicorn/reloaders/noreload.py
@@ -1,0 +1,9 @@
+class NoReload:
+    def __init__(self):
+        pass
+
+    def clear(self):
+        pass
+
+    def should_restart(self):
+        return False

--- a/uvicorn/reloaders/statreload.py
+++ b/uvicorn/reloaders/statreload.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+
+def _iter_py_files():
+    for subdir, dirs, files in os.walk("."):
+        for file in files:
+            filepath = subdir + os.sep + file
+            if filepath.endswith(".py"):
+                yield filepath
+
+
+class StatReload:
+    def __init__(self, logger):
+        self.logger = logger
+        self.mtimes = {}
+
+    def clear(self):
+        self.mtimes = {}
+
+    def should_restart(self):
+        for filename in _iter_py_files():
+            try:
+                mtime = os.stat(filename).st_mtime
+            except OSError:
+                continue
+
+            old_time = self.mtimes.get(filename)
+            if old_time is None:
+                self.mtimes[filename] = mtime
+                continue
+            elif mtime > old_time:
+                message = "Detected file change in '%s'. Reloading..."
+                self.logger.warning(message, filename)
+                return True
+        return False


### PR DESCRIPTION
When `--debug` is provided, two things happen:

* We switch on autoreload. (Occurs when any python files in or below the current working directory change.)
* We include `DebugMiddleware` (Displays tracebacks in the browser when exceptions occur within the ASGI app.)