### PR TITLE
Simplify reloader and remove --workers

### DIFF
--- a/uvicorn/debug.py
+++ b/uvicorn/debug.py
@@ -80,7 +80,10 @@ class _DebugResponder:
             accept = get_accept_header(self.scope)
             if "text/html" in accept:
                 exc_html = html.escape(traceback.format_exc())
-                content = "<html><body><h1>500 Server Error</h1><pre>%s</pre></body></html>" % exc_html
+                content = (
+                    "<html><body><h1>500 Server Error</h1><pre>%s</pre></body></html>"
+                    % exc_html
+                )
                 response = HTMLResponse(content, status_code=500)
             else:
                 content = traceback.format_exc()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -75,9 +75,6 @@ def main(app, host: str, port: int, loop: str, http: str, debug: bool, log_level
     }
 
     if debug:
-        # kwargs['sock'] = get_socket(host, port)
-        # message = "* Uvicorn running on http://%s:%d 🦄 (Press CTRL+C to quit)"
-        # click.echo(message % (host, port))
         logger = get_logger(log_level)
         reloader = StatReload(logger)
         reloader.run(run, kwargs)

--- a/uvicorn/reloaders/noreload.py
+++ b/uvicorn/reloaders/noreload.py
@@ -1,9 +1,0 @@
-class NoReload:
-    def __init__(self):
-        pass
-
-    def clear(self):
-        pass
-
-    def should_restart(self):
-        return False

--- a/uvicorn/reloaders/statreload.py
+++ b/uvicorn/reloaders/statreload.py
@@ -1,25 +1,54 @@
 import os
+import signal
 import sys
+import time
+import multiprocessing
 
 
-def _iter_py_files():
-    for subdir, dirs, files in os.walk("."):
-        for file in files:
-            filepath = subdir + os.sep + file
-            if filepath.endswith(".py"):
-                yield filepath
+HANDLED_SIGNALS = (
+    signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
+    signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
+)
 
 
 class StatReload:
     def __init__(self, logger):
         self.logger = logger
+        self.should_exit = False
         self.mtimes = {}
+
+    def handle_exit(self, sig, frame):
+        self.should_exit = True
+
+    def run(self, target, kwargs):
+        pid = os.getpid()
+
+        self.logger.info("Started reloader process [{}]".format(pid))
+
+        for sig in HANDLED_SIGNALS:
+            signal.signal(sig, self.handle_exit)
+
+        process = multiprocessing.Process(target=target, kwargs=kwargs)
+        process.start()
+
+        while process.is_alive() and not self.should_exit:
+            time.sleep(0.2)
+            if self.should_restart():
+                self.clear()
+                os.kill(process.pid, signal.SIGTERM)
+                process.join()
+                process = multiprocessing.Process(target=target, kwargs=kwargs)
+                process.start()
+
+        self.logger.info("Stopping reloader process [{}]".format(pid))
+
+        sys.exit(process.exitcode)
 
     def clear(self):
         self.mtimes = {}
 
     def should_restart(self):
-        for filename in _iter_py_files():
+        for filename in self.iter_py_files():
             try:
                 mtime = os.stat(filename).st_mtime
             except OSError:
@@ -34,3 +63,10 @@ class StatReload:
                 self.logger.warning(message, filename)
                 return True
         return False
+
+    def iter_py_files(self):
+        for subdir, dirs, files in os.walk("."):
+            for file in files:
+                filepath = subdir + os.sep + file
+                if filepath.endswith(".py"):
+                    yield filepath


### PR DESCRIPTION
Having implemented the `--workers` and thought through the implications,
I now think that we *shouldn't* implement multi-worker, and instead keep it out-of-scope.

This PR removes multi-worker for everything except the auto-reloading, where it's now much simpler.

I think this is preferable because multi-process production deployments should really be run underneath a dedicated process monitoring tool. (Gunicorn, Supervisord, Circus etc...)

