### PR TITLE
Add `--max-connections` setting

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -541,3 +541,12 @@ def test_proxy_headers(protocol_cls):
     protocol.loop.run_one()
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Remote: https://1.2.3.4:567" in protocol.transport.buffer
+
+
+@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+def test_max_connections(protocol_cls):
+    app = lambda scope: None
+    protocol = get_connected_protocol(app, protocol_cls, max_connections=1)
+    protocol.data_received(SIMPLE_GET_REQUEST)
+    protocol.loop.run_one()
+    assert b"HTTP/1.1 503 Service Unavailable" in protocol.transport.buffer

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -92,7 +92,7 @@ class UvicornWorker(Worker):
         ssl_ctx = self.create_ssl_context(self.cfg) if self.cfg.is_ssl else None
 
         for sock in self.sockets:
-            state = {"total_requests": 0}
+            state = {"total_requests": 0, "num_connections": 0}
             protocol = functools.partial(
                 self.protocol_class, app=app, loop=loop, state=state, logger=self.log
             )


### PR DESCRIPTION
Adds a new `--max-connections` setting.

If the maximum number of allowable concurrent exceptions is exceeded then uvicorn will start responding with 503 responses, rather than invoking the ASGI application.

This helps you to bound the resources that each `uvicorn` process can use. You'll still want to ensure that you're adequately provisioning for expected usage, but you'll be able to ensure that severely overloaded servers are less likely to degrade the system.