### PR TITLE
Support 'Expect: 100-continue'

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -663,7 +663,7 @@ def test_100_continue_sent_when_body_consumed(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
-def test_100_continue_sent_when_body_not_consumed(protocol_cls):
+def test_100_continue_not_sent_when_body_not_consumed(protocol_cls):
     def app(scope):
         return Response(b"", status_code=204)
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -466,7 +466,7 @@ class RequestResponseCycle:
             more_body = message.get("more_body", False)
 
             # Write response body
-            if self.scope['method'] == "HEAD":
+            if self.scope["method"] == "HEAD":
                 event = h11.Data()
             else:
                 event = h11.Data(data=body)
@@ -494,7 +494,9 @@ class RequestResponseCycle:
 
     async def receive(self):
         if self.waiting_for_100_continue and not self.transport.is_closing():
-            event = h11.InformationalResponse(status_code=100, headers=[], reason='Continue')
+            event = h11.InformationalResponse(
+                status_code=100, headers=[], reason="Continue"
+            )
             output = self.conn.send(event)
             self.transport.write(output)
             self.waiting_for_100_continue = False

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -434,6 +434,7 @@ class RequestResponseCycle:
                 raise RuntimeError(msg % message_type)
 
             self.response_started = True
+            self.waiting_for_100_continue = False
 
             status_code = message["status"]
             headers = DEFAULT_HEADERS + message.get("headers", [])

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -436,6 +436,7 @@ class RequestResponseCycle:
                 raise RuntimeError(msg % message_type)
 
             self.response_started = True
+            self.waiting_for_100_continue = False
 
             status_code = message["status"]
             headers = message.get("headers", [])

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -144,6 +144,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         # Per-request state
         self.scope = None
         self.headers = None
+        self.expect_100_continue = False
         self.cycle = None
         self.message_event = asyncio.Event()
 
@@ -196,6 +197,7 @@ class HttpToolsProtocol(asyncio.Protocol):
     def on_url(self, url):
         method = self.parser.get_method()
         parsed_url = httptools.parse_url(url)
+        self.expect_100_continue = False
         self.headers = []
         self.scope = {
             "type": "http",
@@ -211,7 +213,10 @@ class HttpToolsProtocol(asyncio.Protocol):
         }
 
     def on_header(self, name: bytes, value: bytes):
-        self.headers.append((name.lower(), value))
+        name = name.lower()
+        if name == b'expect' and value.lower() == b'100-continue':
+            self.expect_100_continue = True
+        self.headers.append((name, value))
 
     def on_headers_complete(self):
         http_version = self.parser.get_http_version()
@@ -242,6 +247,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             flow=self.flow,
             logger=self.logger,
             message_event=self.message_event,
+            expect_100_continue=self.expect_100_continue,
             on_response=self.on_response_complete,
         )
         if existing_cycle is None or existing_cycle.response_complete:
@@ -337,7 +343,7 @@ class HttpToolsProtocol(asyncio.Protocol):
 
 
 class RequestResponseCycle:
-    def __init__(self, scope, transport, flow, logger, message_event, on_response):
+    def __init__(self, scope, transport, flow, logger, message_event, expect_100_continue, on_response):
         self.scope = scope
         self.transport = transport
         self.flow = flow
@@ -348,6 +354,7 @@ class RequestResponseCycle:
         # Connection state
         self.disconnected = False
         self.keep_alive = True
+        self.waiting_for_100_continue = expect_100_continue
 
         # Request state
         self.body = b""
@@ -497,6 +504,10 @@ class RequestResponseCycle:
             raise RuntimeError(msg % message_type)
 
     async def receive(self):
+        if self.waiting_for_100_continue and not self.transport.is_closing():
+            self.transport.write(b'HTTP/1.1 100 Continue\r\n')
+            self.waiting_for_100_continue = False
+
         self.flow.resume_reading()
         await self.message_event.wait()
         self.message_event.clear()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -214,7 +214,7 @@ class HttpToolsProtocol(asyncio.Protocol):
 
     def on_header(self, name: bytes, value: bytes):
         name = name.lower()
-        if name == b'expect' and value.lower() == b'100-continue':
+        if name == b"expect" and value.lower() == b"100-continue":
             self.expect_100_continue = True
         self.headers.append((name, value))
 
@@ -343,7 +343,16 @@ class HttpToolsProtocol(asyncio.Protocol):
 
 
 class RequestResponseCycle:
-    def __init__(self, scope, transport, flow, logger, message_event, expect_100_continue, on_response):
+    def __init__(
+        self,
+        scope,
+        transport,
+        flow,
+        logger,
+        message_event,
+        expect_100_continue,
+        on_response,
+    ):
         self.scope = scope
         self.transport = transport
         self.flow = flow
@@ -474,7 +483,7 @@ class RequestResponseCycle:
             more_body = message.get("more_body", False)
 
             # Write response body
-            if self.scope['method'] == "HEAD":
+            if self.scope["method"] == "HEAD":
                 self.expected_content_length = 0
             elif self.chunked_encoding:
                 content = [b"%x\r\n" % len(body), body, b"\r\n"]
@@ -505,7 +514,7 @@ class RequestResponseCycle:
 
     async def receive(self):
         if self.waiting_for_100_continue and not self.transport.is_closing():
-            self.transport.write(b'HTTP/1.1 100 Continue\r\n')
+            self.transport.write(b"HTTP/1.1 100 Continue\r\n")
             self.waiting_for_100_continue = False
 
         self.flow.resume_reading()


### PR DESCRIPTION
Closes #88 

"HTTP/1.1 100 Continue" is only sent if the request body is accessed prior to sending the response.