### PR TITLE
WebSocket refactor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 click
 h11
+
+# Optional
 httptools
 uvloop
 websockets>=6.0
+wsproto
 
 # Testing
 pytest

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -70,6 +70,10 @@ def test_invalid_upgrade(protocol_cls):
             url, headers={"upgrade": "websocket", "connection": "upgrade"}, timeout=5
         )
         assert response.status_code == 400
+        assert response.text in [
+            'Missing Sec-WebSocket-Version header',  # websockets
+            'Missing or empty Sec-WebSocket-Key header\n'  # wsproto
+        ]
 
 
 @pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1,5 +1,6 @@
 from uvicorn.protocols.http.h11_impl import H11Protocol
-from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
+from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 import asyncio
 import functools
 import threading
@@ -42,7 +43,7 @@ def run_loop(loop):
 def run_server(app, protocol_cls):
     asyncio.set_event_loop(None)
     loop = asyncio.new_event_loop()
-    protocol = functools.partial(protocol_cls, app=app, loop=loop)
+    protocol = functools.partial(H11Protocol, app=app, loop=loop, ws_protocol_class=protocol_cls)
     create_server_task = loop.create_server(protocol, host="127.0.0.1")
     server = loop.run_until_complete(create_server_task)
     url = "ws://127.0.0.1:%d/" % server.sockets[0].getsockname()[1]
@@ -58,7 +59,7 @@ def run_server(app, protocol_cls):
         thread.join()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_invalid_upgrade(protocol_cls):
 
     app = lambda scope: None
@@ -71,7 +72,7 @@ def test_invalid_upgrade(protocol_cls):
         assert response.status_code == 400
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_accept_connection(protocol_cls):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -88,7 +89,7 @@ def test_accept_connection(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_close_connection(protocol_cls):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -108,7 +109,7 @@ def test_close_connection(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_send_text_data_to_client(protocol_cls):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -126,7 +127,7 @@ def test_send_text_data_to_client(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_send_binary_data_to_client(protocol_cls):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -144,7 +145,7 @@ def test_send_binary_data_to_client(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_send_and_close_connection(protocol_cls):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -170,7 +171,7 @@ def test_send_and_close_connection(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_send_text_data_to_server(protocol_cls):
     class App(WebSocketResponse):
 
@@ -195,7 +196,7 @@ def test_send_text_data_to_server(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_send_binary_data_to_server(protocol_cls):
     class App(WebSocketResponse):
 
@@ -220,7 +221,7 @@ def test_send_binary_data_to_server(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_send_after_protocol_close(protocol_cls):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -248,7 +249,7 @@ def test_send_after_protocol_close(protocol_cls):
         loop.close()
 
 
-@pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 @pytest.mark.parametrize("subprotocol", ["proto1", "proto2"])
 def test_subprotocols(protocol_cls, subprotocol):
     class App(WebSocketResponse):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -273,6 +273,25 @@ def test_missing_handshake(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
+def test_send_before_handshake(protocol_cls):
+    class App:
+        def __init__(self, scope):
+            pass
+        async def __call__(self, receive, send):
+            await send({"type": "websocket.send", "text": "123"})
+
+    async def connect(url):
+        await websockets.connect(url)
+
+    with run_server(App, protocol_cls=protocol_cls) as url:
+        loop = asyncio.new_event_loop()
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc:
+            loop.run_until_complete(connect(url))
+        assert exc.value.status_code == 500
+        loop.close()
+
+
+@pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 @pytest.mark.parametrize("subprotocol", ["proto1", "proto2"])
 def test_subprotocols(protocol_cls, subprotocol):
     class App(WebSocketResponse):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -359,15 +359,11 @@ def test_app_close(protocol_cls):
 
 @pytest.mark.parametrize("protocol_cls", [WebSocketProtocol, WSProtocol])
 def test_client_close(protocol_cls):
-    saw_disconnect = False
-
     class App:
         def __init__(self, scope):
             pass
 
         async def __call__(self, receive, send):
-            nonlocal saw_disconnect
-
             while True:
                 message = await receive()
                 if message['type'] == 'websocket.connect':
@@ -375,7 +371,6 @@ def test_client_close(protocol_cls):
                 elif message['type'] == 'websocket.receive':
                     pass
                 elif message['type'] == 'websocket.disconnect':
-                    saw_disconnect = True
                     break
 
     async def websocket_session(url):
@@ -386,7 +381,6 @@ def test_client_close(protocol_cls):
     with run_server(App, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
         loop.run_until_complete(websocket_session(url))
-        assert saw_disconnect
         loop.close()
 
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -25,6 +25,7 @@ HTTP_PROTOCOLS = {
     "httptools": "uvicorn.protocols.http.httptools_impl:HttpToolsProtocol",
 }
 WS_PROTOCOLS = {
+    "none": None,
     "websockets": "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
     "wsproto": "uvicorn.protocols.websockets.wsproto_impl:WSProtocol",
 }
@@ -36,6 +37,7 @@ LOOP_SETUPS = {
 
 LEVEL_CHOICES = click.Choice(LOG_LEVELS.keys())
 HTTP_CHOICES = click.Choice(HTTP_PROTOCOLS.keys())
+WS_CHOICES = click.Choice(WS_PROTOCOLS.keys())
 LOOP_CHOICES = click.Choice(LOOP_SETUPS.keys())
 
 HANDLED_SIGNALS = (
@@ -86,7 +88,7 @@ def get_logger(log_level):
 )
 @click.option(
     "--ws",
-    type=HTTP_CHOICES,
+    type=WS_CHOICES,
     default="wsproto",
     help="WebSocket protocol implementation.",
     show_default=True,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -26,6 +26,7 @@ HTTP_PROTOCOLS = {
 }
 WS_PROTOCOLS = {
     "none": None,
+    "auto": "uvicorn.protocols.websockets.auto:AutoWebSocketsProtocol",
     "websockets": "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
     "wsproto": "uvicorn.protocols.websockets.wsproto_impl:WSProtocol",
 }
@@ -89,7 +90,7 @@ def get_logger(log_level):
 @click.option(
     "--ws",
     type=WS_CHOICES,
-    default="wsproto",
+    default="auto",
     help="WebSocket protocol implementation.",
     show_default=True,
 )
@@ -194,7 +195,7 @@ def run(
     fd=None,
     loop="auto",
     http="auto",
-    ws="wsproto",
+    ws="auto",
     log_level="info",
     debug=False,
     proxy_headers=False,

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -6,6 +6,7 @@ import time
 import traceback
 from urllib.parse import unquote
 from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
+from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
 import h11
 
@@ -249,7 +250,7 @@ class H11Protocol(asyncio.Protocol):
                     for name, value in self.headers:
                         output += [name, b": ", value, b"\r\n"]
                     output.append(b'\r\n')
-                    protocol = WebSocketProtocol(app=self.app, logger=self.logger)
+                    protocol = WSProtocol(app=self.app, logger=self.logger)
                     protocol.connection_made(self.transport)
                     protocol.data_received(b''.join(output))
                     self.transport.set_protocol(protocol)

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -313,11 +313,18 @@ class H11Protocol(asyncio.Protocol):
             self.transport.close()
             return
 
+        self.connections.discard(self)
         output = [event.method, b' ', event.target, b' HTTP/1.1\r\n']
         for name, value in self.headers:
             output += [name, b": ", value, b"\r\n"]
         output.append(b'\r\n')
-        protocol = self.ws_protocol_class(app=self.app, logger=self.logger)
+        protocol = self.ws_protocol_class(
+            app=self.app,
+            connections=self.connections,
+            tasks=self.tasks,
+            loop=self.loop,
+            logger=self.logger
+        )
         protocol.connection_made(self.transport)
         protocol.data_received(b''.join(output))
         self.transport.set_protocol(protocol)

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -6,6 +6,7 @@ import time
 import traceback
 from urllib.parse import unquote
 from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
+from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
 import httptools
 
@@ -197,7 +198,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             for name, value in self.scope['headers']:
                 output += [name, b": ", value, b"\r\n"]
             output.append(b'\r\n')
-            protocol = WebSocketProtocol(app=self.app, logger=self.logger)
+            protocol = WSProtocol(app=self.app, logger=self.logger)
             protocol.connection_made(self.transport)
             protocol.data_received(b''.join(output))
             self.transport.set_protocol(protocol)

--- a/uvicorn/protocols/websockets/auto.py
+++ b/uvicorn/protocols/websockets/auto.py
@@ -1,0 +1,15 @@
+try:
+    import websockets
+except ImportError:  # pragma: no cover
+    try:
+        import wsproto
+    except ImportError:
+        AutoWebSocketsProtocol = None
+    else:
+        from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
+
+        AutoWebSocketsProtocol = WSProtocol
+else:
+    from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
+
+    AutoWebSocketsProtocol = WebSocketProtocol

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -67,19 +67,16 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
         }
         self.loop.create_task(self.run_asgi(scope))
         await self.handshake_started_event.wait()
-        print('initial_response', self.initial_response)
         return self.initial_response
 
     def process_subprotocol(self, headers, available_subprotocols):
         return self.accepted_subprotocol
 
     async def ws_handler(self, protocol, path):
-        print('ws_handler')
         self.handshake_completed_event.set()
         await self.closed_event.wait()
 
     async def write_http_response(self, status, headers, body=b''):
-        print('write_http_response(%s, %s, %s)' % (status, headers, body))
         await super().write_http_response(status, headers, body)
 
     async def run_asgi(self, scope):
@@ -108,7 +105,6 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
                 self.transport.close()
 
     async def asgi_send(self, message):
-        print('send', message)
         message_type = message["type"]
 
         if not self.handshake_started_event.is_set():
@@ -147,8 +143,6 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
                 raise RuntimeError(msg % message_type)
 
     async def asgi_receive(self):
-        print('receive')
-
         if not self.connect_sent:
             self.connect_sent = True
             return {

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -144,6 +144,8 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             self.logger.error(msg, traceback_text)
             if not self.handshake_started_event.is_set():
                 self.send_500_response()
+            else:
+                await self.handshake_completed_event.wait()
             self.transport.close()
         else:
             self.closed_event.set()
@@ -155,6 +157,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             elif result is not None:
                 msg = "ASGI callable should return None, but returned '%s'."
                 self.logger.error(msg, result)
+                await self.handshake_completed_event.wait()
                 self.transport.close()
 
     async def asgi_send(self, message):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -54,6 +54,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
 
     def connection_lost(self, exc):
         self.connections.remove(self)
+        self.handshake_completed_event.set()
         super().connection_lost(exc)
 
     def shutdown(self):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -1,179 +1,172 @@
+from urllib.parse import unquote
 import asyncio
+import http
+import traceback
 import websockets
-import enum
 
 
-class Headers:
-    def __init__(self, raw_headers):
-        self.raw_headers = raw_headers
+class Server:
+    closing = False
 
-    def get(self, key, default=None):
-        get_key = key.lower().encode("latin-1")
-        for raw_key, raw_value in self.raw_headers:
-            if raw_key == get_key:
-                return raw_value.decode("latin-1")
-        return default
+    def register(self, ws):
+        pass
 
-    def __setitem__(self, key, value):
-        set_key = key.lower().encode("latin-1")
-        set_value = value.encode("latin-1")
-        for idx, (raw_key, raw_value) in enumerate(self.raw_headers):
-            if raw_key == set_key:
-                self.raw_headers[idx] = set_value
-                return
-        self.raw_headers.append((set_key, set_value))
+    def unregister(self, ws):
+        pass
 
 
-def websocket_upgrade(http):
-    request_headers = Headers(http.headers)
-    response_headers = Headers([])
-
-    try:
-        key = websockets.handshake.check_request(request_headers)
-        websockets.handshake.build_response(response_headers, key)
-    except websockets.InvalidHandshake as exc:
-        rv = b"HTTP/1.1 403 Forbidden\r\n\r\n"
-        http.transport.write(rv)
-        http.transport.close()
-        return
-
-    # Retrieve any subprotocols to be negotiated with the consumer later
-    subprotocols = [
-        subprotocol.strip()
-        for subprotocol in request_headers.get("sec-websocket-protocol", "").split(",")
-    ]
-    http.scope.update({"type": "websocket", "subprotocols": subprotocols})
-    asgi_instance = http.app(http.scope)
-    request = WebSocketRequest(http, response_headers)
-    http.loop.create_task(asgi_instance(request.receive, request.send))
-    request.put_message({"type": "websocket.connect"})
-
-
-class WebSocketRequestState(enum.Enum):
-    CONNECTING = 0
-    CONNECTED = 1
-    CLOSED = 2
-
-
-class WebSocketRequest:
-    def __init__(self, http, response_headers):
-        self.state = WebSocketRequestState.CONNECTING
-        self.http = http
-        self.scope = http.scope
-        self.response_headers = response_headers
+class WebSocketProtocol(websockets.WebSocketServerProtocol):
+    def __init__(self, app, logger):
+        self.app = app
+        self.root_path = ''
+        self.logger = logger
         self.loop = asyncio.get_event_loop()
-        self.receive_queue = asyncio.Queue()
-        self.protocol = None
 
-    def put_message(self, message):
-        self.receive_queue.put_nowait(message)
+        # Connection state
+        self.transport = None
+        self.server = None
+        self.client = None
+        self.scheme = None
 
-    async def receive(self):
-        return await self.receive_queue.get()
+        # Connection events
+        self.handshake_started_event = asyncio.Event()
+        self.handshake_completed_event = asyncio.Event()
+        self.closed_event = asyncio.Event()
+        self.initial_response = None
+        self.connect_sent = False
+        self.accepted_subprotocol = None
 
-    async def send(self, message):
-        message_type = message["type"]
-        text_data = message.get("text")
-        bytes_data = message.get("bytes")
+        server = Server()
 
-        if self.state == WebSocketRequestState.CLOSED:
-            raise Exception("Unexpected message, WebSocketRequest is CLOSED.")
+        super().__init__(ws_handler=self.ws_handler, ws_server=server)
 
-        if self.state == WebSocketRequestState.CONNECTING:
-            # Complete the handshake after negotiating a subprotocol with the consumer
-            subprotocol = message.get("subprotocol", None)
-            if subprotocol:
-                self.response_headers["Sec-WebSocket-Protocol"] = subprotocol
-            protocol = WebSocketProtocol(self.http, self.response_headers)
-            protocol.connection_made(self.http.transport, subprotocol)
-            protocol.connection_open()
-            self.http.transport.set_protocol(protocol)
-            self.protocol = protocol
-            self.protocol.active_request = self
-
-            if not self.protocol.accepted:
-                accept = message_type == "websocket.accept"
-                close = message_type == "websocket.close"
-
-                if accept or close:
-                    self.protocol.accept()
-                    self.state = WebSocketRequestState.CONNECTED
-                    if accept:
-                        self.protocol.listen()
-                else:
-                    self.protocol.reject()
-                    self.state = WebSocketRequestState.CLOSED
-
-        if self.state == WebSocketRequestState.CONNECTED:
-            if text_data:
-                await self.protocol.send(text_data)
-            elif bytes_data:
-                await self.protocol.send(bytes_data)
-
-            if message_type == "websocket.close":
-                code = message.get("code", 1000)
-                await self.protocol.close(code=code)
-                self.state = WebSocketRequestState.CLOSED
-        else:
-            raise Exception("Unexpected message, WebSocketRequest is %s" % self.state)
-
-
-class WebSocketProtocol(websockets.protocol.WebSocketCommonProtocol):
-    def __init__(self, http, handshake_headers):
-        super().__init__(max_size=10000000, max_queue=10000000)
-        self.handshake_headers = handshake_headers
-        self.accepted = False
-        self.loop = http.loop
-        self.app = http.app
-        self.active_request = None
-
-    def connection_made(self, transport, subprotocol):
-        super().connection_made(transport)
-        self.subprotocol = subprotocol
+    def connection_made(self, transport):
         self.transport = transport
+        self.server = transport.get_extra_info("sockname")
+        self.client = transport.get_extra_info("peername")
+        self.scheme = "wss" if transport.get_extra_info("sslcontext") else "ws"
+        super().connection_made(transport)
 
-    def accept(self):
-        self.accepted = True
-        rv = b"HTTP/1.1 101 Switching Protocols\r\n"
-        for k, v in self.handshake_headers.raw_headers:
-            rv += k + b": " + v + b"\r\n"
-        rv += b"\r\n"
-        self.transport.write(rv)
+    async def process_request(self, path, headers):
+        websockets.handshake.check_request(headers)
 
-    def listen(self):
-        self.loop.create_task(self.websocket_session())
+        subprotocols = []
+        for header in headers.get_all('Sec-WebSocket-Protocol'):
+            subprotocols.extend([token.strip() for token in header.split(',')])
 
-    def reject(self):
-        rv = b"HTTP/1.1 403 Forbidden\r\n\r\n"
-        self.active_request = None
-        self.transport.write(rv)
-        self.transport.close()
-
-    async def websocket_session(self):
-        close_code = None
-        request = self.active_request
-
-        while True:
-            try:
-                data = await self.recv()
-            except websockets.exceptions.ConnectionClosed as exc:
-                close_code = exc.code
-                break
-
-            message = {
-                "type": "websocket.receive",
-                "text": None,
-                "bytes": None,
-            }
-            if isinstance(data, str):
-                message["text"] = data
-            elif isinstance(data, bytes):
-                message["bytes"] = data
-            request.put_message(message)
-
-        message = {
-            "type": "websocket.disconnect",
-            "code": close_code,
+        scope = {
+            'type': 'websocket',
+            'scheme': self.scheme,
+            'server': self.server,
+            'client': self.client,
+            'root_path': self.root_path,
+            'path': unquote(path),
+            'query_string': b'',  # TODO
+            'headers': [],  # TODO
+            'subprotocols': subprotocols,
         }
-        request.put_message(message)
-        self.active_request = None
+        self.loop.create_task(self.run_asgi(scope))
+        await self.handshake_started_event.wait()
+        print('initial_response', self.initial_response)
+        return self.initial_response
+
+    def process_subprotocol(self, headers, available_subprotocols):
+        return self.accepted_subprotocol
+
+    async def ws_handler(self, protocol, path):
+        print('ws_handler')
+        self.handshake_completed_event.set()
+        await self.closed_event.wait()
+
+    async def write_http_response(self, status, headers, body=b''):
+        print('write_http_response(%s, %s, %s)' % (status, headers, body))
+        await super().write_http_response(status, headers, body)
+
+    async def run_asgi(self, scope):
+        """
+        Wrapper around the ASGI callable, handling exceptions and unexpected
+        termination states.
+        """
+        try:
+            asgi = self.app(scope)
+            result = await asgi(self.asgi_receive, self.asgi_send)
+        except:
+            self.closed_event.set()
+            msg = "Exception in ASGI application\n%s"
+            traceback_text = "".join(traceback.format_exc())
+            self.logger.error(msg, traceback_text)
+            self.transport.close()
+        else:
+            self.closed_event.set()
+            if result is not None:
+                msg = "ASGI callable should return None, but returned '%s'."
+                self.logger.error(msg, result)
+                self.transport.close()
+            elif not self.handshake_started_event.is_set():
+                msg = "ASGI callable returned without sending handshake."
+                self.logger.error(msg)
+                self.transport.close()
+
+    async def asgi_send(self, message):
+        print('send', message)
+        message_type = message["type"]
+
+        if not self.handshake_started_event.is_set():
+            if message_type == "websocket.accept":
+                self.initial_response = None
+                self.accepted_subprotocol = message.get('subprotocol')
+                self.handshake_started_event.set()
+
+            elif message_type == "websocket.close":
+                self.initial_response = (http.HTTPStatus.FORBIDDEN, [], b'')
+                self.handshake_started_event.set()
+                self.closed_event.set()
+
+            else:
+                msg = "Expected ASGI message 'websocket.accept' or 'websocket.close', but got '%s'."
+                raise RuntimeError(msg % message_type)
+
+        else:
+            if self.closed_event.is_set():
+                msg = "Unexpected ASGI message '%s', after sending 'websocket.close'."
+                raise RuntimeError(msg % message_type)
+
+            await self.handshake_completed_event.wait()
+
+            if message_type == 'websocket.send':
+                bytes_data = message.get('bytes')
+                text_data = message.get('text')
+                data = text_data if bytes_data is None else bytes_data
+                await self.send(data)
+
+            elif message_type == 'websocket.close':
+                self.closed_event.set()
+
+            else:
+                msg = "Expected ASGI message 'websocket.send' or 'websocket.close', but got '%s'."
+                raise RuntimeError(msg % message_type)
+
+    async def asgi_receive(self):
+        print('receive')
+
+        if not self.connect_sent:
+            self.connect_sent = True
+            return {
+                "type": "websocket.connect"
+            }
+
+        await self.handshake_completed_event.wait()
+        try:
+            data = await self.recv()
+        except websockets.ConnectionClosed as exc:
+            return {
+                "type": "websocket.disconnect",
+                "code": exc.code,
+            }
+
+        is_text = isinstance(data, str)
+        return {
+            "type": "websocket.receive",
+            "text": data if is_text else None,
+            "bytes": None if is_text else data,
+        }

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -142,6 +142,8 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             msg = "Exception in ASGI application\n%s"
             traceback_text = "".join(traceback.format_exc())
             self.logger.error(msg, traceback_text)
+            if not self.handshake_started_event.is_set():
+                self.send_500_response()
             self.transport.close()
         else:
             self.closed_event.set()

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -46,7 +46,7 @@ def websocket_upgrade(http):
     asgi_instance = http.app(http.scope)
     request = WebSocketRequest(http, response_headers)
     http.loop.create_task(asgi_instance(request.receive, request.send))
-    request.put_message({"type": "websocket.connect", "order": 0})
+    request.put_message({"type": "websocket.connect"})
 
 
 class WebSocketRequestState(enum.Enum):
@@ -151,9 +151,7 @@ class WebSocketProtocol(websockets.protocol.WebSocketCommonProtocol):
 
     async def websocket_session(self):
         close_code = None
-        order = 1
         request = self.active_request
-        path = request.scope["path"]
 
         while True:
             try:
@@ -164,23 +162,18 @@ class WebSocketProtocol(websockets.protocol.WebSocketCommonProtocol):
 
             message = {
                 "type": "websocket.receive",
-                "path": path,
                 "text": None,
                 "bytes": None,
-                "order": order,
             }
             if isinstance(data, str):
                 message["text"] = data
             elif isinstance(data, bytes):
                 message["bytes"] = data
             request.put_message(message)
-            order += 1
 
         message = {
             "type": "websocket.disconnect",
             "code": close_code,
-            "path": path,
-            "order": order,
         }
         request.put_message(message)
         self.active_request = None

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -50,10 +50,8 @@ class WSProtocol(asyncio.Protocol):
         pass
 
     def data_received(self, data):
-        print('data_received', data)
         self.conn.receive_bytes(data)
         for event in self.conn.events():
-            print(event)
             if isinstance(event, wsproto.events.ConnectionRequested):
                 self.handle_connect(event)
             elif isinstance(event, wsproto.events.TextReceived):
@@ -128,7 +126,6 @@ class WSProtocol(asyncio.Protocol):
         self.transport.write(output)
 
     async def run_asgi(self, scope):
-        print('run_asgi')
         try:
             asgi = self.app(scope)
             result = await asgi(self.receive, self.send)
@@ -149,7 +146,6 @@ class WSProtocol(asyncio.Protocol):
 
     async def send(self, message):
         message_type = message["type"]
-        print('send', message)
 
         if not self.handshake_complete:
             if message_type == "websocket.accept":
@@ -199,5 +195,4 @@ class WSProtocol(asyncio.Protocol):
             raise RuntimeError(msg % message_type)
 
     async def receive(self):
-        print('receive')
         return await self.queue.get()

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -1,0 +1,203 @@
+from urllib.parse import unquote
+import asyncio
+import h11
+import traceback
+import wsproto.connection
+import wsproto.events
+import wsproto.extensions
+
+
+class WSProtocol(asyncio.Protocol):
+    def __init__(self, app, logger):
+        self.app = app
+        self.root_path = ''
+        self.logger = logger
+        self.loop = asyncio.get_event_loop()
+
+        # Connection state
+        self.transport = None
+        self.server = None
+        self.client = None
+        self.scheme = None
+
+        # WebSocket state
+        self.connect_event = None
+        self.queue = asyncio.Queue()
+        self.handshake_complete = False
+        self.close_sent = False
+
+        self.conn = wsproto.connection.WSConnection(
+            conn_type=wsproto.connection.SERVER,
+            extensions=[wsproto.extensions.PerMessageDeflate()],
+        )
+
+        # Buffers
+        self.bytes = b''
+        self.text = ''
+
+    # Protocol interface
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.server = transport.get_extra_info("sockname")
+        self.client = transport.get_extra_info("peername")
+        self.scheme = "wss" if transport.get_extra_info("sslcontext") else "ws"
+
+    def connection_lost(self, exc):
+        pass
+
+    def eof_received(self):
+        pass
+
+    def data_received(self, data):
+        print('data_received', data)
+        self.conn.receive_bytes(data)
+        for event in self.conn.events():
+            print(event)
+            if isinstance(event, wsproto.events.ConnectionRequested):
+                self.handle_connect(event)
+            elif isinstance(event, wsproto.events.TextReceived):
+                self.handle_text(event)
+            elif isinstance(event, wsproto.events.BytesReceived):
+                self.handle_bytes(event)
+            elif isinstance(event, wsproto.events.ConnectionFailed):
+                self.handle_no_connect(event)
+            elif isinstance(event, wsproto.events.ConnectionClosed):
+                self.handle_close(event)
+            elif isinstance(event, wsproto.events.PingReceived):
+                self.handle_ping(event)
+
+    # Event handlers
+
+    def handle_connect(self, event):
+        self.connect_event = event
+        request = event.h11request
+        headers = [(key.lower(), value) for key, value in request.headers]
+        path, _, query_string = request.target.partition(b'?')
+        scope = {
+            'type': 'websocket',
+            'scheme': self.scheme,
+            'server': self.server,
+            'client': self.client,
+            'root_path': self.root_path,
+            'path': unquote(path.decode('ascii')),
+            'query_string': query_string,
+            'headers': headers,
+            'subprotocols': [],
+        }
+        self.queue.put_nowait({
+            "type": "websocket.connect"
+        })
+        self.loop.create_task(self.run_asgi(scope))
+
+    def handle_no_connect(self, event):
+        msg = h11.Response(status_code=400, headers=[])
+        output = self.conn._upgrade_connection.send(msg)
+        msg = h11.EndOfMessage()
+        output += self.conn._upgrade_connection.send(msg)
+        self.transport.write(output)
+        self.transport.close()
+
+    def handle_text(self, event):
+        self.text += event.data
+        if event.message_finished:
+            self.queue.put_nowait({
+                'type': 'websocket.receive',
+                'text': self.text
+            })
+            self.text = ''
+
+    def handle_bytes(self, event):
+        self.bytes += event.data
+        if event.message_finished:
+            self.queue.put_nowait({
+                'type': 'websocket.receive',
+                'bytes': self.bytes
+            })
+            self.bytes = b''
+
+    def handle_close(self, event):
+        self.queue.put_nowait({
+            'type': 'websocket.disconnect',
+            'code': event.code
+        })
+        self.transport.close()
+
+    def handle_ping(self, event):
+        output = self.conn.bytes_to_send()
+        self.transport.write(output)
+
+    async def run_asgi(self, scope):
+        print('run_asgi')
+        try:
+            asgi = self.app(scope)
+            result = await asgi(self.receive, self.send)
+        except:
+            msg = "Exception in ASGI application\n%s"
+            traceback_text = "".join(traceback.format_exc())
+            self.logger.error(msg, traceback_text)
+            self.transport.close()
+        else:
+            if result is not None:
+                msg = "ASGI callable should return None, but returned '%s'."
+                self.logger.error(msg, result)
+                self.transport.close()
+            elif not self.handshake_complete:
+                msg = "ASGI callable returned without completing handshake."
+                self.logger.error(msg)
+                self.transport.close()
+
+    async def send(self, message):
+        message_type = message["type"]
+        print('send', message)
+
+        if not self.handshake_complete:
+            if message_type == "websocket.accept":
+                self.handshake_complete = True
+                subprotocol = message.get("subprotocol")
+                self.conn.accept(self.connect_event, subprotocol)
+                output = self.conn.bytes_to_send()
+                self.transport.write(output)
+
+            elif message_type == "websocket.close":
+                self.handshake_complete = True
+                self.close_sent = True
+                msg = h11.Response(status_code=403, headers=[])
+                output = self.conn._upgrade_connection.send(msg)
+                msg = h11.EndOfMessage()
+                output += self.conn._upgrade_connection.send(msg)
+                self.transport.write(output)
+                self.transport.close()
+
+            else:
+                msg = "Expected ASGI message 'websocket.accept' or 'websocket.close', but got '%s'."
+                raise RuntimeError(msg % message_type)
+
+        elif not self.close_sent:
+            if message_type == 'websocket.send':
+                bytes_data = message.get('bytes')
+                text_data = message.get('text')
+                data = text_data if bytes_data is None else bytes_data
+                self.conn.send_data(data)
+                output = self.conn.bytes_to_send()
+                self.transport.write(output)
+
+            elif message_type == 'websocket.close':
+                self.close_sent = True
+                message.get('code', 1000)
+                self.conn.close(code)
+                output = self.conn.bytes_to_send()
+                self.transport.write(output)
+                self.transport.close()
+
+            else:
+                msg = "Expected ASGI message 'websocket.send' or 'websocket.close', but got '%s'."
+                raise RuntimeError(msg % message_type)
+
+        else:
+            msg = "Unexpected ASGI message '%s', after sending 'websocket.close'."
+            raise RuntimeError(msg % message_type)
+
+    async def receive(self):
+        print('receive')
+        return await self.queue.get()

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -255,7 +255,7 @@ class WSProtocol(asyncio.Protocol):
 
             elif message_type == 'websocket.close':
                 self.close_sent = True
-                message.get('code', 1000)
+                code = message.get('code', 1000)
                 self.conn.close(code)
                 output = self.conn.bytes_to_send()
                 self.transport.write(output)

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -193,6 +193,8 @@ class WSProtocol(asyncio.Protocol):
             msg = "Exception in ASGI application\n%s"
             traceback_text = "".join(traceback.format_exc())
             self.logger.error(msg, traceback_text)
+            if not self.handshake_complete:
+                self.send_500_response()
             self.transport.close()
         else:
             if not self.handshake_complete:

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -10,6 +10,7 @@ import uvloop
 from gunicorn.workers.base import Worker
 from uvicorn.protocols.http.h11_impl import H11Protocol
 from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
 
 class UvicornWorker(Worker):
@@ -25,6 +26,7 @@ class UvicornWorker(Worker):
     """
 
     protocol_class = HttpToolsProtocol
+    ws_protocol_class = WSProtocol
     loop = "uvloop"
 
     def __init__(self, *args, **kwargs):
@@ -101,6 +103,7 @@ class UvicornWorker(Worker):
                 connections=connections,
                 state=state,
                 logger=self.log,
+                ws_protocol_class=WSProtocol
             )
             server = await loop.create_server(protocol, sock=sock, ssl=ssl_ctx)
             self.servers.append((server, state))


### PR DESCRIPTION
Refactor the websocket implementation, so that:

* We're now subclassing `websockets.WebSocketServerProtocol`, rather than dealing with the handshake ourselves.
* The HTTP protocol passes the entire HTTP request data through to the WS protocol, rather than passing over the scope.
* Add an alternate `wsproto` implementation.
* Support `--ws [none|auto|websockets|wsproto]`

TODO:

- [x] Add reason text to websocket 400/403 responses.
- [x] Handle shutdown.
- [x] Flow control on wsproto.
- [x] Support `--ws none`.

Closes #100
Closes #123 