### PR TITLE
Support `--wsgi`

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,6 +35,11 @@ Options:
   --fd INTEGER                    Bind to socket from this file descriptor.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP parser implementation.  [default: auto]
+  --ws [none|auto|websockets|wsproto]
+                                  WebSocket protocol implementation.
+                                  [default: auto]
+  --wsgi                          Use WSGI as the application interface,
+                                  instead of ASGI.
   --debug                         Enable debug mode.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,11 @@ Options:
   --fd INTEGER                    Bind to socket from this file descriptor.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP parser implementation.  [default: auto]
+  --ws [none|auto|websockets|wsproto]
+                                  WebSocket protocol implementation.
+                                  [default: auto]
+  --wsgi                          Use WSGI as the application interface,
+                                  instead of ASGI.
   --debug                         Enable debug mode.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -26,9 +26,13 @@ equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, timeo
 
 ## Implementation
 
-* `--loop` - Set the event loop implementation. The uvloop implementation provides greater performance, but is not compatible with Windows or PyPy. **Options:** *'auto', 'asyncio', 'uvloop'.* **Default:**: *'auto'*.
-* `--http` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy, and requires compilation on Windows. **Options:** *'auto', 'h11', 'httptools'.* **Default:**: *'auto'*.
-* `--ws` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to deny all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:**: *'auto'*.
+* `--loop` - Set the event loop implementation. The uvloop implementation provides greater performance, but is not compatible with Windows or PyPy. **Options:** *'auto', 'asyncio', 'uvloop'.* **Default:** *'auto'*.
+* `--http` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy, and requires compilation on Windows. **Options:** *'auto', 'h11', 'httptools'.* **Default:** *'auto'*.
+* `--ws` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to deny all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
+
+## Application Interface
+
+* `--wsgi` - Use WSGI as the application interface rather than ASGI. Note that WSGI mode always disables WebSocket support, as it is not supported by the WSGI interface.
 
 ## HTTP
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,0 +1,29 @@
+from tests.client import TestClient
+from uvicorn.wsgi import WSGIMiddleware
+
+
+def hello_world(environ, start_response):
+    status = '200 OK'
+    output = b'Hello World!\n'
+    headers = [
+        ('Content-Type', 'text/plain; charset=utf-8'),
+        ('Content-Length', str(len(output)))
+    ]
+    start_response(status, headers)
+    return [output]
+
+
+def test_wsgi_get():
+    app = WSGIMiddleware(hello_world)
+    client = TestClient(app)
+    response = client.get('/')
+    assert response.status_code == 200
+    assert response.text == 'Hello World!\n'
+
+
+def test_wsgi_post():
+    app = WSGIMiddleware(hello_world)
+    client = TestClient(app)
+    response = client.post('/', json={"example": 123})
+    assert response.status_code == 200
+    assert response.text == 'Hello World!\n'

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,3 +1,5 @@
+import pytest
+import sys
 from tests.client import TestClient
 from uvicorn.wsgi import WSGIMiddleware
 
@@ -24,6 +26,24 @@ def echo_body(environ, start_response):
     return [output]
 
 
+def raise_exception(environ, start_response):
+    raise RuntimeError('Something went wrong')
+
+
+def return_exc_info(environ, start_response):
+    try:
+        raise RuntimeError('Something went wrong')
+    except:
+        status = '500 Internal Server Error'
+        output = b'Internal Server Error'
+        headers = [
+            ('Content-Type', 'text/plain; charset=utf-8'),
+            ('Content-Length', str(len(output)))
+        ]
+        start_response(status, headers, exc_info=sys.exc_info())
+        return [output]
+
+
 def test_wsgi_get():
     app = WSGIMiddleware(hello_world)
     client = TestClient(app)
@@ -38,3 +58,21 @@ def test_wsgi_post():
     response = client.post('/', json={"example": 123})
     assert response.status_code == 200
     assert response.text == '{"example": 123}'
+
+
+def test_wsgi_exception():
+    # Note that we're testing the WSGI app directly here.
+    # The HTTP protocol implementations would catch this error and return 500.
+    app = WSGIMiddleware(raise_exception)
+    client = TestClient(app)
+    with pytest.raises(RuntimeError):
+        response = client.get('/')
+
+
+def test_wsgi_exc_info():
+    # Note that we're testing the WSGI app directly here.
+    # The HTTP protocol implementations would catch this error and return 500.
+    app = WSGIMiddleware(return_exc_info)
+    client = TestClient(app)
+    with pytest.raises(RuntimeError):
+        response = client.get('/')

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -13,6 +13,17 @@ def hello_world(environ, start_response):
     return [output]
 
 
+def echo_body(environ, start_response):
+    status = '200 OK'
+    output = environ['wsgi.input'].read()
+    headers = [
+        ('Content-Type', 'text/plain; charset=utf-8'),
+        ('Content-Length', str(len(output)))
+    ]
+    start_response(status, headers)
+    return [output]
+
+
 def test_wsgi_get():
     app = WSGIMiddleware(hello_world)
     client = TestClient(app)
@@ -22,8 +33,8 @@ def test_wsgi_get():
 
 
 def test_wsgi_post():
-    app = WSGIMiddleware(hello_world)
+    app = WSGIMiddleware(echo_body)
     client = TestClient(app)
     response = client.post('/', json={"example": 123})
     assert response.status_code == 200
-    assert response.text == 'Hello World!\n'
+    assert response.text == '{"example": 123}'

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,6 +1,7 @@
 from uvicorn.debug import DebugMiddleware
 from uvicorn.importer import import_from_string, ImportFromStringError
 from uvicorn.reloaders.statreload import StatReload
+from uvicorn.wsgi import WSGIMiddleware
 import asyncio
 import click
 import signal
@@ -94,6 +95,7 @@ def get_logger(log_level):
     help="WebSocket protocol implementation.",
     show_default=True,
 )
+@click.option("--wsgi", is_flag=True, default=False, help="Enable WSGI mode.")
 @click.option("--debug", is_flag=True, default=False, help="Enable debug mode.")
 @click.option(
     "--log-level",
@@ -149,6 +151,7 @@ def main(
     loop: str,
     http: str,
     ws: str,
+    wsgi: bool,
     debug: bool,
     log_level: str,
     proxy_headers: bool,
@@ -170,6 +173,7 @@ def main(
         "http": http,
         "ws": ws,
         "log_level": log_level,
+        "wsgi": wsgi,
         "debug": debug,
         "proxy_headers": proxy_headers,
         "root_path": root_path,
@@ -197,6 +201,7 @@ def run(
     http="auto",
     ws="auto",
     log_level="info",
+    wsgi=False,
     debug=False,
     proxy_headers=False,
     root_path="",
@@ -228,6 +233,8 @@ def run(
         click.echo("Error loading ASGI app. %s" % exc)
         sys.exit(1)
 
+    if wsgi:
+        app = WSGIMiddleware(app)
     if debug:
         app = DebugMiddleware(app)
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -95,7 +95,7 @@ def get_logger(log_level):
     help="WebSocket protocol implementation.",
     show_default=True,
 )
-@click.option("--wsgi", is_flag=True, default=False, help="Enable WSGI mode.")
+@click.option("--wsgi", is_flag=True, default=False, help="Use WSGI as the application interface, instead of ASGI.")
 @click.option("--debug", is_flag=True, default=False, help="Enable debug mode.")
 @click.option(
     "--log-level",
@@ -235,6 +235,7 @@ def run(
 
     if wsgi:
         app = WSGIMiddleware(app)
+        ws_protocol_class = None
     if debug:
         app = DebugMiddleware(app)
 

--- a/uvicorn/wsgi.py
+++ b/uvicorn/wsgi.py
@@ -22,10 +22,12 @@ def build_environ(scope, message, body):
         "wsgi.multiprocess": True,
         "wsgi.run_once": False,
     }
+
     # Get server name and port - required in WSGI, not in ASGI
     server = scope.get("server", ("localhost", 80))
     environ["SERVER_NAME"] = server[0]
     environ["SERVER_PORT"] = server[1]
+
     # Go through headers and make them into environ entries
     for name, value in scope.get("headers", []):
         name = name.decode("latin1")
@@ -89,6 +91,8 @@ class WSGIResponder:
                 self.send_event.clear()
 
     def start_response(self, status, response_headers, exc_info=None):
+        if exc_info is not None:
+            raise exc_info[0].with_traceback(exc_info[1], exc_info[2])
         status_code, _ = status.split(" ", 1)
         status_code = int(status_code)
         headers = [

--- a/uvicorn/wsgi.py
+++ b/uvicorn/wsgi.py
@@ -1,0 +1,112 @@
+import asyncio
+import concurrent.futures
+import io
+import sys
+
+
+def build_environ(scope, message):
+    """
+    Builds a scope and request message into a WSGI environ object.
+    """
+    environ = {
+        "REQUEST_METHOD": scope["method"],
+        "SCRIPT_NAME": "",
+        "PATH_INFO": scope["path"],
+        "QUERY_STRING": scope["query_string"].decode("ascii"),
+        "SERVER_PROTOCOL": "HTTP/%s" % scope["http_version"],
+        "wsgi.version": (1, 0),
+        "wsgi.url_scheme": scope.get("scheme", "http"),
+        "wsgi.input": io.BytesIO(message.get("body", b"")),
+        "wsgi.errors": sys.stdout,
+        "wsgi.multithread": True,
+        "wsgi.multiprocess": True,
+        "wsgi.run_once": False,
+    }
+    # Get server name and port - required in WSGI, not in ASGI
+    server = scope.get("server", ("localhost", 80))
+    environ["SERVER_NAME"] = server[0]
+    environ["SERVER_PORT"] = server[1]
+    # Go through headers and make them into environ entries
+    for name, value in scope.get("headers", []):
+        name = name.decode("latin1")
+        if name == "content-length":
+            corrected_name = "CONTENT_LENGTH"
+        elif name == "content-type":
+            corrected_name = "CONTENT_TYPE"
+        else:
+            corrected_name = "HTTP_%s" % name.upper().replace("-", "_")
+        # HTTPbis say only ASCII chars are allowed in headers, but we latin1 just in case
+        value = value.decode("latin1")
+        if corrected_name in environ:
+            value = environ[corrected_name] + "," + value
+        environ[corrected_name] = value
+    return environ
+
+
+class WSGIMiddleware:
+    def __init__(self, app, workers=10):
+        self.app = app
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
+
+    def __call__(self, scope):
+        return WSGIResponder(self.app, self.executor, scope)
+
+
+class WSGIResponder:
+    def __init__(self, app, executor, scope):
+        self.app = app
+        self.executor = executor
+        self.scope = scope
+        self.status = None
+        self.response_headers = None
+        self.send_event = asyncio.Event()
+        self.send_queue = []
+        self.loop = None
+
+    async def __call__(self, receive, send):
+        message = await receive()
+        environ = build_environ(self.scope, message)
+        self.loop = asyncio.get_event_loop()
+        wsgi = self.loop.run_in_executor(self.executor, self.wsgi, environ, self.start_response)
+        self.loop.create_task(self.sender(send))
+        await asyncio.wait_for(wsgi, 60)
+
+    async def sender(self, send):
+        while True:
+            if self.send_queue:
+                message = self.send_queue.pop(0)
+                await send(message)
+                if message['type'] == 'http.response.body' and not message.get('more_body'):
+                    break
+            else:
+                await self.send_event.wait()
+                self.send_event.clear()
+
+    def start_response(self, status, response_headers, exc_info=None):
+        status_code, _ = status.split(" ", 1)
+        status_code = int(status_code)
+        headers = [
+            (name.encode("ascii"), value.encode("ascii"))
+            for name, value in response_headers
+        ]
+        self.send_queue.append({
+            "type": "http.response.start",
+            "status": status_code,
+            "headers": headers,
+        })
+        self.loop.call_soon_threadsafe(self.send_event.set)
+
+    def wsgi(self, environ, start_response):
+        for chunk in self.app(environ, start_response):
+            self.send_queue.append({
+                "type": "http.response.body",
+                "body": chunk,
+                "more_body": True
+            })
+            self.loop.call_soon_threadsafe(self.send_event.set)
+
+        self.send_queue.append({
+            "type": "http.response.body",
+            "body": b""
+        })
+        self.loop.call_soon_threadsafe(self.send_event.set)


### PR DESCRIPTION
Support running Uvicorn as a standard WSGI server, handing incoming requests with `asyncio`, and running the WSGI application within a thread-pool.

Remaining:

- [x] Exception handling.
- [x] Read complete request body.

We could also implement streaming the request body, but that's a bit fiddly to bridge from asyncio to the WSGI thread.