### PR TITLE
giving logger a name

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -51,7 +51,7 @@ HANDLED_SIGNALS = (
 def get_logger(log_level):
     log_level = LOG_LEVELS[log_level]
     logging.basicConfig(format="%(levelname)s: %(message)s", level=log_level)
-    return logging.getLogger()
+    return logging.getLogger("uvicorn")
 
 
 @click.command()


### PR DESCRIPTION
This will allow django to configure the output

i believe giving it a name will allow non-django users to configure it as well, but i'm only familiar with django