### PR TITLE
bug(Doc): Missing `'type'` key in `send()` dict

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -223,7 +223,7 @@ class EchoMethodAndPath():
     async def __call__(self, recieve, send):
         body = 'Received %s request to %s' % (self.scope['method'], self.scope['path'])
         await send({
-            'http.response.start',
+            'type': 'http.response.start',
             'status': 200,
             'headers': [
                 [b'content-type', b'text/plain'],
@@ -263,7 +263,7 @@ class EchoBody():
     async def __call__(self, receive, send):
         body = await self.read_body(receive)
         await send({
-            'http.response.start',
+            'type': 'http.response.start',
             'status': 200,
             'headers': [
                 [b'content-type', b'text/plain'],
@@ -288,7 +288,7 @@ class StreamResponse():
     async def __call__(self, receive, send):
         body = await self.read_body(receive)
         await send({
-            'http.response.start',
+            'type': 'http.response.start',
             'status': 200,
             'headers': [
                 [b'content-type', b'text/plain'],


### PR DESCRIPTION
The example in the documentation sometimes missed the `type` key, but not the value, so the example code had syntax errors. 