### PR TITLE
Add 'access_log=False' / --no-access-log

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,7 @@ Options:
   --debug                         Enable debug mode.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]
+  --no-access-log                 Disable access log.
   --proxy-headers                 Use X-Forwarded-Proto, X-Forwarded-For,
                                   X-Forwarded-Port to populate remote address
                                   info.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -3,7 +3,7 @@
 Use the following options to configure Uvicorn, when running from the command line.
 
 If you're running using programmatically, using `uvicorn.run(...)`, then use
-equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, timeout_keep_alive=10)`.
+equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, access_log=False)`.
 
 ## Application
 
@@ -23,6 +23,7 @@ equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, timeo
 ## Logging
 
 * `--log-level` - Set the log level. **Options:** *'critical', 'error', 'warning', 'info', 'debug'.* **Default:** *'info'*.
+* `--no-access-log` - Disable access log only, without changing log level.
 
 ## Implementation
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -104,6 +104,7 @@ def get_logger(log_level):
     help="Log level.",
     show_default=True,
 )
+@click.option("--no-access-log", is_flag=True, default=False, help="Disable access log.")
 @click.option(
     "--proxy-headers",
     is_flag=True,
@@ -154,6 +155,7 @@ def main(
     wsgi: bool,
     debug: bool,
     log_level: str,
+    no_access_log: bool,
     proxy_headers: bool,
     root_path: str,
     limit_concurrency: int,
@@ -173,6 +175,7 @@ def main(
         "http": http,
         "ws": ws,
         "log_level": log_level,
+        "access_log": not no_access_log,
         "wsgi": wsgi,
         "debug": debug,
         "proxy_headers": proxy_headers,
@@ -201,6 +204,7 @@ def run(
     http="auto",
     ws="auto",
     log_level="info",
+    access_log=True,
     wsgi=False,
     debug=False,
     proxy_headers=False,
@@ -248,6 +252,7 @@ def run(
             app=app,
             loop=loop,
             logger=logger,
+            access_log=access_log,
             connections=connections,
             tasks=tasks,
             state=state,


### PR DESCRIPTION
This configuration just disables access logging, without changing the log level.
Useful, since you'll still get info-level messages about startup/process id/shutdown.

Eg. `uvicorn.run(App, access_log=False)`