### PR TITLE
Break cyclical references

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -136,13 +136,6 @@ def get_logger(log_level):
     help="Close Keep-Alive connections if no new data is received within this timeout.",
     show_default=True,
 )
-@click.option(
-    "--timeout-response",
-    type=int,
-    default=60,
-    help="Cancel request/response tasks that do not complete within this timeout.",
-    show_default=True,
-)
 def main(
     app,
     host: str,
@@ -161,7 +154,6 @@ def main(
     limit_concurrency: int,
     limit_max_requests: int,
     timeout_keep_alive: int,
-    timeout_response: int,
 ):
     sys.path.insert(0, ".")
 
@@ -183,7 +175,6 @@ def main(
         "limit_concurrency": limit_concurrency,
         "limit_max_requests": limit_max_requests,
         "timeout_keep_alive": timeout_keep_alive,
-        "timeout_response": timeout_response,
     }
 
     if debug:
@@ -212,7 +203,6 @@ def run(
     limit_concurrency=None,
     limit_max_requests=None,
     timeout_keep_alive=5,
-    timeout_response=60,
     install_signal_handlers=True,
     ready_event=None,
 ):
@@ -261,7 +251,6 @@ def run(
             root_path=root_path,
             limit_concurrency=limit_concurrency,
             timeout_keep_alive=timeout_keep_alive,
-            timeout_response=timeout_response,
         )
 
     server = Server(

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -115,7 +115,6 @@ class H11Protocol(asyncio.Protocol):
         root_path="",
         limit_concurrency=None,
         timeout_keep_alive=5,
-        timeout_response=60,
     ):
         self.app = app
         self.loop = loop or asyncio.get_event_loop()
@@ -133,7 +132,6 @@ class H11Protocol(asyncio.Protocol):
         # Timeouts
         self.timeout_keep_alive_task = None
         self.timeout_keep_alive = timeout_keep_alive
-        self.timeout_response = timeout_response
 
         # Per-connection state
         self.transport = None
@@ -268,11 +266,8 @@ class H11Protocol(asyncio.Protocol):
                     on_response=self.on_response_complete,
                 )
                 task = self.loop.create_task(self.cycle.run_asgi(app))
-                task.add_done_callback(self.on_task_complete)
+                task.add_done_callback(self.tasks.discard)
                 self.tasks.add(task)
-                self.loop.call_later(
-                    self.timeout_response, self.timeout_response_handler, task
-                )
 
             elif event_type is h11.Data:
                 if self.conn.our_state is h11.DONE:
@@ -351,9 +346,6 @@ class H11Protocol(asyncio.Protocol):
             self.conn.start_next_cycle()
             self.handle_events()
 
-    def on_task_complete(self, task):
-        self.tasks.discard(task)
-
     def shutdown(self):
         """
         Called by the server to commence a graceful shutdown.
@@ -385,14 +377,6 @@ class H11Protocol(asyncio.Protocol):
             event = h11.ConnectionClosed()
             self.conn.send(event)
             self.transport.close()
-
-    def timeout_response_handler(self, task):
-        """
-        Called once per task, when the reponse timeout is reached.
-        """
-        if not task.done():
-            self.logger.error("Task exceeded response timeout.")
-            task.cancel()
 
 
 class RequestResponseCycle:
@@ -457,6 +441,8 @@ class RequestResponseCycle:
                 self.logger.error(msg)
                 if not self.disconnected:
                     self.transport.close()
+        finally:
+            self.on_response = None
 
     async def send_500_response(self):
         await self.send(


### PR DESCRIPTION
Break cyclical references that were causing the GC to run during request/response cycles and incur significant latencies on some requests.

This does remove the response timeouts for now.

We'll want an alternative implementation of the response timeouts, but we want a different approach there *anyways* (eg. timeout on no-data after a given period) to allow for long-running connections (eg. SSE).