### PR TITLE
Include tag to disable favicon request in debug middleware

### DIFF
--- a/uvicorn/middleware/debug.py
+++ b/uvicorn/middleware/debug.py
@@ -85,7 +85,7 @@ class _DebugResponder:
             if "text/html" in accept:
                 exc_html = html.escape(traceback.format_exc())
                 content = (
-                    "<html><body><h1>500 Server Error</h1><pre>%s</pre></body></html>"
+                    "<html><head><link rel='icon' href='data:,'></head><body><h1>500 Server Error</h1><pre>%s</pre></body></html>"
                     % exc_html
                 )
                 response = HTMLResponse(content, status_code=500)


### PR DESCRIPTION
Minor tweak to the debug middleware HTML response. 

I am including this middleware in https://github.com/erm/fikki/issues/3, and I was able to just drop it in for the most part, but in the case of HTML responses the favicon request prevents the entire stack trace from being rendered in my server implementation. 

It did not occur when running the app with `uvicorn`, so I imagine this is handled here somehow, but this change seems minor enough to make it on this end.