### PR TITLE
Fix sample nginx conf block

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -178,8 +178,8 @@ http {
     location / {
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
-      proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+      proxy_set_header X-Forwarded-Port 80;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_redirect off;
       proxy_buffering off;
       proxy_pass http://uvicorn;
@@ -192,7 +192,7 @@ http {
   }
 
   upstream uvicorn {
-    server unix:/tmp/uvicorn.sock
+    server unix:/tmp/uvicorn.sock;
   }
 
 }


### PR DESCRIPTION
After basing my nginx conf on the sample nginx conf in the docs, I encountered some problems:

1. Missing semicolon in the upstream block causes nginx to crash
2. $proxy_x_forwarded_port and $proxy_x_forwarded_proto are not valid variables. This might have been copied from a different nginx conf that used map to define these? I am not sure about this one.