### PR TITLE
Include REMOTE_ADDR (client IP) in WSGI environ

### DIFF
--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -28,6 +28,10 @@ def build_environ(scope, message, body):
     environ["SERVER_NAME"] = server[0]
     environ["SERVER_PORT"] = server[1]
 
+    # Get client IP address
+    client = scope.get("client")
+    environ["REMOTE_ADDR"] = client[0]
+
     # Go through headers and make them into environ entries
     for name, value in scope.get("headers", []):
         name = name.decode("latin1")

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -29,8 +29,8 @@ def build_environ(scope, message, body):
     environ["SERVER_PORT"] = server[1]
 
     # Get client IP address
-    client = scope.get("client")
-    environ["REMOTE_ADDR"] = client[0]
+    if "client" in scope:
+        environ["REMOTE_ADDR"] = scope["client"][0]
 
     # Go through headers and make them into environ entries
     for name, value in scope.get("headers", []):


### PR DESCRIPTION
PR to add the REMOTE_ADDR (client IP) variable to the WSGI environ dict.

When running --wsgi, REMOTE_ADDR is not included in the WSGI environ variables, as implemented by other WSGI servers, and standardised in [CGI 1.1](https://www.ietf.org/rfc/rfc3875). That's fair enough, I note it's not on the list of required vars in the WSGI spec ([PEP 333](https://www.python.org/dev/peps/pep-0333/#id19)). 

However,  the fact that its missing is a bit painful for users of Django and its ecosystem, which in my experience, expect it to be present.