### PR TITLE
Send HTTP 400 response for invalid request

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -179,7 +179,7 @@ class H11Protocol(asyncio.Protocol):
             except h11.RemoteProtocolError as exc:
                 msg = "Invalid HTTP request received."
                 self.logger.warning(msg)
-                self.transport.close()
+                self.send_400_response(msg)
                 return
             event_type = type(event)
 
@@ -268,21 +268,7 @@ class H11Protocol(asyncio.Protocol):
         if upgrade_value != b'websocket' or self.ws_protocol_class is None:
             msg = "Unsupported upgrade request."
             self.logger.warning(msg)
-            reason = STATUS_PHRASES[400]
-            headers = [
-                (b"content-type", b"text/plain; charset=utf-8"),
-                (b"connection", b"close"),
-            ]
-            event = h11.Response(status_code=400, headers=headers, reason=reason)
-            output = self.conn.send(event)
-            self.transport.write(output)
-            event = h11.Data(data=b'Unsupported upgrade request.')
-            output = self.conn.send(event)
-            self.transport.write(output)
-            event = h11.EndOfMessage()
-            output = self.conn.send(event)
-            self.transport.write(output)
-            self.transport.close()
+            self.send_400_response(msg)
             return
 
         self.connections.discard(self)
@@ -300,6 +286,23 @@ class H11Protocol(asyncio.Protocol):
         protocol.connection_made(self.transport)
         protocol.data_received(b''.join(output))
         self.transport.set_protocol(protocol)
+
+    def send_400_response(self, msg):
+        reason = STATUS_PHRASES[400]
+        headers = [
+            (b"content-type", b"text/plain; charset=utf-8"),
+            (b"connection", b"close"),
+        ]
+        event = h11.Response(status_code=400, headers=headers, reason=reason)
+        output = self.conn.send(event)
+        self.transport.write(output)
+        event = h11.Data(data=bytes(msg, 'utf-8'))
+        output = self.conn.send(event)
+        self.transport.write(output)
+        event = h11.EndOfMessage()
+        output = self.conn.send(event)
+        self.transport.write(output)
+        self.transport.close()
 
     def on_response_complete(self):
         self.state["total_requests"] += 1


### PR DESCRIPTION
Given an invalid request, respond with an HTTP 400 error instead of closing the connection without a response.

Before this change, a request with invalid characters would result in the HTTP connection being dropped, as in this example:

```
$ curl -i -X GET 'http://localhost:8000/example?coordinates=76.916664, 8.483333'
curl: (52) Empty reply from server
```

Such a request should result in an HTTP 400 (Bad Request).

With a reverse-proxied application, this would typically be presented to the user as a 502 (Bad Gateway) error.