### PR TITLE
Add debug-level logging

### DIFF
--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -1,0 +1,46 @@
+from tests.client import TestClient
+from uvicorn.middleware.message_logger import MessageLoggerMiddleware
+import pytest
+import logging
+
+
+def test_message_logger(caplog):
+    def app(scope):
+        async def asgi(receive, send):
+            message = await receive()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+        return asgi
+
+    caplog.set_level(logging.DEBUG)
+    app = MessageLoggerMiddleware(app)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    messages = [record.msg % record.args for record in caplog.records]
+    assert sum(['ASGI [1] Started' in message for message in messages]) == 1
+    assert sum(['ASGI [1] Sent' in message for message in messages]) == 1
+    assert sum(['ASGI [1] Received' in message for message in messages]) == 2
+    assert sum(['ASGI [1] Completed' in message for message in messages]) == 1
+    assert sum(['ASGI [1] Raised exception' in message for message in messages]) == 0
+
+
+def test_message_logger_exc(caplog):
+    def app(scope):
+        async def asgi(receive, send):
+            raise RuntimeError()
+
+        return asgi
+
+    caplog.set_level(logging.DEBUG)
+    app = MessageLoggerMiddleware(app)
+    client = TestClient(app)
+    with pytest.raises(RuntimeError):
+        client.get("/")
+    messages = [record.msg % record.args for record in caplog.records]
+    assert sum(['ASGI [1] Started' in message for message in messages]) == 1
+    assert sum(['ASGI [1] Sent' in message for message in messages]) == 0
+    assert sum(['ASGI [1] Received' in message for message in messages]) == 0
+    assert sum(['ASGI [1] Completed' in message for message in messages]) == 0
+    assert sum(['ASGI [1] Raised exception' in message for message in messages]) == 1

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,6 +1,7 @@
 from uvicorn.importer import import_from_string, ImportFromStringError
 from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.reloaders.statreload import StatReload
 import asyncio
@@ -241,6 +242,8 @@ def run(
         ws_protocol_class = None
     if debug:
         app = DebugMiddleware(app)
+    if logger.level <= logging.DEBUG:
+        app = MessageLoggerMiddleware(app)
     if proxy_headers:
         app = ProxyHeadersMiddleware(app)
 

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -1,0 +1,72 @@
+import logging
+
+PLACEHOLDER_FORMAT = {
+    'body': '<{length} bytes>',
+    'bytes': '<{length} bytes>',
+    'text': '<{length} chars>',
+    'headers': '<...>',
+}
+
+
+def message_with_placeholders(message):
+    """
+    Return an ASGI message, with any body-type content omitted and replaced
+    with a placeholder.
+    """
+    new_message = message.copy()
+    for attr in PLACEHOLDER_FORMAT.keys():
+        if attr in message:
+            content = message[attr]
+            placeholder = PLACEHOLDER_FORMAT[attr].format(length=len(content))
+            new_message[attr] = placeholder
+    return new_message
+
+
+class MessageLoggerMiddleware:
+    def __init__(self, app):
+        self.task_counter = 0
+        self.app = app
+        self.logger = logging.getLogger("uvicorn")
+
+    def __call__(self, scope):
+        self.task_counter += 1
+        return MessageLoggerResponder(scope, self.app, self.logger, self.task_counter)
+
+
+class MessageLoggerResponder:
+    def __init__(self, scope, app, logger, task_counter):
+        self.scope = scope
+        self.app = app
+        self.logger = logger
+        self.task_counter = task_counter
+        self.client_addr = scope['client'][0]
+
+    async def __call__(self, receive, send):
+        self._receive = receive
+        self._send = send
+        logged_scope = message_with_placeholders(self.scope)
+        log_text = '%s - ASGI [%d] Started %s'
+        self.logger.debug(log_text, self.client_addr, self.task_counter, logged_scope)
+        try:
+            inner = self.app(self.scope)
+            await inner(self.receive, self.send)
+        except:
+            log_text = '%s - ASGI [%d] Raised exception'
+            self.logger.debug(texlog_text, self.client_addr, self.task_counter)
+            raise
+        else:
+            log_text = '%s - ASGI [%d] Completed'
+            self.logger.debug(log_text, self.client_addr, self.task_counter)
+
+    async def receive(self):
+        message = await self._receive()
+        logged_message = message_with_placeholders(message)
+        log_text = '%s - ASGI [%d] Sent %s'
+        self.logger.debug(log_text, self.client_addr, self.task_counter, logged_message)
+        return message
+
+    async def send(self, message):
+        logged_message = message_with_placeholders(message)
+        log_text = '%s - ASGI [%d] Received %s'
+        self.logger.debug(log_text, self.client_addr, self.task_counter, logged_message)
+        await self._send(message)

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -52,7 +52,7 @@ class MessageLoggerResponder:
             await inner(self.receive, self.send)
         except:
             log_text = '%s - ASGI [%d] Raised exception'
-            self.logger.debug(texlog_text, self.client_addr, self.task_counter)
+            self.logger.debug(log_text, self.client_addr, self.task_counter)
             raise
         else:
             log_text = '%s - ASGI [%d] Completed'

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -141,13 +141,13 @@ class H11Protocol(asyncio.Protocol):
         self.scheme = "https" if transport.get_extra_info("sslcontext") else "http"
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Connected", self.server[0])
+            self.logger.debug("%s - Connected", self.client[0])
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Disconnected", self.server[0])
+            self.logger.debug("%s - Disconnected", self.client[0])
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True
@@ -460,7 +460,7 @@ class RequestResponseCycle:
             if self.access_log:
                 self.logger.info(
                     '%s - "%s %s HTTP/%s" %d',
-                    self.scope["server"][0],
+                    self.scope["client"][0],
                     self.scope["method"],
                     self.scope["path"],
                     self.scope["http_version"],

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -145,13 +145,13 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.scheme = "https" if transport.get_extra_info("sslcontext") else "http"
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Connected", self.server[0])
+            self.logger.debug("%s - Connected", self.client[0])
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Disconnected", self.server[0])
+            self.logger.debug("%s - Disconnected", self.client[0])
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True
@@ -448,7 +448,7 @@ class RequestResponseCycle:
             if self.access_log:
                 self.logger.info(
                     '%s - "%s %s HTTP/%s" %d',
-                    self.scope["server"][0],
+                    self.scope["client"][0],
                     self.scope["method"],
                     self.scope["path"],
                     self.scope["http_version"],


### PR DESCRIPTION
Closes #91

Adds extensive debug-level logging, which tracks all ASGI messages, and the ASGI lifetime.

```shell
$ uvicorn example:App --log-level debug
INFO: Started server process [21757]
INFO: Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
DEBUG: 127.0.0.1 - Connected
DEBUG: 127.0.0.1 - ASGI [1] Started {'type': 'http', 'http_version': '1.1', 'server': ('127.0.0.1', 8000), 'client': ('127.0.0.1', 58339), 'scheme': 'http', 'method': 'GET', 'root_path': '', 'path': '/', 'query_string': b'', 'headers': '<...>'}
DEBUG: 127.0.0.1 - ASGI [1] Received {'type': 'http.response.start', 'status': 200, 'headers': '<...>'}
INFO: 127.0.0.1 - "GET / HTTP/1.1" 200
DEBUG: 127.0.0.1 - ASGI [1] Received {'type': 'http.response.body', 'body': '<13 bytes>'}
DEBUG: 127.0.0.1 - ASGI [1] Completed
DEBUG: 127.0.0.1 - Disconnected
```

Includes a unique ASGI task counter so that all messages can be properly referenced against a single lifetime.

Complexity is kept out of the server implementations by including this as optional middleware, that is added in if the log level <= DEBUG