### PR TITLE
Fix log error on uds

### DIFF
--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -39,7 +39,7 @@ class MessageLoggerResponder:
         self.app = app
         self.logger = logger
         self.task_counter = task_counter
-        self.client_addr = scope['client'][0]
+        self.client_addr = scope['client']
 
     async def __call__(self, receive, send):
         self._receive = receive

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -118,7 +118,6 @@ class H11Protocol(asyncio.Protocol):
         self.server = None
         self.client = None
         self.scheme = None
-        self.connection_id = None
 
         # Per-request state
         self.scope = None
@@ -131,20 +130,6 @@ class H11Protocol(asyncio.Protocol):
         global DEFAULT_HEADERS
         DEFAULT_HEADERS = _get_default_headers()
 
-    def get_connection_id(self):
-        if self.client:
-            if isinstance(self.client, str):
-                connection_id = self.client
-            else:
-                connection_id = self.client[0]
-        else:
-            if isinstance(self.server, str):
-                connection_id = self.server
-            else:
-                connection_id = self.server[0]
-
-        return connection_id
-
     # Protocol interface
     def connection_made(self, transport):
         self.connections.add(self)
@@ -154,16 +139,15 @@ class H11Protocol(asyncio.Protocol):
         self.server = transport.get_extra_info("sockname")
         self.client = transport.get_extra_info("peername")
         self.scheme = "https" if transport.get_extra_info("sslcontext") else "http"
-        self.connection_id = self.get_connection_id()
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Connected", self.connection_id)
+            self.logger.debug("%s - Connected", self.client)
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Disconnected", self.connection_id)
+            self.logger.debug("%s - Disconnected", self.client)
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True
@@ -474,7 +458,7 @@ class RequestResponseCycle:
             if self.access_log:
                 self.logger.info(
                     '%s - "%s %s HTTP/%s" %d',
-                    self.scope["client"][0],
+                    self.scope["client"],
                     self.scope["method"],
                     self.scope["path"],
                     self.scope["http_version"],

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -119,6 +119,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.server = None
         self.client = None
         self.scheme = None
+        self.connection_id = None
         self.pipeline = []
 
         # Per-request state
@@ -134,6 +135,20 @@ class HttpToolsProtocol(asyncio.Protocol):
         global DEFAULT_HEADERS
         DEFAULT_HEADERS = _get_default_headers()
 
+    def get_connection_id(self):
+        if self.client:
+            if isinstance(self.client, str):
+                connection_id = self.client
+            else:
+                connection_id = self.client[0]
+        else:
+            if isinstance(self.server, str):
+                connection_id = self.server
+            else:
+                connection_id = self.server[0]
+
+        return connection_id
+
     # Protocol interface
     def connection_made(self, transport):
         self.connections.add(self)
@@ -143,15 +158,16 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.server = transport.get_extra_info("sockname")
         self.client = transport.get_extra_info("peername")
         self.scheme = "https" if transport.get_extra_info("sslcontext") else "http"
+        self.connection_id = self.get_connection_id()
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Connected", self.client[0])
+            self.logger.debug("%s - Connected", self.connection_id)
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
         if self.logger.level <= logging.DEBUG:
-            self.logger.debug("%s - Disconnected", self.client[0])
+            self.logger.debug("%s - Disconnected", self.connection_id)
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True


### PR DESCRIPTION
 Currently uvicorn 0.3.8 crashes while logging when run with a unix domain socket so it is unusable. Unix domain sockets return a peername of `""` and the sockname is also a string. [Docs](https://docs.python.org/3/library/socket.html#socket-families)

```
server_1         | ERROR: Exception in callback UVTransport._call_connection_lost
server_1         | handle: <Handle UVTransport._call_connection_lost>
server_1         | Traceback (most recent call last):
server_1         |   File "uvloop/cbhandles.pyx", line 72, in uvloop.loop.Handle._run
server_1         |   File "uvloop/handles/basetransport.pyx", line 181, in uvloop.loop.UVBaseTransport._call_connection_lost
server_1         |   File "/venv/lib/python3.7/site-packages/uvicorn/protocols/http/httptools_impl.py", line 163, in connection_lost
server_1         |     self.logger.debug("%s - Disconnected", self.connection_id)
server_1         |   File "/venv/lib/python3.7/site-packages/uvicorn/protocols/http/httptools_impl.py", line 140, in connection_id
server_1         |     return self.client[0]
server_1         | IndexError: string index out of range
```