### PR TITLE
Use environment markers in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,26 +34,13 @@ def get_packages(package):
             if os.path.exists(os.path.join(dirpath, '__init__.py'))]
 
 
-if platform.python_implementation() == 'PyPy':
-    requirements = [
-        'click',
-        'h11',
-        'websockets>=6.0'
-    ]
-elif platform.system() == 'Windows' or platform.system().startswith('CYGWIN'):
-    requirements = [
-        'click',
-        'h11',
-        'websockets>=6.0'
-    ]
-else:
-    requirements = [
-        'click',
-        'h11',
-        'httptools',
-        'uvloop',
-        'websockets>=6.0'
-    ]
+requirements = [
+    'h11',
+    'click',
+    'websockets>=6.0',
+    'uvloop; os_name == "posix"; platform_python_implementation == "CPython"',
+    'httptools; os_name == "posix"; platform_python_implementation == "CPython"'
+]
 
 
 setup(


### PR DESCRIPTION
Use environment markers in `setup.py` rather than explicitly switching requirements.  #135

uvloop: https://github.com/MagicStack/uvloop/blob/8d5a9a3a4a5a74b1caad12423305b23049c00ab9/setup.py#L241

httptools: https://github.com/MagicStack/httptools/blob/14043bd7cb46fb879aaa1072dccf9a3817afaf32/setup.py#L22