### PR TITLE
WIP: Implement h2 protocol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click
 h11
 
 # Optional
+h2
 httptools
 uvloop
 websockets>=6.0

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -340,13 +340,13 @@ def run(
             cert_reqs=cert_reqs,
             ca_certs=ca_certs,
             ciphers=ciphers,
-            enable_h2=getattr(http_protocol_class, "http2"),
+            enable_h2=getattr(http_protocol_class, "http2", False),
         )
     else:
         sslctx = None
 
     def create_protocol():
-        return http_protocol_class(
+        protocol = http_protocol_class(
             app=app,
             loop=loop,
             logger=logger,
@@ -359,6 +359,9 @@ def run(
             limit_concurrency=limit_concurrency,
             timeout_keep_alive=timeout_keep_alive,
         )
+        if not (keyfile and certfile):
+            protocol.h2_protocol_class = import_from_string(HTTP_PROTOCOLS["h2"])
+        return protocol
 
     server = Server(
         app=app,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -7,6 +7,7 @@ from uvicorn.reloaders.statreload import StatReload
 import asyncio
 import click
 import signal
+import ssl
 import os
 import logging
 import socket
@@ -145,6 +146,36 @@ def get_logger(log_level):
     help="Close Keep-Alive connections if no new data is received within this timeout.",
     show_default=True,
 )
+@click.option(
+    "--keyfile", type=str, default=None, help="SSL key file", show_default=True
+)
+@click.option(
+    "--certfile", type=str, default=None, help="SSL certificate file", show_default=True
+)
+@click.option(
+    "--ssl-version",
+    type=int,
+    default=ssl.PROTOCOL_TLS,
+    help="SSL version to use (see stdlib ssl module's)",
+    show_default=True,
+)
+@click.option(
+    "--cert-reqs",
+    type=int,
+    default=ssl.CERT_NONE,
+    help="Whether client certificate is required (see stdlib ssl module's)",
+    show_default=True,
+)
+@click.option(
+    "--ca-certs", type=str, default=None, help="CA certificates file", show_default=True
+)
+@click.option(
+    "--ciphers",
+    type=str,
+    default="TLSv1",
+    help="Ciphers to use (see stdlib ssl module's)",
+    show_default=True,
+)
 def main(
     app,
     host: str,
@@ -163,6 +194,12 @@ def main(
     limit_concurrency: int,
     limit_max_requests: int,
     timeout_keep_alive: int,
+    keyfile: str,
+    certfile: str,
+    ssl_version: int,
+    cert_reqs: int,
+    ca_certs: str,
+    ciphers: str,
 ):
     sys.path.insert(0, ".")
 
@@ -184,6 +221,12 @@ def main(
         "limit_concurrency": limit_concurrency,
         "limit_max_requests": limit_max_requests,
         "timeout_keep_alive": timeout_keep_alive,
+        "keyfile": keyfile,
+        "certfile": certfile,
+        "ssl_version": ssl_version,
+        "cert_reqs": cert_reqs,
+        "ca_certs": ca_certs,
+        "ciphers": ciphers,
     }
 
     if debug:
@@ -192,6 +235,17 @@ def main(
         reloader.run(run, kwargs)
     else:
         run(**kwargs)
+
+
+def create_ssl_context(certfile, keyfile, ssl_version, cert_reqs, ca_certs, ciphers):
+    ctx = ssl.SSLContext(ssl_version)
+    ctx.load_cert_chain(certfile, keyfile)
+    ctx.verify_mode = cert_reqs
+    if ca_certs:
+        ctx.load_verify_locations(ca_certs)
+    if ciphers:
+        ctx.set_ciphers(ciphers)
+    return ctx
 
 
 def run(
@@ -214,6 +268,12 @@ def run(
     timeout_keep_alive=5,
     install_signal_handlers=True,
     ready_event=None,
+    keyfile=None,
+    certfile=None,
+    ssl_version=None,
+    cert_reqs=False,
+    ca_certs=None,
+    ciphers=None,
 ):
 
     if fd is None:
@@ -250,6 +310,17 @@ def run(
     connections = set()
     tasks = set()
     state = {"total_requests": 0}
+    if keyfile or certfile:
+        sslctx = create_ssl_context(
+            keyfile=keyfile,
+            certfile=certfile,
+            ssl_version=ssl_version,
+            cert_reqs=cert_reqs,
+            ca_certs=ca_certs,
+            ciphers=ciphers,
+        )
+    else:
+        sslctx = None
 
     def create_protocol():
         return http_protocol_class(
@@ -282,6 +353,7 @@ def run(
         on_tick=http_protocol_class.tick,
         install_signal_handlers=install_signal_handlers,
         ready_event=ready_event,
+        ssl=sslctx,
     )
     server.run()
 
@@ -304,6 +376,7 @@ class Server:
         on_tick,
         install_signal_handlers,
         ready_event,
+        ssl,
     ):
         self.app = app
         self.host = host
@@ -322,6 +395,7 @@ class Server:
         self.ready_event = ready_event
         self.should_exit = False
         self.pid = os.getpid()
+        self.ssl = ssl
 
     def set_signal_handlers(self):
         if not self.install_signal_handlers:
@@ -351,7 +425,7 @@ class Server:
         if self.sock is not None:
             # Use an existing socket.
             self.server = await self.loop.create_server(
-                self.create_protocol, sock=self.sock
+                self.create_protocol, sock=self.sock, ssl=self.ssl
             )
             message = "Uvicorn running on socket %s (Press CTRL+C to quit)"
             self.logger.info(message % str(self.sock.getsockname()))
@@ -359,7 +433,7 @@ class Server:
         elif self.uds is not None:
             # Create a socket using UNIX domain socket.
             self.server = await self.loop.create_unix_server(
-                self.create_protocol, path=self.uds
+                self.create_protocol, path=self.uds, ssl=self.ssl
             )
             message = "Uvicorn running on unix socket %s (Press CTRL+C to quit)"
             self.logger.info(message % self.uds)
@@ -367,7 +441,7 @@ class Server:
         else:
             # Standard case. Create a socket from a host/port pair.
             self.server = await self.loop.create_server(
-                self.create_protocol, host=self.host, port=self.port
+                self.create_protocol, host=self.host, port=self.port, ssl=self.ssl
             )
             message = "Uvicorn running on http://%s:%d (Press CTRL+C to quit)"
             self.logger.info(message % (self.host, self.port))

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -173,7 +173,7 @@ def get_logger(log_level):
 @click.option(
     "--ciphers",
     type=str,
-    default="TLSv1",
+    default="TLSv1.2",
     help="Ciphers to use (see stdlib ssl module's)",
     show_default=True,
 )
@@ -255,6 +255,7 @@ def create_ssl_context(
             | ssl.OP_NO_TLSv1
             | ssl.OP_NO_TLSv1_1
             | ssl.OP_NO_COMPRESSION
+            | ssl.OP_CIPHER_SERVER_PREFERENCE
         )
         for cipher in ctx.get_ciphers():
             if cipher["protocol"] in ["TLSv1.2", "TLSv1.3"]:

--- a/uvicorn/protocols/http/h2_impl.py
+++ b/uvicorn/protocols/http/h2_impl.py
@@ -1,0 +1,572 @@
+import h2.connection
+import h2.errors
+import h2.events
+import h2.exceptions
+import io
+import http
+import time
+import asyncio
+import logging
+import collections
+from urllib.parse import unquote
+from email.utils import formatdate
+
+_StreamRequest = collections.namedtuple("_StreamRequest", ("headers", "scope", "cycle"))
+
+
+def _get_default_headers():
+    current_time = time.time()
+    current_date = formatdate(current_time, usegmt=True).encode()
+    return (("server", "uvicorn"), ("date", current_date))
+
+
+def _get_status_phrase(status_code):
+    try:
+        return http.HTTPStatus(status_code).phrase.encode()
+    except ValueError as exc:
+        return b""
+
+
+DEFAULT_HEADERS = _get_default_headers()
+
+HIGH_WATER_LIMIT = 65536
+
+
+class FlowControl:
+    def __init__(self, transport):
+        self._transport = transport
+        self.read_paused = False
+        self.write_paused = False
+        self._is_writable_event = asyncio.Event()
+        self._is_writable_event.set()
+
+    async def drain(self):
+        await self._is_writable_event.wait()
+
+    def pause_reading(self):
+        if not self.read_paused:
+            self.read_paused = True
+            self._transport.pause_reading()
+
+    def resume_reading(self):
+        if self.read_paused:
+            self.read_paused = False
+            self._transport.resume_reading()
+
+    def pause_writing(self):
+        if not self.write_paused:
+            self.write_paused = True
+            self._is_writable_event.clear()
+
+    def resume_writing(self):
+        if self.write_paused:
+            self.write_paused = False
+            self._is_writable_event.set()
+
+
+class ServiceUnavailable:
+    def __init__(self, scope):
+        pass
+
+    async def __call__(self, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"connection", b"close"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b"Service Unavailable"})
+
+
+class H2Protocol(asyncio.Protocol):
+    http2 = True
+
+    def __init__(
+        self,
+        app,
+        loop=None,
+        connections=None,
+        tasks=None,
+        state=None,
+        logger=None,
+        access_log=None,
+        ws_protocol_class=None,
+        root_path="",
+        limit_concurrency=None,
+        timeout_keep_alive=5,
+    ):
+        self.app = app
+        self.loop = loop or asyncio.get_event_loop()
+        self.connections = set() if connections is None else connections
+        self.tasks = set() if tasks is None else tasks
+        self.state = {"total_requests": 0} if state is None else state
+        self.logger = logger or logging.getLogger("uvicorn")
+        self.access_log = access_log and (self.logger.level <= logging.INFO)
+        self.conn = h2.connection.H2Connection(
+            config=h2.config.H2Configuration(client_side=False, header_encoding=None)
+        )
+        self.ws_protocol_class = ws_protocol_class
+        self.root_path = root_path
+        self.limit_concurrency = limit_concurrency
+
+        # Timeouts
+        self.timeout_keep_alive_task = None
+        self.timeout_keep_alive = timeout_keep_alive
+
+        # Per-connection state
+        self.transport = None
+        self.flow = None
+        self.server = None
+        self.client = None
+        self.scheme = None
+
+        # Per-request state
+        self.scope = None
+        self.headers = None
+        self.streams = {}
+        self.message_event = asyncio.Event()
+
+    @classmethod
+    def tick(cls):
+        global DEFAULT_HEADERS
+        DEFAULT_HEADERS = _get_default_headers()
+
+    def connection_made(self, transport: asyncio.Transport):
+        self.transport = transport
+        self.flow = FlowControl(transport)
+        self.server = transport.get_extra_info("sockname")
+        self.client = transport.get_extra_info("peername")
+        self.scheme = "https" if transport.get_extra_info("sslcontext") else "http"
+
+        self.logger.debug("connection made, tranport %s", dir(transport))
+        self.conn.initiate_connection()
+        self.transport.write(self.conn.data_to_send())
+        self.logger.debug("%s - Connected", self.client[0])
+
+    def connection_lost(self, exc):
+        self.logger.debug("%s - Disconnected", self.client[0])
+
+        for stream_id, stream in self.streams.items():
+            if stream.cycle and not stream.cycle.response_complete:
+                stream.cycle.disconnected = True
+
+        # TODO: send close
+
+        self.logger.debug("Disconnected, current streams: %s", self.streams)
+        self.logger.debug("Exc", exc_info=exc)
+        self.streams = {}
+        self.message_event.set()
+
+    def eof_received(self):
+        self.streams = {}
+        self.logger.debug("eof received, current streams: %s", self.streams)
+
+    def data_received(self, data):
+        if self.timeout_keep_alive_task is not None:
+            self.timeout_keep_alive_task.cancel()
+            self.timeout_keep_alive_task = None
+
+        try:
+            events = self.conn.receive_data(data)
+        except h2.exceptions.ProtocolError:
+            self.transport.write(self.conn.data_to_send())
+            self.transport.close()
+        else:
+            self.transport.write(self.conn.data_to_send())
+            for event in events:
+                if isinstance(event, h2.events.RequestReceived):
+                    self.on_request_received(event)
+                elif isinstance(event, h2.events.DataReceived):
+                    self.on_data_received(event)
+                elif isinstance(event, h2.events.StreamEnded):
+                    self.on_stream_ended(event)
+                elif isinstance(event, h2.events.ConnectionTerminated):
+                    self.on_connection_terminated(event)
+                else:
+                    self.logger.debug("Unhandled event %s.", event)
+
+                self.transport.write(self.conn.data_to_send())
+
+    def on_request_received(self, event):
+        self.headers = []
+        self.scope = dict(
+            headers=self.headers,
+            http_version="2",
+            server=self.server,
+            client=self.client,
+            root_path=self.root_path,
+            type="http",
+            extensions={"http.response.push": {}},
+        )
+        scope_mapping = {
+            b":scheme": "scheme",
+            b":authority": "authority",
+            b":method": "method",
+            b":path": "path",
+        }
+        stream_id = event.stream_id
+        for key, value in event.headers:
+            if key in scope_mapping:
+                self.scope[scope_mapping[key]] = value.decode("ascii")
+            else:
+                lower_key = key.lower()
+                if lower_key == "connection":
+                    tokens = [
+                        token.lower().strip().decode("ascii")
+                        for token in value.split(b",")
+                    ]
+                    if "upgrade" in tokens:
+                        self.handle_upgrade(event)
+                        return
+                self.scope["headers"].append((lower_key, value))
+
+        path, _, query_string = self.scope["path"].partition("?")
+        self.scope["path"], self.scope["query_string"] = (
+            unquote(path),
+            query_string.encode("ascii"),
+        )
+
+        self.logger.debug("Request received, current scope %s", self.scope)
+        self.logger.debug("Request received, current headers %s", self.scope["headers"])
+
+        cycle = RequestResponseCycle(
+            scope=self.scope,
+            conn=self.conn,
+            transport=self.transport,
+            flow=self.flow,
+            stream_id=stream_id,
+            logger=self.logger,
+            access_log=self.access_log,
+            message_event=self.message_event,
+            on_response=self.on_response_complete,
+            on_request=self.on_request_received,
+        )
+        self.streams[stream_id] = _StreamRequest(
+            headers=self.scope["headers"], scope=self.scope, cycle=cycle
+        )
+        self.logger.debug(
+            "On request received, current %s, streams: %s", stream_id, self.streams
+        )
+
+        # Handle 503 responses when 'limit_concurrency' is exceeded.
+        if self.limit_concurrency is not None and (
+            len(self.connections) >= self.limit_concurrency
+            or len(self.tasks) >= self.limit_concurrency
+        ):
+            message = "Exceeded concurrency limit."
+            self.logger.warning(message)
+            app = ServiceUnavailable
+        else:
+            app = self.app
+
+        def cleanup(task):
+            self.streams.pop(stream_id)
+
+        task = self.loop.create_task(self.streams[stream_id].cycle.run_asgi(app))
+        task.add_done_callback(self.tasks.discard)
+        # task.add_done_callback(cleanup)
+        task.add_done_callback(
+            lambda t: self.logger.debug(
+                "task done StreamID(%s), path %s", stream_id, self.scope["path"]
+            )
+        )
+        self.tasks.add(task)
+
+    def on_data_received(self, event):
+        stream_id = event.stream_id
+        self.logger.debug(
+            "On data received, current %s, streams: %s", stream_id, self.streams
+        )
+        try:
+            self.streams[stream_id].cycle.body += event.data
+        except KeyError:
+            self.conn.reset_stream(
+                stream_id, error_code=h2.errors.ErrorCodes.PROTOCOL_ERROR
+            )
+        else:
+            body_size = self.streams[stream_id].body.getbuffer().nbytes
+            if body_size > HIGH_WATER_LIMIT:
+                self.flow.pause_reading()
+            self.message_event.set()
+
+    def on_stream_ended(self, event):
+        stream_id = event.stream_id
+        self.logger.debug(
+            "On stream ended, current %s, streams: %s", stream_id, self.streams
+        )
+        try:
+            stream = self.streams[stream_id]
+        except KeyError:
+            # TODO: error code
+            self.conn.reset_stream(
+                stream_id, error_code=h2.errors.ErrorCodes.PROTOCOL_ERROR
+            )
+        else:
+            self.transport.resume_reading()
+            stream.cycle.more_body = False
+            self.message_event.set()
+
+    def on_connection_terminated(self, event):
+        stream_id = event.stream_id
+        self.logger.debug(
+            "On connection terminated, current %s, streams: %s", stream_id, self.streams
+        )
+        self.streams.pop(stream_id).cycle.disconnected = True
+        self.conn.close_cconnection(last_stream_id=stream_id)
+        self.transport.write(self.conn.data_to_send())
+        self.transport.close()
+
+    def handle_upgrade(self, event):
+        upgrade_value = None
+
+    def shutdown(self):
+        self.logger.debug("Shutdown. streams: %s, tasks: %s", self.streams, self.tasks)
+        if self.streams:
+            for stream_id, stream in self.streams.items():
+                if stream.cycle.response_complete:
+                    self.conn.close_cconnection(last_stream_id=stream_id)
+                    self.transport.write(self.conn.data_to_send())
+                else:
+                    stream.cycle.keep_alive = False
+            self.streams = {}
+
+    def pause_writing(self):
+        """
+        Called by the transport when the write buffer exceeds the high water mark.
+        """
+        self.flow.pause_writing()
+
+    def resume_writing(self):
+        """
+        Called by the transport when the write buffer drops below the low water mark.
+        """
+        self.flow.resume_writing()
+
+    def timeout_keep_alive_handler(self):
+        """
+        Called on a keep-alive connection if no new data is received after a short delay.
+        """
+        if not self.transport.is_closing():
+            for stream_id, stream in self.streams.items():
+                self.conn.close_connection(last_stream_id=stream_id)
+                self.transport.write(self.conn.data_to_send())
+            self.transport.close()
+
+    def on_response_complete(self):
+        self.state["total_requests"] += 1
+
+        if self.transport.is_closing():
+            return
+
+        # Set a short Keep-Alive timeout.
+        self.timeout_keep_alive_task = self.loop.call_later(
+            self.timeout_keep_alive, self.timeout_keep_alive_handler
+        )
+
+        # Unpause data reads if needed.
+        self.flow.resume_reading()
+
+
+class RequestResponseCycle:
+    def __init__(
+        self,
+        scope,
+        conn,
+        transport,
+        flow,
+        logger,
+        access_log,
+        stream_id,
+        message_event,
+        on_response,
+        on_request,
+    ):
+        self.scope = scope
+        self.conn = conn
+        self.transport = transport
+        self.flow = flow
+        self.logger = logger
+        self.access_log = access_log
+        self.message_event = message_event
+        self.on_response = on_response
+        self.on_request = on_request
+        self.stream_id = stream_id
+
+        # Connection state
+        self.disconnected = False
+        self.keep_alive = True
+
+        # Request state
+        self.body = b""
+        self.more_body = True
+
+        # Response state
+        self.response_started = False
+        self.response_complete = False
+
+    # ASGI exception wrapper
+    async def run_asgi(self, app):
+        try:
+            asgi = app(self.scope)
+            result = await asgi(self.receive, self.send)
+        except:
+            msg = "Exception in ASGI application"
+            self.logger.error(msg, exc_info=True)
+            if not self.response_started:
+                await self.send_500_response()
+            else:
+                self.transport.close()
+        else:
+            if result is not None:
+                msg = "ASGI callable should return None, but returned '%s'."
+                self.logger.error(msg, result)
+                self.transport.close()
+            elif not self.response_started and not self.disconnected:
+                msg = "ASGI callable returned without starting response."
+                self.logger.error(msg)
+                await self.send_500_response()
+            elif not self.response_complete and not self.disconnected:
+                msg = "ASGI callable returned without completing response."
+                self.logger.error(msg)
+                self.transport.close()
+        finally:
+            self.on_response = None
+
+    async def send_500_response(self):
+        await self.send(
+            {
+                "type": "http.response.start",
+                "status": 500,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"connection", b"close"),
+                ],
+            }
+        )
+        await self.send(
+            {"type": "http.response.body", "body": b"Internal Server Error"}
+        )
+
+    # ASGI interface
+    async def send(self, message):
+        global DEFAULT_HEADERS
+
+        message_type = message["type"]
+
+        if self.disconnected:
+            return
+
+        if self.flow.write_paused:
+            await self.flow.drain()
+
+        if not self.response_started:
+            # Sending response status line and headers
+            if message_type != "http.response.start":
+                msg = "Expected ASGI message 'http.response.start', but got '%s'."
+                raise RuntimeError(msg % message_type)
+
+            self.response_started = True
+
+            status_code = message["status"]
+            headers = (*DEFAULT_HEADERS, *message.get("headers", ()))
+
+            if self.access_log:
+                self.logger.info(
+                    '%s - "%s %s HTTP/%s" %d',
+                    self.scope["client"][0],
+                    self.scope["method"],
+                    self.scope["path"],
+                    self.scope["http_version"],
+                    status_code,
+                )
+
+            # Write response status line and headers
+            headers = ((":status", str(status_code)), *headers)
+            self.logger.debug("response start, message %s", message)
+            self.conn.send_headers(self.stream_id, headers, end_stream=False)
+            self.transport.write(self.conn.data_to_send())
+
+        elif not self.response_complete:
+            # Sending response body
+            if message_type == "http.response.body":
+
+                more_body = message.get("more_body", False)
+
+                # Write response body
+                if self.scope["method"] == "HEAD":
+                    body = b""
+                else:
+                    body = message.get("body", b"")
+                self.conn.send_data(self.stream_id, body, end_stream=(not more_body))
+                self.transport.write(self.conn.data_to_send())
+
+                # Handle response completion
+                if not more_body:
+                    self.response_complete = True
+            elif message_type == "http.response.push":
+                push_stream_id = self.conn.get_next_available_stream_id()
+                self.logger.debug("headers in scope %s", self.scope["headers"])
+                request_headers = [
+                    (ensure_bytes(name), ensure_bytes(value))
+                    for name, value in (
+                        (b":method", b"GET"),
+                        (b":path", message["path"]),
+                        (b":scheme", self.scope["scheme"]),
+                        (b":authority", self.scope["authority"]),
+                        *message["headers"],
+                    )
+                ]
+                try:
+                    self.conn.push_stream(
+                        stream_id=self.stream_id,
+                        promised_stream_id=push_stream_id,
+                        request_headers=request_headers,
+                    )
+                except h2.exceptions.ProtocolError:
+                    self.logger.debug("h2 protocol error.", exc_info=True)
+                else:
+                    event = h2.events.RequestReceived()
+                    event.stream_id = push_stream_id
+                    event.headers = request_headers
+                    self.on_request(event)
+                    self.transport.write(self.conn.data_to_send())
+            else:
+                msg = "Expected ASGI message 'http.response.body', but got '%s'."
+                raise RuntimeError(msg % message_type)
+
+        else:
+            # Response already sent
+            msg = "Unexpected ASGI message '%s' sent, after response already completed."
+            raise RuntimeError(msg % message_type)
+
+        if self.response_complete:
+            self.on_response()
+
+    async def receive(self):
+        self.flow.resume_reading()
+        await self.message_event.wait()
+        self.message_event.clear()
+
+        if self.disconnected or self.response_complete:
+            message = {"type": "http.disconnect"}
+        else:
+            message = {
+                "type": "http.request",
+                "body": self.body,
+                "more_body": self.more_body,
+            }
+            self.body = b""
+
+        return message
+
+
+def ensure_bytes(bytes_or_str):
+    if isinstance(bytes_or_str, bytes):
+        return bytes_or_str
+    if isinstance(bytes_or_str, str):
+        return bytes_or_str.encode("ascii")
+    return bytes(bytes_or_str)


### PR DESCRIPTION
#47 

Something to be fixed:
1. Too much code is duplicated with H11's implementation.
2. `ssl.SSLError: [SSL: KRB5_S_INIT] application data after close notify`. This error occurred with hypercorn too.
3. `connection: upgrade` support. to websocket and h11 to h2(https auto upgrade to h2 is supported).
4. logger
5. tests

It works.