### PR TITLE
Return `server` instance from run

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -285,6 +285,7 @@ def run(
         ready_event=ready_event,
     )
     server.run()
+    return server
 
 
 class Server:


### PR DESCRIPTION
In some cases a application needs to be able to shutdown the server on command from a outside signal or coordinate the shutdown process.

In this case I also need to shutdown Kafka consumer. By allowing the application to get the server instance it can register its own signal handlers and shutdown everything in the correct order.