### PR TITLE
Fixes bug #242, Exception in ASGI application 

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -88,7 +88,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
         self.scope = {
             'type': 'websocket',
             'scheme': self.scheme,
-            'server': self.server,
+            'server': self.server or ('unknown', 0),
             'client': self.client,
             'root_path': self.root_path,
             'path': unquote(path_portion),


### PR DESCRIPTION
When a unix socket is used `transport.get_extra_info("sockname")` returns None. This is normal and accounted for in the tests. However it is assumed to be there in websockets_impl.py where the server variable is used for logging. This sets it to a default of "unknown".