### PR TITLE
Fix issue with websockets logging

### DIFF
--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,4 +1,4 @@
 from uvicorn.main import main, run
 
-__version__ = "0.3.21"
+__version__ = "0.3.22"
 __all__ = ["main", "run"]

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -167,7 +167,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             if message_type == "websocket.accept":
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
-                    self.scope["server"][0],
+                    self.scope["client"],
                     self.scope["path"],
                 )
                 self.initial_response = None
@@ -177,7 +177,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             elif message_type == "websocket.close":
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
-                    self.scope["server"][0],
+                    self.scope["client"],
                     self.scope["path"],
                 )
                 self.initial_response = (http.HTTPStatus.FORBIDDEN, [], b'')

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -215,7 +215,7 @@ class WSProtocol(asyncio.Protocol):
             if message_type == "websocket.accept":
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
-                    self.scope["server"][0],
+                    self.scope["client"],
                     self.scope["path"],
                 )
                 self.handshake_complete = True
@@ -231,7 +231,7 @@ class WSProtocol(asyncio.Protocol):
                 })
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
-                    self.scope["server"][0],
+                    self.scope["client"],
                     self.scope["path"],
                 )
                 self.handshake_complete = True


### PR DESCRIPTION
Two issues here:

* We weren't allowing for the `None` case.
* We should be logging the *client* address, not the server.

Closes #242
Closes #254