### PR TITLE
Include 'enable-lifespan' run option for lifespan support

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -48,3 +48,7 @@ equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, acces
 ## Timeouts
 
 * `--timeout-keep-alive` - Close Keep-Alive connections if no new data is received within this timeout. **Default:** *5*.
+
+## Lifespan
+
+* `--disable-lifespan` - Disable lifespan events (such as startup and shutdown) within an ASGI application.

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -153,7 +153,7 @@ def get_logger(log_level):
     "--disable-lifespan",
     is_flag=True,
     default=False,
-    help="Enable lifespan events such as startup and shutdown within an ASGI application.",
+    help="Disable lifespan events (such as startup and shutdown) within an ASGI application.",
     show_default=True,
 )
 def main(

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -154,7 +154,6 @@ def get_logger(log_level):
     is_flag=True,
     default=False,
     help="Disable lifespan events (such as startup and shutdown) within an ASGI application.",
-    show_default=True,
 )
 def main(
     app,


### PR DESCRIPTION
Refs https://github.com/encode/uvicorn/issues/260

Introduces an option to make lifespan support configurable. This allows ASGI applications that do not support the lifespan protocol to run with the defaults.