### PR TITLE
[RFC] run: add use_reloader

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -191,11 +191,16 @@ def main(
     }
 
     if debug:
-        logger = get_logger(log_level)
-        reloader = StatReload(logger)
-        reloader.run(run, kwargs)
+        run_with_reloader(**kwargs)
     else:
         run(**kwargs)
+
+
+def run_with_reloader(**kwargs):
+    log_level = kwargs.get("log_level", "info")
+    logger = get_logger(log_level)
+    reloader = StatReload(logger)
+    reloader.run(run, kwargs)
 
 
 def run(

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -291,7 +291,7 @@ def run(
 
     if use_reloader:
         reloader = StatReload(logger)
-        reloader.run(server.run, {})
+        reloader.run(server.run)
     else:
         server.run()
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -183,6 +183,7 @@ def main(
         "access_log": not no_access_log,
         "wsgi": wsgi,
         "debug": debug,
+        "use_reloader": debug,
         "proxy_headers": proxy_headers,
         "root_path": root_path,
         "limit_concurrency": limit_concurrency,
@@ -190,17 +191,7 @@ def main(
         "timeout_keep_alive": timeout_keep_alive,
     }
 
-    if debug:
-        run_with_reloader(**kwargs)
-    else:
-        run(**kwargs)
-
-
-def run_with_reloader(**kwargs):
-    log_level = kwargs.get("log_level", "info")
-    logger = get_logger(log_level)
-    reloader = StatReload(logger)
-    reloader.run(run, kwargs)
+    run(**kwargs)
 
 
 def run(
@@ -217,6 +208,7 @@ def run(
     access_log=True,
     wsgi=False,
     debug=False,
+    use_reloader=False,
     proxy_headers=False,
     root_path="",
     limit_concurrency=None,
@@ -296,7 +288,12 @@ def run(
         install_signal_handlers=install_signal_handlers,
         ready_event=ready_event,
     )
-    server.run()
+
+    if use_reloader:
+        reloader = StatReload(logger)
+        reloader.run(server.run, {})
+    else:
+        server.run()
 
 
 class Server:

--- a/uvicorn/reloaders/statreload.py
+++ b/uvicorn/reloaders/statreload.py
@@ -20,7 +20,7 @@ class StatReload:
     def handle_exit(self, sig, frame):
         self.should_exit = True
 
-    def run(self, target, kwargs):
+    def run(self, target):
         pid = os.getpid()
 
         self.logger.info("Started reloader process [{}]".format(pid))
@@ -28,7 +28,7 @@ class StatReload:
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.handle_exit)
 
-        process = multiprocessing.Process(target=target, kwargs=kwargs)
+        process = multiprocessing.Process(target=target)
         process.start()
 
         while process.is_alive() and not self.should_exit:
@@ -37,7 +37,7 @@ class StatReload:
                 self.clear()
                 os.kill(process.pid, signal.SIGTERM)
                 process.join()
-                process = multiprocessing.Process(target=target, kwargs=kwargs)
+                process = multiprocessing.Process(target=target)
                 process.start()
 
         self.logger.info("Stopping reloader process [{}]".format(pid))


### PR DESCRIPTION
This is useful when not using `main` (e.g. from an own `__main__` function),
but you want to have the reloading feature.

I could imagine to enable this just with `debug=True` for `run()` already, but that would require to move the body of the existing `run` to `run_inner` or something similar.

Of course, using `main()` in this case might also do, but it requires `args` to be provided for click, and I've thought that `click` should really be used from CLI only (and not your own `__main__`).