### PR TITLE
Missing imports, flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,11 @@ script:
 
 after_script:
     - codecov
+
+jobs:
+    include:
+        - stage: style
+          install: skip
+          script:
+              - pip install flake8
+              - flake8 .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501,E731,F401,F841,W503
+# max-line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import sys
 import platform
 
 from setuptools import setup
@@ -68,7 +67,7 @@ setup(
     author_email='tom@tomchristie.com',
     packages=get_packages('uvicorn'),
     install_requires=requirements,
-    data_files = [("", ["LICENSE.md"])],
+    data_files=[("", ["LICENSE.md"])],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',

--- a/tests/client.py
+++ b/tests/client.py
@@ -112,7 +112,6 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
         return self.build_response(request, raw)
 
 
-
 class _TestClient(requests.Session):
     def __init__(self, app: typing.Callable, base_url: str, raise_server_exceptions=True) -> None:
         super(_TestClient, self).__init__()

--- a/tests/importer/raise_import_error.py
+++ b/tests/importer/raise_import_error.py
@@ -2,4 +2,4 @@
 
 myattr = 123
 
-import does_not_exist
+import does_not_exist  # noqa

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -33,7 +33,7 @@ def raise_exception(environ, start_response):
 def return_exc_info(environ, start_response):
     try:
         raise RuntimeError('Something went wrong')
-    except:
+    except RuntimeError:
         status = '500 Internal Server Error'
         output = b'Internal Server Error'
         headers = [

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -11,7 +11,7 @@ class MockTransport:
 
 def test_get_local_addr():
     transport = MockTransport({"sockname": "path/to/unix-domain-socket"})
-    assert get_local_addr(transport) == None
+    assert get_local_addr(transport) is None
 
     transport = MockTransport({"sockname": ['123.45.6.7', 123]})
     assert get_local_addr(transport) == ('123.45.6.7', 123)
@@ -19,7 +19,7 @@ def test_get_local_addr():
 
 def test_get_remote_addr():
     transport = MockTransport({"peername": None})
-    assert get_remote_addr(transport) == None
+    assert get_remote_addr(transport) is None
 
     transport = MockTransport({"peername": ['123.45.6.7', 123]})
     assert get_remote_addr(transport) == ('123.45.6.7', 123)

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -163,7 +163,7 @@ def test_send_and_close_connection(protocol_cls):
             is_open = True
             try:
                 await websocket.recv()
-            except:
+            except Exception:
                 is_open = False
             return (data, is_open)
 
@@ -235,7 +235,7 @@ def test_send_after_protocol_close(protocol_cls):
             is_open = True
             try:
                 await websocket.recv()
-            except:
+            except Exception:
                 is_open = False
             return (data, is_open)
 
@@ -252,6 +252,7 @@ def test_missing_handshake(protocol_cls):
     class App:
         def __init__(self, scope):
             pass
+
         async def __call__(self, receive, send):
             pass
 
@@ -271,6 +272,7 @@ def test_send_before_handshake(protocol_cls):
     class App:
         def __init__(self, scope):
             pass
+
         async def __call__(self, receive, send):
             await send({"type": "websocket.send", "text": "123"})
 
@@ -290,6 +292,7 @@ def test_duplicate_handshake(protocol_cls):
     class App:
         def __init__(self, scope):
             pass
+
         async def __call__(self, receive, send):
             await send({"type": "websocket.accept"})
             await send({"type": "websocket.accept"})
@@ -315,6 +318,7 @@ def test_asgi_return_value(protocol_cls):
     class App:
         def __init__(self, scope):
             pass
+
         async def __call__(self, receive, send):
             await send({"type": "websocket.accept"})
             return 123

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ def hello_world(scope):
 
 
 def test_explicit_base_url():
-    client = TestClient(hello_world, base_url = "http://testserver:321")
+    client = TestClient(hello_world, base_url="http://testserver:321")
     response = client.get('/')
     assert response.status_code == 200
     assert response.text == 'hello, world'

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -5,6 +5,7 @@ from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 import click
 import logging
+import socket
 import sys
 
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -6,11 +6,7 @@ import asyncio
 import click
 import signal
 import os
-import logging
-import socket
 import sys
-import time
-import multiprocessing
 
 
 LEVEL_CHOICES = click.Choice(LOG_LEVELS.keys())

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -9,6 +9,7 @@ the connecting client, rather that the connecting proxy.
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
 
+
 class ProxyHeadersMiddleware:
     def __init__(self, app, num_proxies=1):
         self.app = app

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -1,4 +1,5 @@
 from urllib.parse import unquote
+from uvicorn.global_state import GlobalState
 from uvicorn.protocols.utils import get_local_addr, get_remote_addr, is_ssl
 import asyncio
 import h11

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -137,7 +137,6 @@ class UvicornWorker(Worker):
         return ctx
 
     async def tick(self, loop):
-        pid = os.getpid()
         cycle = 0
 
         while self.alive:


### PR DESCRIPTION
I'm not sure whether you want this or not, but I noticed a few fixups because of missing imports in the history -- things which might be detected automatically before merging.

I propose adding a build stage which checks the coding style using flake8. Because I didn't want to put in too much work without some feedback first I have added an ignore list for some flake8 errors. It might be better to let https://github.com/ambv/black fix the remaining warnings anyway instead of tackling them by hand, at least if you like the black coding style. (I wasn't a big fan of some aspects at first, but an automatic an opinionated source code formatter *can* be helpful.)

Anyway, no hard feelings at all if you reject this pull request. The first commit (https://github.com/encode/uvicorn/commit/ec8e24f0fa3d4f2a3923cf3abb3dc82e7017ce1e) should be uncontroversial though.