### PR TITLE
Use optional package installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install using `pip`:
 
 ```shell
 $ pip install uvicorn  # Install with minimal (pure Python) deps
-$ pip install uvicorn[default]  # Install with fast deps (where possible)
+$ pip install uvicorn[standard]  # Install with fast deps (where possible)
 ```
 
 Create an application, in `example.py`:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Uvicorn currently supports HTTP/1.1 and WebSockets. Support for HTTP/2 is planne
 Install using `pip`:
 
 ```shell
-$ pip install uvicorn
+$ pip install uvicorn[pure]  # Install pure Python deps (works anywhere)
+$ pip install uvicorn[fast]  # Install fast deps (not for e.g. Windows or Pypy)
 ```
 
 Create an application, in `example.py`:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Uvicorn currently supports HTTP/1.1 and WebSockets. Support for HTTP/2 is planne
 Install using `pip`:
 
 ```shell
-$ pip install uvicorn[pure]  # Install pure Python deps (works anywhere)
-$ pip install uvicorn[fast]  # Install fast deps (not for e.g. Windows or Pypy)
+$ pip install uvicorn  # Install with minimal (pure Python) deps
+$ pip install uvicorn[default]  # Install with fast deps (where possible)
 ```
 
 Create an application, in `example.py`:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
+# Minimal
 click
-
-# Pure
 h11
 
 # Optional

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 click
+
+# Pure
 h11
 
 # Optional

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     packages=get_packages('uvicorn'),
     data_files = [("", ["LICENSE.md"])],
     install_requires=minimal_requirements,
-    extras_require={'default': extra_requirements},
+    extras_require={'standard': extra_requirements},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@
 import os
 import re
 import sys
-import platform
 
 from setuptools import setup
 
@@ -60,8 +59,19 @@ setup(
     author='Tom Christie',
     author_email='tom@tomchristie.com',
     packages=get_packages('uvicorn'),
-    install_requires=requirements,
     data_files = [("", ["LICENSE.md"])],
+    install_requires=[
+        'click'
+        'h11',
+        'wsproto'
+    ],
+    extras_require={
+        'full': [
+            'uvloop',
+            'httptools',
+            'websockets>=6.0'
+        ]
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,12 @@ env_marker = (
     " and platform_python_implementation != 'pypy'"
 )
 
-requirements = [
+minimal_requirements = [
     "click==7.*",
     "h11==0.8.*",
+]
+
+extra_requirements = [
     "websockets==8.*",
     "httptools==0.0.13 ;" + env_marker,
     "uvloop==0.14.0rc2 ;" + env_marker,
@@ -59,11 +62,8 @@ setup(
     author_email='tom@tomchristie.com',
     packages=get_packages('uvicorn'),
     data_files = [("", ["LICENSE.md"])],
-    install_requires=['click'],
-    extras_require={
-        'pure': ['h11', 'wsproto==0.13.*'],
-        'fast': ['uvloop', 'httptools', 'websockets>=6.0'],
-    },
+    install_requires=minimal_requirements,
+    extras_require={'default': extra_requirements},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import sys
 
 from setuptools import setup
 
@@ -60,17 +59,10 @@ setup(
     author_email='tom@tomchristie.com',
     packages=get_packages('uvicorn'),
     data_files = [("", ["LICENSE.md"])],
-    install_requires=[
-        'click'
-        'h11',
-        'wsproto'
-    ],
+    install_requires=['click'],
     extras_require={
-        'full': [
-            'uvloop',
-            'httptools',
-            'websockets>=6.0'
-        ]
+        'pure': ['h11', 'wsproto==0.13.*'],
+        'fast': ['uvloop', 'httptools', 'websockets>=6.0'],
     },
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This is #224 rebased to master. Closes #219.

I also pinned `wsproto` because uvicorn does not work for wsproto 0.13. Would probably be good to fix that (in another PR).

Suggestion: what about also adding `[dev]`. We could use that in the CI script, so we'd have all dependencies defined in a single place.