### PR TITLE
Reload

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,6 +33,11 @@ Options:
   --port INTEGER                  Bind socket to this port.  [default: 8000]
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
+  --reload                        Enable auto-reload.
+  --reload-dir TEXT               Set reload directories explicitly, instead
+                                  of using 'sys.path'.
+  --workers INTEGER               Number of worker processes. Not valid with
+                                  --reload.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
@@ -42,7 +47,6 @@ Options:
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --wsgi                          Use WSGI as the application interface,
                                   instead of ASGI.
-  --reload                        Enable auto-reload.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]
   --no-access-log                 Disable access log.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ Server deployment is a complex area, that will depend on what kind of service yo
 
 As a general rule, you probably want to:
 
-* Run `uvicorn --debug` from the command line for local development.
+* Run `uvicorn --reload` from the command line for local development.
 * Run `gunicorn -k uvicorn.workers.UvicornWorker` for production.
 * Additionally run behind Nginx for self-hosted deployments.
 * Finally, run everything behind a CDN for caching support, and serious DDOS protection.
@@ -14,12 +14,12 @@ As a general rule, you probably want to:
 Typically you'll run `uvicorn` from the command line.
 
 ```bash
-$ uvicorn app:App --debug --port 5000
+$ uvicorn app:App --reload --port 5000
 ```
 
 The ASGI application should be specified in the form `path.to.module:instance.path`.
 
-When running locally, use `--debug` to turn on auto-reloading, and display error tracebacks in the browser.
+When running locally, use `--reload` to turn on auto-reloading.
 
 To see the complete set of available options, use `uvicorn --help`:
 
@@ -34,14 +34,15 @@ Options:
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
-  --http [auto|h11|httptools]     HTTP protocol implementation.  [default: auto]
+  --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
+                                  auto]
   --ws [none|auto|websockets|wsproto]
                                   WebSocket protocol implementation.
                                   [default: auto]
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --wsgi                          Use WSGI as the application interface,
                                   instead of ASGI.
-  --debug                         Enable debug mode.
+  --reload                        Enable auto-reload.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]
   --no-access-log                 Disable access log.

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,13 +81,15 @@ Options:
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
-  --http [auto|h11|httptools]     HTTP parser implementation.  [default: auto]
+  --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
+                                  auto]
   --ws [none|auto|websockets|wsproto]
                                   WebSocket protocol implementation.
                                   [default: auto]
+  --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --wsgi                          Use WSGI as the application interface,
                                   instead of ASGI.
-  --debug                         Enable debug mode.
+  --reload                        Enable auto-reload.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]
   --no-access-log                 Disable access log.
@@ -104,6 +106,15 @@ Options:
   --timeout-keep-alive INTEGER    Close Keep-Alive connections if no new data
                                   is received within this timeout.  [default:
                                   5]
+  --ssl-keyfile TEXT              SSL key file
+  --ssl-certfile TEXT             SSL certificate file
+  --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
+                                  [default: 2]
+  --ssl-cert-reqs INTEGER         Whether client certificate is required (see
+                                  stdlib ssl module's)  [default: 0]
+  --ssl-ca-certs TEXT             CA certificates file
+  --ssl-ciphers TEXT              Ciphers to use (see stdlib ssl module's)
+                                  [default: TLSv1]
   --help                          Show this message and exit.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,11 @@ Options:
   --port INTEGER                  Bind socket to this port.  [default: 8000]
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
+  --reload                        Enable auto-reload.
+  --reload-dir TEXT               Set reload directories explicitly, instead
+                                  of using 'sys.path'.
+  --workers INTEGER               Number of worker processes. Not valid with
+                                  --reload.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
@@ -89,7 +94,6 @@ Options:
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --wsgi                          Use WSGI as the application interface,
                                   instead of ASGI.
-  --reload                        Enable auto-reload.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]
   --no-access-log                 Disable access log.

--- a/docs/server-behavior.md
+++ b/docs/server-behavior.md
@@ -83,8 +83,6 @@ Server errors will be logged at the `error` log level. All logging defaults to b
 
 If an exception is raised by an ASGI application, and a response has not yet been sent on the connection, then a `500 Server Error` HTTP response will be sent.
 
-If running with `--debug` then the response will include an error traceback, in either HTML or plaintext, depending on the request `Accept` header.
-
 ### Invalid responses
 
 Uvicorn will ensure that ASGI applications send the correct sequence of messages, and will raise errors otherwise. This includes checking for no response sent, partial response sent, or invalid message sequences being sent.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,25 +11,31 @@ equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, acces
 
 ## Socket Binding
 
-* `--host` - Bind socket to this host. Use `--host 0.0.0.0` to make the application available on your local network. **Default:** *'127.0.0.1'*.
-* `--port` - Bind to a socket with this port. **Default:** *8000*.
-* `--uds` - Bind to a UNIX domain socket. Useful if you want to run Uvicorn behind a reverse proxy.
-* `--fd` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.
+* `--host <str>` - Bind socket to this host. Use `--host 0.0.0.0` to make the application available on your local network. **Default:** *'127.0.0.1'*.
+* `--port <int>` - Bind to a socket with this port. **Default:** *8000*.
+* `--uds <str>` - Bind to a UNIX domain socket. Useful if you want to run Uvicorn behind a reverse proxy.
+* `--fd <int>` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.
 
 ## Development
 
-* `--debug` - Enable debug mode. Provides error tracebacks in the browser, and enables auto-reloading.
+* `--reload` - Enable auto-reload.
+* `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default all directories in `sys.path` will be watched.
+
+## Production
+
+* `--workers <int>` - Use multiple worker processes.
 
 ## Logging
 
-* `--log-level` - Set the log level. **Options:** *'critical', 'error', 'warning', 'info', 'debug'.* **Default:** *'info'*.
+* `--log-level <str>` - Set the log level. **Options:** *'critical', 'error', 'warning', 'info', 'debug'.* **Default:** *'info'*.
 * `--no-access-log` - Disable access log only, without changing log level.
 
 ## Implementation
 
-* `--loop` - Set the event loop implementation. The uvloop implementation provides greater performance, but is not compatible with Windows or PyPy. **Options:** *'auto', 'asyncio', 'uvloop'.* **Default:** *'auto'*.
-* `--http` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy, and requires compilation on Windows. **Options:** *'auto', 'h11', 'httptools'.* **Default:** *'auto'*.
-* `--ws` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to deny all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
+* `--loop <str>` - Set the event loop implementation. The uvloop implementation provides greater performance, but is not compatible with Windows or PyPy. **Options:** *'auto', 'asyncio', 'uvloop'.* **Default:** *'auto'*.
+* `--http <str>` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy, and requires compilation on Windows. **Options:** *'auto', 'h11', 'httptools'.* **Default:** *'auto'*.
+* `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to deny all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
+* `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.
 
 ## Application Interface
 
@@ -37,27 +43,23 @@ equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, acces
 
 ## HTTP
 
-* `--root-path` - Set the ASGI `root_path` for applications submounted below a given URL path.
+* `--root-path <str>` - Set the ASGI `root_path` for applications submounted below a given URL path.
 * `--proxy-headers` - Use the X-Forwarded-Proto and X-Forwarded-For headers to populate remote scheme/address info.
 
 ## HTTPS
 
-* `--ssl-keyfile` - SSL key file
-* `--ssl-certfile` - SSL certificate file
-* `--ssl-version` - SSL version to use (see stdlib ssl module's)
-* `--ssl-cert-reqs` - Whether client certificate is required (see stdlib ssl module's)
-* `--ssl-ca-certs` - CA certificates file
-* `--ssl-ciphers` - Ciphers to use (see stdlib ssl module's)
+* `--ssl-keyfile <path>` - SSL key file
+* `--ssl-certfile <path>` - SSL certificate file
+* `--ssl-version <int>` - SSL version to use (see stdlib ssl module's)
+* `--ssl-cert-reqs <int>` - Whether client certificate is required (see stdlib ssl module's)
+* `--ssl-ca-certs <str>` - CA certificates file
+* `--ssl-ciphers <str>` - Ciphers to use (see stdlib ssl module's)
 
 ## Resource Limits
 
-* `--limit-concurrency` - Maximum number of concurrent connections or tasks to allow, before issuing HTTP 503 responses. Useful for ensuring known memory usage patterns even under over-resourced loads.
-* `--limit-max-requests` - Maximum number of requests to service before terminating the process. Useful when running together with a process manager, for preventing memory leaks from impacting long-running processes.
+* `--limit-concurrency <int>` - Maximum number of concurrent connections or tasks to allow, before issuing HTTP 503 responses. Useful for ensuring known memory usage patterns even under over-resourced loads.
+* `--limit-max-requests <int>` - Maximum number of requests to service before terminating the process. Useful when running together with a process manager, for preventing memory leaks from impacting long-running processes.
 
 ## Timeouts
 
-* `--timeout-keep-alive` - Close Keep-Alive connections if no new data is received within this timeout. **Default:** *5*.
-
-## Lifespan
-
-* `--disable-lifespan` - Disable lifespan events (such as startup and shutdown) within an ASGI application.
+* `--timeout-keep-alive <int>` - Close Keep-Alive connections if no new data is received within this timeout. **Default:** *5*.

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -11,7 +11,7 @@ from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
 try:
     from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
-except ImportError:
+except ImportError:  # pragma: nocover
     HttpToolsProtocol = None
 
 
@@ -695,8 +695,4 @@ def test_supported_upgrade_request(protocol_cls):
 
     protocol = get_connected_protocol(app, protocol_cls, ws="wsproto")
     protocol.data_received(UPGRADE_REQUEST)
-    if b"HTTP/1.1 426 " in protocol.transport.buffer:
-        pass  # wsproto 0.13
-    else:
-        assert b"HTTP/1.1 400 Bad Request" in protocol.transport.buffer
-        assert b"Missing Sec-WebSocket-Version header" in protocol.transport.buffer
+    assert b"HTTP/1.1 426 " in protocol.transport.buffer

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -15,7 +15,7 @@ from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 try:
     import websockets
     from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
-except ImportError:
+except ImportError:  # pragma: nocover
     websockets = None
     WebSocketProtocol = None
 

--- a/tests/reloaders/test_statreload.py
+++ b/tests/reloaders/test_statreload.py
@@ -1,0 +1,12 @@
+from uvicorn.config import Config
+from uvicorn.reloaders.statreload import StatReload
+
+
+def no_op():
+    pass
+
+
+def test_statreload():
+    config = Config(app=None)
+    reloader = StatReload(config)
+    reloader.run(no_op)

--- a/tests/reloaders/test_statreload.py
+++ b/tests/reloaders/test_statreload.py
@@ -1,3 +1,7 @@
+import os
+import time
+from pathlib import Path
+
 from uvicorn.config import Config
 from uvicorn.reloaders.statreload import StatReload
 
@@ -6,7 +10,31 @@ def no_op():
     pass
 
 
+def wait_for_reload(reloader, until, update_file):
+    # I think coverage doesn't fully track this, since it runs in a spawned subprocess.
+    while reloader.reload_count < until:  # pragma: nocover
+        time.sleep(0.1)
+        Path(update_file).touch()
+
+
+def mock_signal(reloader):
+    reloader.handle_exit(None, None)
+
+
 def test_statreload():
     config = Config(app=None)
     reloader = StatReload(config)
     reloader.run(no_op)
+
+
+def test_reload_dirs(tmpdir):
+    update_file = os.path.join(tmpdir, "example.py")
+    config = Config(app=None, reload_dirs=[str(tmpdir)])
+    reloader = StatReload(config)
+    reloader.run(wait_for_reload, reloader=reloader, until=1, update_file=update_file)
+
+
+def test_exit_signal(tmpdir):
+    config = Config(app=None)
+    reloader = StatReload(config)
+    reloader.run(mock_signal, reloader=reloader)

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -16,7 +16,7 @@ def test_multiprocess():
     reloader.run(no_op)
 
 
-def test_exit_signal(tmpdir):
+def test_exit_signal():
     config = Config(app=None, workers=2)
     reloader = Multiprocess(config)
     reloader.run(mock_signal, reloader=reloader)

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -6,8 +6,8 @@ def no_op():
     pass
 
 
-def mock_signal(reloader):
-    reloader.handle_exit(None, None)
+def mock_signal(handle_exit):
+    handle_exit(None, None)
 
 
 def test_multiprocess():
@@ -19,4 +19,4 @@ def test_multiprocess():
 def test_exit_signal():
     config = Config(app=None, workers=2)
     reloader = Multiprocess(config)
-    reloader.run(mock_signal, reloader=reloader)
+    reloader.run(mock_signal, handle_exit=reloader.handle_exit)

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,0 +1,22 @@
+from uvicorn.config import Config
+from uvicorn.supervisors import Multiprocess
+
+
+def no_op():
+    pass
+
+
+def mock_signal(reloader):
+    reloader.handle_exit(None, None)
+
+
+def test_multiprocess():
+    config = Config(app=None, workers=2)
+    reloader = Multiprocess(config)
+    reloader.run(no_op)
+
+
+def test_exit_signal(tmpdir):
+    config = Config(app=None, workers=2)
+    reloader = Multiprocess(config)
+    reloader.run(mock_signal, reloader=reloader)

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -17,8 +17,8 @@ def wait_for_reload(reloader, until, update_file):
         Path(update_file).touch()
 
 
-def mock_signal(reloader):
-    reloader.handle_exit(None, None)
+def mock_signal(handle_exit):
+    handle_exit(None, None)
 
 
 def test_statreload():
@@ -37,4 +37,4 @@ def test_reload_dirs(tmpdir):
 def test_exit_signal(tmpdir):
     config = Config(app=None)
     reloader = StatReload(config)
-    reloader.run(mock_signal, reloader=reloader)
+    reloader.run(mock_signal, handle_exit=reloader.handle_exit)

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -3,7 +3,7 @@ import time
 from pathlib import Path
 
 from uvicorn.config import Config
-from uvicorn.reloaders.statreload import StatReload
+from uvicorn.supervisors import StatReload
 
 
 def no_op():

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -28,7 +28,7 @@ def test_statreload():
 
 
 def test_reload_dirs(tmpdir):
-    update_file = os.path.join(tmpdir, "example.py")
+    update_file = os.path.join(str(tmpdir), "example.py")
     config = Config(app=None, reload_dirs=[str(tmpdir)])
     reloader = StatReload(config)
     reloader.run(wait_for_reload, reloader=reloader, until=1, update_file=update_file)

--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -8,17 +8,18 @@ from uvicorn.protocols.websockets.auto import AutoWebSocketsProtocol
 
 try:
     import uvloop
-except ImportError:
+except ImportError:  # pragma: no cover
     uvloop = None
 
 try:
     import httptools
-except ImportError:
+except ImportError:  # pragma: no cover
     httptools = None
 
 try:
     import websockets
-except ImportError:  # Note that when this happens, the websocket tests are skipped
+except ImportError:  # pragma: no cover
+    # Note that we skip the websocket tests completely in this case.
     websockets = None
 
 
@@ -30,28 +31,21 @@ def test_loop_auto():
     loop = auto_loop_setup()
     policy = asyncio.get_event_loop_policy()
     assert isinstance(policy, asyncio.events.BaseDefaultEventLoopPolicy)
-    if uvloop is None:
-        assert type(policy).__module__.startswith("asyncio")
-    else:
-        assert isinstance(policy, uvloop.EventLoopPolicy)
-        assert type(policy).__module__.startswith("uvloop")
+    expected_loop = "asyncio" if uvloop is None else "uvloop"
+    assert type(policy).__module__.startswith(expected_loop)
 
 
 def test_http_auto():
     config = Config(app=None)
     server_state = ServerState()
     protocol = AutoHTTPProtocol(config=config, server_state=server_state)
-    if httptools is None:
-        assert type(protocol).__name__ == "H11Protocol"
-    else:
-        assert type(protocol).__name__ == "HttpToolsProtocol"
+    expected_http = "H11Protocol" if httptools is None else "HttpToolsProtocol"
+    assert type(protocol).__name__ == expected_http
 
 
 def test_websocket_auto():
     config = Config(app=None)
     server_state = ServerState()
     protocol = AutoWebSocketsProtocol(config=config, server_state=server_state)
-    if websockets is None:
-        assert type(protocol).__name__ == "WSProtocol"
-    else:
-        assert type(protocol).__name__ == "WebSocketProtocol"
+    expected_websockets = "WSProtocol" if websockets is None else "WebSocketProtocol"
+    assert type(protocol).__name__ == expected_websockets

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -104,11 +104,10 @@ def create_certfile_and_keyfile(request):
     return certfile, keyfile
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Skipping SSL test on Windows"
+)
 def test_run(create_certfile_and_keyfile):
-
-    if sys.platform.startswith("win"):
-        pytest.skip("Skipping SSL test on Windows for now :(")
-
     certfile, keyfile = create_certfile_and_keyfile
 
     class App:

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.4.6"
+__version__ = "0.5.0"
 __all__ = ["main", "run", "Config", "Server"]

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -77,6 +77,7 @@ class Config:
         wsgi=False,
         debug=False,
         reload=False,
+        reload_dirs=None,
         proxy_headers=False,
         root_path="",
         limit_concurrency=None,
@@ -137,6 +138,11 @@ class Config:
             )
         else:
             self.ssl = None
+
+        if reload_dirs is None:
+            self.reload_dirs = sys.path
+        else:
+            self.reload_dirs = reload_dirs
 
         self.loaded = False
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -123,11 +123,6 @@ class Config:
         self.ssl_ca_certs = ssl_ca_certs
         self.ssl_ciphers = ssl_ciphers
 
-        if self.logger is None:
-            self.logger_instance = get_logger(self.log_level)
-        else:
-            self.logger_instance = self.logger
-
         if self.ssl_keyfile or self.ssl_certfile:
             self.ssl = create_ssl_context(
                 keyfile=self.ssl_keyfile,
@@ -149,11 +144,6 @@ class Config:
 
     def load(self):
         assert not self.loaded
-
-        if self.logger is None:
-            # We re-apply this, in order to ensure that subprocesses get
-            # the correct basicConfig setup too.
-            get_logger(self.log_level)
 
         if isinstance(self.http, str):
             self.http_protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])
@@ -198,3 +188,9 @@ class Config:
         protocol_name = "https" if self.ssl else "http"
         self.logger_instance.info(message % (protocol_name, self.host, self.port))
         return sock
+
+    @property
+    def logger_instance(self):
+        if self.logger is not None:
+            return self.logger
+        return get_logger(self.log_level)

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -19,7 +19,7 @@ from uvicorn.config import (
     Config,
     get_logger,
 )
-from uvicorn.reloaders.statreload import StatReload
+from uvicorn.supervisors import Multiprocess, StatReload
 
 LEVEL_CHOICES = click.Choice(LOG_LEVELS.keys())
 HTTP_CHOICES = click.Choice(HTTP_PROTOCOLS.keys())
@@ -94,9 +94,14 @@ HANDLED_SIGNALS = (
 @click.option(
     "--reload-dir",
     "reload_dirs",
-    default=None,
     multiple=True,
     help="Set reload directories explicitly, instead of using 'sys.path'.",
+)
+@click.option(
+    "--workers",
+    default=1,
+    type=int,
+    help="Number of worker processes. Not valid with --reload.",
 )
 @click.option(
     "--log-level",
@@ -190,7 +195,8 @@ def main(
     wsgi: bool,
     debug: bool,
     reload: bool,
-    reload_dirs: typing.Optional[typing.List[str]],
+    reload_dirs: typing.List[str],
+    workers: int,
     log_level: str,
     no_access_log: bool,
     proxy_headers: bool,
@@ -222,7 +228,8 @@ def main(
         "wsgi": wsgi,
         "debug": debug,
         "reload": reload,
-        "reload_dir": reload_dir,
+        "reload_dirs": reload_dirs if reload_dirs else None,
+        "workers": workers,
         "proxy_headers": proxy_headers,
         "root_path": root_path,
         "limit_concurrency": limit_concurrency,
@@ -241,13 +248,19 @@ def main(
 def run(app, **kwargs):
     config = Config(app, **kwargs)
     server = Server(config=config)
+
+    if config.debug:
+        MESSAGE = "The 'debug' option is due to be deprecated. Use 'reload' instead."
+        config.logger_instance.warn(MESSAGE)
+
     if config.debug or config.reload:
-        if config.debug:
-            config.logger_instance.warn(
-                "The 'debug' option is due to be deprecated. Use 'reload' instead."
-            )
-        reloader = StatReload(config)
-        reloader.run(server.run)
+        socket = config.bind_socket()
+        supervisor = StatReload(config)
+        supervisor.run(server.run, sockets=[socket])
+    elif config.workers > 1:
+        socket = config.bind_socket()
+        supervisor = Multiprocess(config)
+        supervisor.run(server.run, sockets=[socket])
     else:
         server.run()
 
@@ -273,12 +286,12 @@ class Server:
         self.should_exit = False
         self.force_exit = False
 
-    def run(self):
+    def run(self, sockets=None, shutdown_servers=True):
         self.config.setup_event_loop()
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.serve())
+        loop.run_until_complete(self.serve(sockets=sockets))
 
-    async def serve(self):
+    async def serve(self, sockets=None, shutdown_servers=True):
         process_id = os.getpid()
 
         config = self.config
@@ -291,12 +304,12 @@ class Server:
         self.install_signal_handlers()
 
         self.logger.info("Started server process [{}]".format(process_id))
-        await self.startup()
+        await self.startup(sockets=sockets)
         await self.main_loop()
-        await self.shutdown()
+        await self.shutdown(shutdown_servers=shutdown_servers)
         self.logger.info("Finished server process [{}]".format(process_id))
 
-    async def startup(self):
+    async def startup(self, sockets=None):
         config = self.config
 
         await self.lifespan.startup()
@@ -307,11 +320,11 @@ class Server:
 
         loop = asyncio.get_event_loop()
 
-        if config.sockets is not None:
+        if sockets is not None:
             # Explicitly passed a list of open sockets.
             # We use this when the server is run from a Gunicorn worker.
             self.servers = []
-            for socket in config.sockets:
+            for socket in sockets:
                 server = await loop.create_server(
                     create_protocol, sock=socket, ssl=config.ssl
                 )
@@ -377,11 +390,11 @@ class Server:
             return self.server_state.total_requests >= self.config.limit_max_requests
         return False
 
-    async def shutdown(self):
+    async def shutdown(self, shutdown_servers=True):
         self.logger.info("Shutting down")
 
         # Stop accepting new connections.
-        if not self.config.sockets:
+        if shutdown_servers:
             for server in self.servers:
                 server.close()
             for server in self.servers:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -249,10 +249,6 @@ def run(app, **kwargs):
     config = Config(app, **kwargs)
     server = Server(config=config)
 
-    if config.debug:
-        MESSAGE = "The 'debug' option is due to be deprecated. Use 'reload' instead."
-        config.logger_instance.warn(MESSAGE)
-
     if config.debug or config.reload:
         socket = config.bind_socket()
         supervisor = StatReload(config)

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -54,6 +54,22 @@ HANDLED_SIGNALS = (
     "--fd", type=int, default=None, help="Bind to socket from this file descriptor."
 )
 @click.option(
+    "--debug", is_flag=True, default=False, help="Enable debug mode.", hidden=True
+)
+@click.option("--reload", is_flag=True, default=False, help="Enable auto-reload.")
+@click.option(
+    "--reload-dir",
+    "reload_dirs",
+    multiple=True,
+    help="Set reload directories explicitly, instead of using 'sys.path'.",
+)
+@click.option(
+    "--workers",
+    default=1,
+    type=int,
+    help="Number of worker processes. Not valid with --reload.",
+)
+@click.option(
     "--loop",
     type=LOOP_CHOICES,
     default="auto",
@@ -86,22 +102,6 @@ HANDLED_SIGNALS = (
     is_flag=True,
     default=False,
     help="Use WSGI as the application interface, instead of ASGI.",
-)
-@click.option(
-    "--debug", is_flag=True, default=False, help="Enable debug mode.", hidden=True
-)
-@click.option("--reload", is_flag=True, default=False, help="Enable auto-reload.")
-@click.option(
-    "--reload-dir",
-    "reload_dirs",
-    multiple=True,
-    help="Set reload directories explicitly, instead of using 'sys.path'.",
-)
-@click.option(
-    "--workers",
-    default=1,
-    type=int,
-    help="Number of worker processes. Not valid with --reload.",
 )
 @click.option(
     "--log-level",

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -5,6 +5,7 @@ import signal
 import ssl
 import sys
 import time
+import typing
 from email.utils import formatdate
 
 import click
@@ -90,6 +91,13 @@ HANDLED_SIGNALS = (
     "--debug", is_flag=True, default=False, help="Enable debug mode.", hidden=True
 )
 @click.option("--reload", is_flag=True, default=False, help="Enable auto-reload.")
+@click.option(
+    "--reload-dir",
+    "reload_dirs",
+    default=None,
+    multiple=True,
+    help="Set reload directories explicitly, instead of using 'sys.path'.",
+)
 @click.option(
     "--log-level",
     type=LEVEL_CHOICES,
@@ -182,6 +190,7 @@ def main(
     wsgi: bool,
     debug: bool,
     reload: bool,
+    reload_dirs: typing.Optional[typing.List[str]],
     log_level: str,
     no_access_log: bool,
     proxy_headers: bool,
@@ -213,6 +222,7 @@ def main(
         "wsgi": wsgi,
         "debug": debug,
         "reload": reload,
+        "reload_dir": reload_dir,
         "proxy_headers": proxy_headers,
         "root_path": root_path,
         "limit_concurrency": limit_concurrency,

--- a/uvicorn/reloaders/statreload.py
+++ b/uvicorn/reloaders/statreload.py
@@ -1,7 +1,6 @@
 import multiprocessing
 import os
 import signal
-import sys
 import time
 
 HANDLED_SIGNALS = (
@@ -41,8 +40,6 @@ class StatReload:
                 process.start()
 
         self.logger.info("Stopping reloader process [{}]".format(pid))
-
-        sys.exit(process.exitcode)
 
     def clear(self):
         self.mtimes = {}

--- a/uvicorn/supervisors/__init__.py
+++ b/uvicorn/supervisors/__init__.py
@@ -1,0 +1,4 @@
+from uvicorn.supervisors.multiprocess import Multiprocess
+from uvicorn.supervisors.statreload import StatReload
+
+__all__ = ["Multiprocess", "StatReload"]

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -1,0 +1,41 @@
+import multiprocessing
+import os
+import signal
+import time
+
+HANDLED_SIGNALS = (
+    signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
+    signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
+)
+
+
+class Multiprocess:
+    def __init__(self, config):
+        self.logger = config.logger_instance
+        self.workers = config.workers
+        self.should_exit = False
+
+    def handle_exit(self, sig, frame):
+        self.should_exit = True
+
+    def run(self, target, *args, **kwargs):
+        pid = os.getpid()
+
+        self.logger.info("Started parent process [{}]".format(pid))
+
+        for sig in HANDLED_SIGNALS:
+            signal.signal(sig, self.handle_exit)
+
+        spawn = multiprocessing.get_context("spawn")
+        processes = []
+        for idx in range(self.workers):
+            process = spawn.Process(target=target, args=args, kwargs=kwargs)
+            process.start()
+            processes.append(process)
+
+        while (
+            any([process.is_alive() for process in processes]) and not self.should_exit
+        ):
+            time.sleep(0.1)
+
+        self.logger.info("Stopping parent process [{}]".format(pid))

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -11,7 +11,7 @@ HANDLED_SIGNALS = (
 
 class Multiprocess:
     def __init__(self, config):
-        self.logger = config.logger_instance
+        self.config = config
         self.workers = config.workers
         self.should_exit = False
 
@@ -20,8 +20,9 @@ class Multiprocess:
 
     def run(self, target, *args, **kwargs):
         pid = os.getpid()
+        logger = self.config.logger_instance
 
-        self.logger.info("Started parent process [{}]".format(pid))
+        logger.info("Started parent process [{}]".format(pid))
 
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.handle_exit)
@@ -38,4 +39,4 @@ class Multiprocess:
         ):
             time.sleep(0.1)
 
-        self.logger.info("Stopping parent process [{}]".format(pid))
+        logger.info("Stopping parent process [{}]".format(pid))

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -12,8 +12,7 @@ HANDLED_SIGNALS = (
 
 class StatReload:
     def __init__(self, config):
-        self.logger = config.logger_instance
-        self.reload_dirs = config.reload_dirs
+        self.config = config
         self.should_exit = False
         self.reload_count = 0
         self.mtimes = {}
@@ -23,8 +22,9 @@ class StatReload:
 
     def run(self, target, *args, **kwargs):
         pid = os.getpid()
+        logger = self.config.logger_instance
 
-        self.logger.info("Started reloader process [{}]".format(pid))
+        logger.info("Started reloader process [{}]".format(pid))
 
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.handle_exit)
@@ -43,7 +43,7 @@ class StatReload:
                 process.start()
                 self.reload_count += 1
 
-        self.logger.info("Stopping reloader process [{}]".format(pid))
+        logger.info("Stopping reloader process [{}]".format(pid))
 
     def clear(self):
         self.mtimes = {}
@@ -64,12 +64,12 @@ class StatReload:
                 if Path.cwd() in Path(filename).parents:
                     display_path = os.path.normpath(os.path.relpath(filename))
                 message = "Detected file change in '%s'. Reloading..."
-                self.logger.warning(message, display_path)
+                self.config.logger_instance.warning(message, display_path)
                 return True
         return False
 
     def iter_py_files(self):
-        for reload_dir in self.reload_dirs:
+        for reload_dir in self.config.reload_dirs:
             for subdir, dirs, files in os.walk(reload_dir):
                 for file in files:
                     filepath = subdir + os.sep + file

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -2,6 +2,7 @@ import multiprocessing
 import os
 import signal
 import time
+from pathlib import Path
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
@@ -33,7 +34,7 @@ class StatReload:
         process.start()
 
         while process.is_alive() and not self.should_exit:
-            time.sleep(0.2)
+            time.sleep(0.1)
             if self.should_restart():
                 self.clear()
                 os.kill(process.pid, signal.SIGTERM)
@@ -59,8 +60,11 @@ class StatReload:
                 self.mtimes[filename] = mtime
                 continue
             elif mtime > old_time:
+                display_path = os.path.normpath(filename)
+                if Path.cwd() in Path(filename).parents:
+                    display_path = os.path.normpath(os.path.relpath(filename))
                 message = "Detected file change in '%s'. Reloading..."
-                self.logger.warning(message, filename)
+                self.logger.warning(message, display_path)
                 return True
         return False
 

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -21,7 +21,6 @@ class UvicornWorker(Worker):
 
         config_kwargs = {
             "app": None,
-            "sockets": self.sockets,
             "logger": self.log,
             "timeout_keep_alive": self.cfg.keepalive,
             "timeout_notify": self.timeout,
@@ -54,7 +53,9 @@ class UvicornWorker(Worker):
         self.config.app = self.wsgi
         server = Server(config=self.config)
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(server.serve())
+        loop.run_until_complete(
+            server.serve(sockets=self.sockets, shutdown_servers=False)
+        )
 
     async def callback_notify(self):
         self.notify()


### PR DESCRIPTION
* `--reload` command line option now replaces `--debug`.
* `uvicorn.run(app, reload=True)` is now supported.
* `--reload-dir` command line option added (May be used multiple times)
* `reload_dirs` argument added.
* `--workers` command line option added.
* `workers` argument added.
* Reloading will be more robust.

Closes #239 

Multi-workers may become the default at some point, but let's not do that yet until it's had a run around.