### PR TITLE
Allow for Modification of Default HTTP Response Headers

### DIFF
--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -76,28 +76,6 @@ def test_override_server_header_multiple_times():
     thread.join()
 
 
-def test_override_date_header():
-    config = Config(
-        app=App,
-        loop="asyncio",
-        limit_max_requests=1,
-        custom_headers=[("Date", "over-ridden")],
-    )
-    server = CustomServer(config=config)
-    thread = threading.Thread(target=server.run)
-    thread.start()
-    while not server.started:
-        time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
-
-    assert (
-        response.headers["server"] == "uvicorn"
-        and response.headers["date"] == "over-ridden"
-    )
-
-    thread.join()
-
-
 def test_add_additional_header():
     config = Config(
         app=App,

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -1,0 +1,107 @@
+import threading
+import time
+
+import requests
+
+from uvicorn import Config, Server
+
+
+class App:
+    def __init__(self, scope):
+        if scope["type"] != "http":
+            raise Exception()
+
+    async def __call__(self, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+class CustomServer(Server):
+    def install_signal_handlers(self):
+        pass
+
+
+def test_default_default_headers():
+    config = Config(app=App, loop="asyncio", limit_max_requests=1)
+    server = CustomServer(config=config)
+    thread = threading.Thread(target=server.run)
+    thread.start()
+    while not server.started:
+        time.sleep(0.01)
+    response = requests.get('http://127.0.0.1:8000')
+
+    assert (response.headers['server'] == 'uvicorn'
+            and response.headers['date'])
+
+    thread.join()
+
+
+def test_override_server_header():
+    config = Config(
+        app=App, loop="asyncio", limit_max_requests=1,
+        custom_headers=[('Server', 'over-ridden')])
+    server = CustomServer(config=config)
+    thread = threading.Thread(target=server.run)
+    thread.start()
+    while not server.started:
+        time.sleep(0.01)
+    response = requests.get('http://127.0.0.1:8000')
+
+    assert (response.headers['server'] == 'over-ridden' and
+            response.headers['date'])
+
+    thread.join()
+
+
+def test_override_server_header_multiple_times():
+    config = Config(
+        app=App, loop="asyncio", limit_max_requests=1,
+        custom_headers=[
+            ('Server', 'over-ridden'),
+            ('Server', 'another-value')])
+    server = CustomServer(config=config)
+    thread = threading.Thread(target=server.run)
+    thread.start()
+    while not server.started:
+        time.sleep(0.01)
+    response = requests.get('http://127.0.0.1:8000')
+
+    assert (response.headers['server'] == 'over-ridden, another-value' and
+            response.headers['date'])
+
+    thread.join()
+
+
+def test_override_date_header():
+    config = Config(
+        app=App, loop="asyncio", limit_max_requests=1,
+        custom_headers=[('Date', 'over-ridden')])
+    server = CustomServer(config=config)
+    thread = threading.Thread(target=server.run)
+    thread.start()
+    while not server.started:
+        time.sleep(0.01)
+    response = requests.get('http://127.0.0.1:8000')
+
+    assert (response.headers['server'] == 'uvicorn' and
+            response.headers['date'] == 'over-ridden')
+
+    thread.join()
+
+
+def test_add_additional_header():
+    config = Config(
+        app=App, loop="asyncio", limit_max_requests=1,
+        custom_headers=[('X-Additional', 'new-value')])
+    server = CustomServer(config=config)
+    thread = threading.Thread(target=server.run)
+    thread.start()
+    while not server.started:
+        time.sleep(0.01)
+    response = requests.get('http://127.0.0.1:8000')
+
+    assert (response.headers['x-additional'] == 'new-value' and
+            response.headers['server'] == 'uvicorn' and
+            response.headers['date'])
+
+    thread.join()

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -40,7 +40,7 @@ def test_override_server_header():
         app=App,
         loop="asyncio",
         limit_max_requests=1,
-        custom_headers=[("Server", "over-ridden")],
+        headers=[("Server", "over-ridden")],
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
@@ -59,7 +59,7 @@ def test_override_server_header_multiple_times():
         app=App,
         loop="asyncio",
         limit_max_requests=1,
-        custom_headers=[("Server", "over-ridden"), ("Server", "another-value")],
+        headers=[("Server", "over-ridden"), ("Server", "another-value")],
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
@@ -81,7 +81,7 @@ def test_add_additional_header():
         app=App,
         loop="asyncio",
         limit_max_requests=1,
-        custom_headers=[("X-Additional", "new-value")],
+        headers=[("X-Additional", "new-value")],
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -28,80 +28,94 @@ def test_default_default_headers():
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get('http://127.0.0.1:8000')
+    response = requests.get("http://127.0.0.1:8000")
 
-    assert (response.headers['server'] == 'uvicorn'
-            and response.headers['date'])
+    assert response.headers["server"] == "uvicorn" and response.headers["date"]
 
     thread.join()
 
 
 def test_override_server_header():
     config = Config(
-        app=App, loop="asyncio", limit_max_requests=1,
-        custom_headers=[('Server', 'over-ridden')])
+        app=App,
+        loop="asyncio",
+        limit_max_requests=1,
+        custom_headers=[("Server", "over-ridden")],
+    )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get('http://127.0.0.1:8000')
+    response = requests.get("http://127.0.0.1:8000")
 
-    assert (response.headers['server'] == 'over-ridden' and
-            response.headers['date'])
+    assert response.headers["server"] == "over-ridden" and response.headers["date"]
 
     thread.join()
 
 
 def test_override_server_header_multiple_times():
     config = Config(
-        app=App, loop="asyncio", limit_max_requests=1,
-        custom_headers=[
-            ('Server', 'over-ridden'),
-            ('Server', 'another-value')])
+        app=App,
+        loop="asyncio",
+        limit_max_requests=1,
+        custom_headers=[("Server", "over-ridden"), ("Server", "another-value")],
+    )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get('http://127.0.0.1:8000')
+    response = requests.get("http://127.0.0.1:8000")
 
-    assert (response.headers['server'] == 'over-ridden, another-value' and
-            response.headers['date'])
+    assert (
+        response.headers["server"] == "over-ridden, another-value"
+        and response.headers["date"]
+    )
 
     thread.join()
 
 
 def test_override_date_header():
     config = Config(
-        app=App, loop="asyncio", limit_max_requests=1,
-        custom_headers=[('Date', 'over-ridden')])
+        app=App,
+        loop="asyncio",
+        limit_max_requests=1,
+        custom_headers=[("Date", "over-ridden")],
+    )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get('http://127.0.0.1:8000')
+    response = requests.get("http://127.0.0.1:8000")
 
-    assert (response.headers['server'] == 'uvicorn' and
-            response.headers['date'] == 'over-ridden')
+    assert (
+        response.headers["server"] == "uvicorn"
+        and response.headers["date"] == "over-ridden"
+    )
 
     thread.join()
 
 
 def test_add_additional_header():
     config = Config(
-        app=App, loop="asyncio", limit_max_requests=1,
-        custom_headers=[('X-Additional', 'new-value')])
+        app=App,
+        loop="asyncio",
+        limit_max_requests=1,
+        custom_headers=[("X-Additional", "new-value")],
+    )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get('http://127.0.0.1:8000')
+    response = requests.get("http://127.0.0.1:8000")
 
-    assert (response.headers['x-additional'] == 'new-value' and
-            response.headers['server'] == 'uvicorn' and
-            response.headers['date'])
+    assert (
+        response.headers["x-additional"] == "new-value"
+        and response.headers["server"] == "uvicorn"
+        and response.headers["date"]
+    )
 
     thread.join()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -124,8 +124,8 @@ class Config:
         self.ssl_cert_reqs = ssl_cert_reqs
         self.ssl_ca_certs = ssl_ca_certs
         self.ssl_ciphers = ssl_ciphers
-        self._headers = headers if headers else []
-        self.headers = None  # type: List[Tuple[bytes, bytes]]
+        self.headers = headers if headers else []  # type: List[str]
+        self.encoded_headers = None  # type: List[Tuple[bytes, bytes]]
 
         if self.ssl_keyfile or self.ssl_certfile:
             self.ssl = create_ssl_context(
@@ -151,9 +151,9 @@ class Config:
 
         encoded_headers = [
             (key.lower().encode("latin1"), value.encode("latin1"))
-            for key, value in self._headers
+            for key, value in self.headers
         ]
-        self.headers = (
+        self.encoded_headers = (
             encoded_headers
             if b"server" in dict(encoded_headers)
             else [(b"server", b"uvicorn")] + encoded_headers

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -92,6 +92,7 @@ class Config:
         ssl_cert_reqs=ssl.CERT_NONE,
         ssl_ca_certs=None,
         ssl_ciphers="TLSv1",
+        custom_headers=None,
     ):
         self.app = app
         self.host = host
@@ -139,6 +140,11 @@ class Config:
             self.reload_dirs = sys.path
         else:
             self.reload_dirs = reload_dirs
+
+        if custom_headers is None:
+            self.custom_headers = []
+        else:
+            self.custom_headers = custom_headers
 
         self.loaded = False
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -381,10 +381,10 @@ class Server:
         # Update the default headers, once per second.
         if counter % 10 == 0:
             current_time = time.time()
-            current_date = formatdate(current_time, usegmt=True)
+            current_date = formatdate(current_time, usegmt=True).encode()
             self.server_state.default_headers = [
-                (b"date", current_date.encode("latin1"))
-            ] + self.config.headers
+                (b"date", current_date)
+            ] + self.config.encoded_headers
 
         # Callback to `callback_notify` once every `timeout_notify` seconds.
         if self.config.callback_notify is not None:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -182,6 +182,12 @@ HANDLED_SIGNALS = (
     help="Ciphers to use (see stdlib ssl module's)",
     show_default=True,
 )
+@click.option(
+    "--default-header",
+    "custom_headers",
+    multiple=True,
+    help="Specify custom default HTTP response headers as a Name:Value pair",
+)
 def main(
     app,
     host: str,
@@ -210,6 +216,7 @@ def main(
     ssl_cert_reqs: int,
     ssl_ca_certs: str,
     ssl_ciphers: str,
+    custom_headers: typing.List[str],
 ):
     sys.path.insert(0, ".")
 
@@ -241,6 +248,8 @@ def main(
         "ssl_cert_reqs": ssl_cert_reqs,
         "ssl_ca_certs": ssl_ca_certs,
         "ssl_ciphers": ssl_ciphers,
+        "custom_headers": list(
+            [custom_header.split(':') for custom_header in custom_headers])
     }
     run(**kwargs)
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -249,7 +249,8 @@ def main(
         "ssl_ca_certs": ssl_ca_certs,
         "ssl_ciphers": ssl_ciphers,
         "custom_headers": list(
-            [custom_header.split(':') for custom_header in custom_headers])
+            [custom_header.split(":") for custom_header in custom_headers]
+        ),
     }
     run(**kwargs)
 
@@ -454,24 +455,22 @@ def default_headers(config: Config) -> typing.List[typing.Tuple[bytes, bytes]]:
     for header in config.custom_headers:
         name, value = header[0], header[1]
 
-        if name.lower() == 'server':
+        if name.lower() == "server":
             other_servers.append(value.encode())
 
-        elif name.lower() == 'date':
+        elif name.lower() == "date":
             current_date = value.encode()
 
         else:
             other_headers.append((name.lower().encode(), value.encode()))
 
     server_headers = (
-        list([(b'server', value) for value in other_servers])
-        if other_servers else [(b'server', b'uvicorn')])
+        list([(b"server", value) for value in other_servers])
+        if other_servers
+        else [(b"server", b"uvicorn")]
+    )
 
-    return [
-        *server_headers,
-        (b'date', bytes(current_date)),
-        *other_headers,
-    ]
+    return [*server_headers, (b"date", bytes(current_date)), *other_headers]
 
 
 if __name__ == "__main__":

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from gunicorn.workers.base import Worker
-
 from uvicorn.config import Config
 from uvicorn.main import Server
 


### PR DESCRIPTION
As per issue #243, this PR allows a user to programmatically, or, through the passing of CLI arguments, modify the default HTTP response headers that uvicorn sends out. In the case of the `Server` header, user specified values will over-ride the default value of _uvicorn_. If multiple `Server` header values are passed, then they will all be kept and will over-ride the default value as well.

The progammatic method of specifying default server headers is to pass a list of tuples to the `Config` class instantiation under the kwarg `headers` like so:

```python
config = Config(
    app=App, headers=[('Server', 'Cool Name'), ('X-Candy', 'Is Yummy')])
```

This also introduces a new CLI argument named `--header`. This argument takes a single argument, which is a header name/value pair delineated by a `:`. IE: `uvicorn --header Server:Coolness`. This argument can be passed multiple times to supply multiple over-riding headers.