### PR TITLE
Support --interface [auto|asgi3|asgi2|wsgi]

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,8 +45,9 @@ Options:
                                   WebSocket protocol implementation.
                                   [default: auto]
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
-  --wsgi                          Use WSGI as the application interface,
-                                  instead of ASGI.
+  --interface [auto|asgi3|agsi2|wsgi]
+                                  Select ASGI3, ASGI2, or WSGI as the
+                                  application interface.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]
   --no-access-log                 Disable access log.

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,8 +92,9 @@ Options:
                                   WebSocket protocol implementation.
                                   [default: auto]
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
-  --wsgi                          Use WSGI as the application interface,
-                                  instead of ASGI.
+  --interface [auto|asgi3|agsi2|wsgi]
+                                  Select ASGI3, ASGI2, or WSGI as the
+                                  application interface.
   --log-level [critical|error|warning|info|debug]
                                   Log level.  [default: info]
   --no-access-log                 Disable access log.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -39,7 +39,9 @@ equivalent keyword arguments, eg. `uvicorn.run(App, port=5000, debug=True, acces
 
 ## Application Interface
 
-* `--wsgi` - Use WSGI as the application interface rather than ASGI. Note that WSGI mode always disables WebSocket support, as it is not supported by the WSGI interface.
+* `--interface` - Select ASGI3, ASGI2, or WSGI as the application interface.
+Note that WSGI mode always disables WebSocket support, as it is not supported by the WSGI interface.
+**Options:** *'auto', 'asgi3', 'asgi2', 'wsgi'.* **Default:** *'auto'*.
 
 ## HTTP
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -4,6 +4,7 @@ import ssl
 import sys
 
 from uvicorn.importer import ImportFromStringError, import_from_string
+from uvicorn.middleware.asgi3 import ASGI3Middleware
 from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -37,7 +38,7 @@ LOOP_SETUPS = {
     "asyncio": "uvicorn.loops.asyncio:asyncio_setup",
     "uvloop": "uvicorn.loops.uvloop:uvloop_setup",
 }
-INTERFACES = set(["asgi", "wsgi"])
+INTERFACES = set(["asgi3", "asgi2", "wsgi"])
 
 
 def get_logger(log_level):
@@ -167,6 +168,9 @@ class Config:
         if self.interface == "wsgi":
             self.loaded_app = WSGIMiddleware(self.loaded_app)
             self.ws_protocol_class = None
+        elif self.interface == "asgi3":
+            self.loaded_app = ASGI3Middleware(self.loaded_app)
+
         if self.debug:
             self.loaded_app = DebugMiddleware(self.loaded_app)
         if self.logger_instance.level <= logging.DEBUG:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -173,7 +173,8 @@ class Config:
             elif inspect.isfunction(self.loaded_app):
                 use_asgi_3 = asyncio.iscoroutinefunction(self.loaded_app)
             else:
-                use_asgi_3 = asyncio.iscoroutinefunction(self.loaded_app.__call__)
+                call = getattr(self.loaded_app, '__call__', None)
+                use_asgi_3 = asyncio.iscoroutinefunction(call)
             self.interface = "asgi3" if use_asgi_3 else "asgi2"
 
         if self.interface == "wsgi":

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -169,7 +169,7 @@ class Config:
 
         if self.interface == "auto":
             if inspect.isclass(self.loaded_app):
-                use_asgi_3 = hasattr(self.loaded_app, '__await__')
+                use_asgi_3 = hasattr(self.loaded_app, "__await__")
             elif inspect.isfunction(self.loaded_app):
                 use_asgi_3 = asyncio.iscoroutinefunction(self.loaded_app)
             else:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -37,6 +37,7 @@ LOOP_SETUPS = {
     "asyncio": "uvicorn.loops.asyncio:asyncio_setup",
     "uvloop": "uvicorn.loops.uvloop:uvloop_setup",
 }
+INTERFACES = set(["asgi", "wsgi"])
 
 
 def get_logger(log_level):
@@ -74,7 +75,7 @@ class Config:
         log_level="info",
         logger=None,
         access_log=True,
-        wsgi=False,
+        interface="asgi",
         debug=False,
         reload=False,
         reload_dirs=None,
@@ -105,7 +106,7 @@ class Config:
         self.log_level = log_level
         self.logger = logger
         self.access_log = access_log
-        self.wsgi = wsgi
+        self.interface = interface
         self.debug = debug
         self.reload = reload
         self.workers = workers
@@ -163,7 +164,7 @@ class Config:
             self.logger_instance.error("Error loading ASGI app. %s" % exc)
             sys.exit(1)
 
-        if self.wsgi:
+        if self.interface == "wsgi":
             self.loaded_app = WSGIMiddleware(self.loaded_app)
             self.ws_protocol_class = None
         if self.debug:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -173,7 +173,7 @@ class Config:
             elif inspect.isfunction(self.loaded_app):
                 use_asgi_3 = asyncio.iscoroutinefunction(self.loaded_app)
             else:
-                call = getattr(self.loaded_app, '__call__', None)
+                call = getattr(self.loaded_app, "__call__", None)
                 use_asgi_3 = asyncio.iscoroutinefunction(call)
             self.interface = "asgi3" if use_asgi_3 else "asgi2"
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -102,8 +102,8 @@ HANDLED_SIGNALS = (
 @click.option(
     "--interface",
     type=INTERFACE_CHOICES,
-    default="asgi",
-    help="Select ASGI or WSGI as the application interface.",
+    default="asgi2",
+    help="Select ASGI2, ASGI3, or WSGI as the application interface.",
 )
 @click.option(
     "--log-level",

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -102,8 +102,8 @@ HANDLED_SIGNALS = (
 @click.option(
     "--interface",
     type=INTERFACE_CHOICES,
-    default="asgi2",
-    help="Select ASGI2, ASGI3, or WSGI as the application interface.",
+    default="auto",
+    help="Select ASGI3, ASGI2, or WSGI as the application interface.",
 )
 @click.option(
     "--log-level",

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -16,6 +16,7 @@ from uvicorn.config import (
     LOG_LEVELS,
     LOOP_SETUPS,
     WS_PROTOCOLS,
+    INTERFACES,
     Config,
     get_logger,
 )
@@ -26,6 +27,7 @@ HTTP_CHOICES = click.Choice(HTTP_PROTOCOLS.keys())
 WS_CHOICES = click.Choice(WS_PROTOCOLS.keys())
 LIFESPAN_CHOICES = click.Choice(LIFESPAN.keys())
 LOOP_CHOICES = click.Choice(LOOP_SETUPS.keys())
+INTERFACE_CHOICES = click.Choice(INTERFACES)
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
@@ -98,10 +100,10 @@ HANDLED_SIGNALS = (
     show_default=True,
 )
 @click.option(
-    "--wsgi",
-    is_flag=True,
-    default=False,
-    help="Use WSGI as the application interface, instead of ASGI.",
+    "--interface",
+    type=INTERFACE_CHOICES,
+    default="asgi",
+    help="Select ASGI or WSGI as the application interface.",
 )
 @click.option(
     "--log-level",
@@ -192,7 +194,7 @@ def main(
     http: str,
     ws: str,
     lifespan: str,
-    wsgi: bool,
+    interface: str,
     debug: bool,
     reload: bool,
     reload_dirs: typing.List[str],
@@ -225,7 +227,7 @@ def main(
         "lifespan": lifespan,
         "log_level": log_level,
         "access_log": not no_access_log,
-        "wsgi": wsgi,
+        "interface": interface,
         "debug": debug,
         "reload": reload,
         "reload_dirs": reload_dirs if reload_dirs else None,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -12,11 +12,11 @@ import click
 
 from uvicorn.config import (
     HTTP_PROTOCOLS,
+    INTERFACES,
     LIFESPAN,
     LOG_LEVELS,
     LOOP_SETUPS,
     WS_PROTOCOLS,
-    INTERFACES,
     Config,
     get_logger,
 )

--- a/uvicorn/middleware/asgi3.py
+++ b/uvicorn/middleware/asgi3.py
@@ -1,0 +1,12 @@
+import functools
+
+
+class ASGI3Middleware:
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, scope):
+        return functools.partial(self.asgi, scope=scope)
+
+    async def asgi(self, receive, send, scope):
+        await self.app(scope, receive, send)


### PR DESCRIPTION
Switches `--wsgi` to a more generic `--interface`.
Adds support for `--interface [auto|asgi3|asgi2|wsgi]`.
Since it'll stick with asgi2 for existing cases I don't see any reason not to get this in pre-emptively.

We'd need to jump to 0.6 for this, since it changes the programmatic API: `wsgi=True` to `interface="wsgi"` and the command line API `--wsgi` to `--interface wsgi`


```python
import uvicorn


async def app(scope, receive, send):
    assert scope['type'] == 'http'
    await send({
        'type': 'http.response.start',
        'status': 200,
        'headers': [
            [b'content-type', b'text/plain'],
        ]
    })
    await send({
        'type': 'http.response.body',
        'body': b'Hello, world!',
    })


if __name__ == "__main__":
    uvicorn.run(app)
```

See https://github.com/django/asgiref/issues/78 and https://github.com/django/asgiref/pull/80