### PR TITLE
Changed reload check time to 1 sec from 100ms

### DIFF
--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -34,7 +34,7 @@ class StatReload:
         process.start()
 
         while process.is_alive() and not self.should_exit:
-            time.sleep(0.1)
+            time.sleep(1)
             if self.should_restart():
                 self.clear()
                 os.kill(process.pid, signal.SIGTERM)

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -34,7 +34,7 @@ class StatReload:
         process.start()
 
         while process.is_alive() and not self.should_exit:
-            time.sleep(1)
+            time.sleep(.300)
             if self.should_restart():
                 self.clear()
                 os.kill(process.pid, signal.SIGTERM)

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -34,7 +34,7 @@ class StatReload:
         process.start()
 
         while process.is_alive() and not self.should_exit:
-            time.sleep(.3)
+            time.sleep(0.3)
             if self.should_restart():
                 self.clear()
                 os.kill(process.pid, signal.SIGTERM)

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -34,7 +34,7 @@ class StatReload:
         process.start()
 
         while process.is_alive() and not self.should_exit:
-            time.sleep(.300)
+            time.sleep(.3)
             if self.should_restart():
                 self.clear()
                 os.kill(process.pid, signal.SIGTERM)


### PR DESCRIPTION
Every 100ms seemed too fast and unnecessarily adding CPU load when debugging is turned on. If 1000ms is too much, maybe 500ms?

This is in response to #338