### PR TITLE
main.py imports code before eventloop starts running

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -300,6 +300,8 @@ class Server:
 
     def run(self, sockets=None, shutdown_servers=True):
         self.config.setup_event_loop()
+        if not self.config.loaded:
+            self.config.load()
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.serve(sockets=sockets))
 


### PR DESCRIPTION
Before this patch there was an inconsistency where if you ran uvicorn
from the CLI versus programmatically the eventloop would either be or
not be running when the code was imported. It is generally good practice
to make sure that the event loop isn't running when code is imported
since async code can only be run at import time using the
loop.run_until_complete(...) command which requires the event loop to
not be running.

This patch makes sure that the code is loaded after the event loop is
configured, but before it starts running. This allows for consistent
behavior across deployment options.

Solves: https://github.com/encode/uvicorn/issues/346