### PR TITLE
Add support for lifespan.startup.failed

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -122,20 +122,23 @@ def test_lifespan_on_with_error():
 
 
 @pytest.mark.parametrize("mode", ("auto", "on"))
-def test_lifespan_with_failed_startup(mode):
+@pytest.mark.parametrize("raise_exception", (True, False))
+def test_lifespan_with_failed_startup(mode, raise_exception):
     async def app(scope, receive, send):
         message = await receive()
         assert message["type"] == "lifespan.startup"
         await send({"type": "lifespan.startup.failed"})
-        # App should be able to re-raise an exception if startup failed.
-        raise RuntimeError()
+        if raise_exception:
+            # App should be able to re-raise an exception if startup failed.
+            raise RuntimeError()
 
     async def test():
         config = Config(app=app, lifespan=mode)
         lifespan = LifespanOn(config)
 
         await lifespan.startup()
-        assert lifespan.error_occured
+        assert lifespan.startup_failed
+        assert lifespan.error_occured is raise_exception
         assert lifespan.should_exit
         await lifespan.shutdown()
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -126,9 +126,9 @@ def test_lifespan_with_failed_startup(mode):
     async def app(scope, receive, send):
         message = await receive()
         assert message["type"] == "lifespan.startup"
-        exc = RuntimeError("Failed")
-        await send({"type": "lifespan.startup.failed", "message": str(exc)})
-        raise exc
+        await send({"type": "lifespan.startup.failed"})
+        # App should be able to re-raise an exception if startup failed.
+        raise RuntimeError()
 
     async def test():
         config = Config(app=app, lifespan=mode)

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -126,13 +126,16 @@ def test_lifespan_with_failed_startup(mode):
     async def app(scope, receive, send):
         message = await receive()
         assert message["type"] == "lifespan.startup"
-        await send({"type": "lifespan.startup.failed", "message": "Failed"})
+        exc = RuntimeError("Failed")
+        await send({"type": "lifespan.startup.failed", "message": str(exc)})
+        raise exc
 
     async def test():
         config = Config(app=app, lifespan=mode)
         lifespan = LifespanOn(config)
 
         await lifespan.startup()
+        assert lifespan.error_occured
         assert lifespan.should_exit
         await lifespan.shutdown()
 

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -73,10 +73,9 @@ class LifespanOn:
             assert not self.startup_event.is_set(), STATE_TRANSITION_ERROR
             assert not self.shutdown_event.is_set(), STATE_TRANSITION_ERROR
             self.startup_event.set()
-
+            self.startup_failed = True
             if message.get("message"):
                 self.logger.error(message["message"])
-            self.startup_failed = True
 
         elif message["type"] == "lifespan.shutdown.complete":
             assert self.startup_event.is_set(), STATE_TRANSITION_ERROR

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -74,7 +74,7 @@ class LifespanOn:
             assert not self.shutdown_event.is_set(), STATE_TRANSITION_ERROR
             self.startup_event.set()
 
-            if message["message"]:
+            if message.get("message", ""):
                 self.logger.error(message["message"])
             self.error_occured = True
             self.should_exit = True

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -74,7 +74,7 @@ class LifespanOn:
             assert not self.shutdown_event.is_set(), STATE_TRANSITION_ERROR
             self.startup_event.set()
 
-            if message.get("message", ""):
+            if message.get("message"):
                 self.logger.error(message["message"])
             self.error_occured = True
             self.should_exit = True


### PR DESCRIPTION
This PR implements this part of the [ASGI spec](https://asgi.readthedocs.io/en/latest/specs/lifespan.html#scope):

> If you want to log an error that occurred during lifespan startup and prevent the server from starting, then send back `lifespan.startup.failed` instead.

and helps with https://github.com/encode/starlette/issues/486.

Unless I'm mistaken, contrary to what was mentioned in #333 uvicorn does not react to `lifespan.startup.failed` events yet.

It's the first time I dive into the lifespan internals, so very keen for any feedback on the code and tests. :+1: