### PR TITLE
Add extra context to access log records

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -435,6 +435,7 @@ class RequestResponseCycle:
                     self.scope.get("root_path", "") + self.scope["path"],
                     self.scope["http_version"],
                     status_code,
+                    extra={"status_code": status_code, "scope": self.scope},
                 )
 
             # Write response status line and headers

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -434,6 +434,7 @@ class RequestResponseCycle:
                     self.scope.get("root_path", "") + self.scope["path"],
                     self.scope["http_version"],
                     status_code,
+                    extra={"status_code": status_code, "scope": self.scope},
                 )
 
             # Write response status line and headers


### PR DESCRIPTION
This uses the `extra` kwarg ([documented here](https://docs.python.org/3/library/logging.html#logging.Logger.debug)) to pass additional information which can be used by a logging handler.

We plan to use this in a log handler to produce structured (LDJSON) logs.