### PR TITLE
Do not unquote path

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -1,7 +1,6 @@
 import asyncio
 import http
 import logging
-from urllib.parse import unquote
 
 import h11
 
@@ -182,7 +181,7 @@ class H11Protocol(asyncio.Protocol):
                     "scheme": self.scheme,
                     "method": event.method.decode("ascii"),
                     "root_path": self.root_path,
-                    "path": unquote(path.decode("ascii")),
+                    "path": path.decode("ascii"),
                     "query_string": query_string,
                     "headers": self.headers,
                 }

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -1,7 +1,6 @@
 import asyncio
 import http
 import logging
-import urllib
 
 import httptools
 
@@ -194,8 +193,6 @@ class HttpToolsProtocol(asyncio.Protocol):
         method = self.parser.get_method()
         parsed_url = httptools.parse_url(url)
         path = parsed_url.path.decode("ascii")
-        if "%" in path:
-            path = urllib.parse.unquote(path)
         self.url = url
         self.expect_100_continue = False
         self.headers = []


### PR DESCRIPTION
If `/foo%2Fbar` is requested, it should be passed on like that.

It is the responsibility of the app to do any encoding (if wanted), and
currently prevents to get the raw value.

Found only https://github.com/encode/uvicorn/commit/b420242ab7e5336cfca8a8bd16795e0ab21af889 quickly in this regard.