### PR TITLE
Fix reload with custom logger

### DIFF
--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -1,13 +1,11 @@
 import os
 import time
+import logging
 from pathlib import Path
 
 from uvicorn.config import Config
+from uvicorn.main import Server
 from uvicorn.supervisors import StatReload
-
-
-def no_op():
-    pass
 
 
 def wait_for_reload(reloader, until, update_file):
@@ -22,9 +20,12 @@ def mock_signal(handle_exit):
 
 
 def test_statreload():
-    config = Config(app=None)
+    config = Config(app=None, logger=logging.getLogger())
+    server = Server(config)
+    type(server).run = lambda self: None
+
     reloader = StatReload(config)
-    reloader.run(no_op)
+    reloader.run(server.run)
 
 
 def test_reload_dirs(tmpdir):

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -114,8 +114,10 @@ class Config:
 
                 if getLogger(obj.name) is not obj:
                     import pickle
-                    raise pickle.PicklingError('logger cannot be pickled')
+
+                    raise pickle.PicklingError("logger cannot be pickled")
                 return getLogger, (obj.name,)
+
             type(logger).__reduce__ = types.MethodType(__reduce__, logger)
 
         self.app = app


### PR DESCRIPTION
It will resolve #328, backport `__reduce__` method from Python 3.7.

https://github.com/python/cpython/blob/29500737d45cbca9604d9ce845fb2acc3f531401/Lib/logging/__init__.py#L1730-L1736

```Python
    def __reduce__(self):
        # In general, only the root logger will not be accessible via its name.
        # However, the root logger's class has its own __reduce__ method.
        if getLogger(self.name) is not self:
            import pickle
            raise pickle.PicklingError('logger cannot be pickled')
        return getLogger, (self.name,)
```