### PR TITLE
Cast headers to list whichever iterable it is (list, tuple, other)

### DIFF
--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -424,7 +424,7 @@ class RequestResponseCycle:
             self.waiting_for_100_continue = False
 
             status_code = message["status"]
-            headers = self.default_headers + message.get("headers", [])
+            headers = self.default_headers + list(message.get("headers", []))
 
             if self.access_log:
                 self.logger.info(


### PR DESCRIPTION
[In reference to this issue](https://github.com/encode/uvicorn/issues/366)

Uvicorn should be fine with just any iterable.

Closes #366