### PR TITLE
Implement scope["raw_path"] for both HTTP and websockets

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -58,6 +58,10 @@ FINISH_POST_REQUEST = b'{"hello": "world"}'
 
 HTTP10_GET_REQUEST = b"\r\n".join([b"GET / HTTP/1.0", b"Host: example.org", b"", b""])
 
+GET_REQUEST_WITH_RAW_PATH = b"\r\n".join(
+    [b"GET /one%2Ftwo HTTP/1.1", b"Host: example.org", b"", b""]
+)
+
 UPGRADE_REQUEST = b"\r\n".join(
     [
         b"GET / HTTP/1.1",
@@ -539,9 +543,7 @@ def test_raw_path(protocol_cls):
         await response(scope, receive, send)
 
     protocol = get_connected_protocol(app, protocol_cls, root_path="/app")
-    protocol.data_received(
-        b"\r\n".join([b"GET /one%2Ftwo HTTP/1.1", b"Host: example.org", b"", b""])
-    )
+    protocol.data_received(GET_REQUEST_WITH_RAW_PATH)
     protocol.loop.run_one()
     assert b"Done" in protocol.transport.buffer
 

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -532,10 +532,10 @@ def test_raw_path(protocol_cls):
     async def app(scope, receive, send):
         path = scope["path"]
         raw_path = scope.get("raw_path", None)
-        response = Response(
-            "Path: {}\nraw_path: {}".format(path, repr(raw_path)),
-            media_type="text/plain",
-        )
+        assert "/one/two" == path
+        assert b"/one%2Ftwo" == raw_path
+
+        response = Response("Done", media_type="text/plain")
         await response(scope, receive, send)
 
     protocol = get_connected_protocol(app, protocol_cls, root_path="/app")
@@ -543,10 +543,7 @@ def test_raw_path(protocol_cls):
         b"\r\n".join([b"GET /one%2Ftwo HTTP/1.1", b"Host: example.org", b"", b""])
     )
     protocol.loop.run_one()
-
-    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
-    assert b"Path: /one/two" in protocol.transport.buffer
-    assert b"raw_path: b'/one%2Ftwo'" in protocol.transport.buffer
+    assert b"Done" in protocol.transport.buffer
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -60,9 +60,8 @@ def run_server(app, protocol_cls, path="/"):
     protocol = functools.partial(H11Protocol, config=config, server_state=server_state)
     create_server_task = loop.create_server(protocol, host="127.0.0.1")
     server = loop.run_until_complete(create_server_task)
-    url = "ws://127.0.0.1:{port}{path}".format(
-        port=server.sockets[0].getsockname()[1], path=path
-    )
+    port = server.sockets[0].getsockname()[1]
+    url = "ws://127.0.0.1:{port}{path}".format(port=port, path=path)
     try:
         # Run the event loop in a new thread.
         thread = threading.Thread(target=run_loop, args=[loop])

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -52,7 +52,7 @@ def run_loop(loop):
 
 
 @contextmanager
-def run_server(app, protocol_cls):
+def run_server(app, protocol_cls, path="/"):
     asyncio.set_event_loop(None)
     loop = asyncio.new_event_loop()
     config = Config(app=app, ws=protocol_cls)
@@ -60,7 +60,10 @@ def run_server(app, protocol_cls):
     protocol = functools.partial(H11Protocol, config=config, server_state=server_state)
     create_server_task = loop.create_server(protocol, host="127.0.0.1")
     server = loop.run_until_complete(create_server_task)
-    url = "ws://127.0.0.1:%d/" % server.sockets[0].getsockname()[1]
+    url = "ws://127.0.0.1:{port}{path}" .format(
+        port=server.sockets[0].getsockname()[1],
+        path=path
+    )
     try:
         # Run the event loop in a new thread.
         thread = threading.Thread(target=run_loop, args=[loop])
@@ -151,6 +154,26 @@ def test_headers(protocol_cls):
         loop = asyncio.new_event_loop()
         is_open = loop.run_until_complete(open_connection(url))
         assert is_open
+        loop.close()
+
+
+@pytest.mark.parametrize("protocol_cls", WS_PROTOCOLS)
+def test_path_and_raw_path(protocol_cls):
+    class App(WebSocketResponse):
+        async def websocket_connect(self, message):
+            path = self.scope.get("path")
+            raw_path = self.scope.get("raw_path")
+            assert path == "/one/two"
+            assert raw_path == "/one%2Ftwo"
+            await self.send({"type": "websocket.accept"})
+
+    async def open_connection(url):
+        async with websockets.connect(url) as websocket:
+            return websocket.open
+
+    with run_server(App, protocol_cls=protocol_cls, path="/one%2Ftwo") as url:
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(open_connection(url))
         loop.close()
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -60,9 +60,8 @@ def run_server(app, protocol_cls, path="/"):
     protocol = functools.partial(H11Protocol, config=config, server_state=server_state)
     create_server_task = loop.create_server(protocol, host="127.0.0.1")
     server = loop.run_until_complete(create_server_task)
-    url = "ws://127.0.0.1:{port}{path}" .format(
-        port=server.sockets[0].getsockname()[1],
-        path=path
+    url = "ws://127.0.0.1:{port}{path}".format(
+        port=server.sockets[0].getsockname()[1], path=path
     )
     try:
         # Run the event loop in a new thread.

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -173,7 +173,7 @@ class H11Protocol(asyncio.Protocol):
 
             elif event_type is h11.Request:
                 self.headers = [(key.lower(), value) for key, value in event.headers]
-                path, _, query_string = event.target.partition(b"?")
+                raw_path, _, query_string = event.target.partition(b"?")
                 self.scope = {
                     "type": "http",
                     "http_version": event.http_version.decode("ascii"),
@@ -182,7 +182,8 @@ class H11Protocol(asyncio.Protocol):
                     "scheme": self.scheme,
                     "method": event.method.decode("ascii"),
                     "root_path": self.root_path,
-                    "path": unquote(path.decode("ascii")),
+                    "path": unquote(raw_path.decode("ascii")),
+                    "raw_path": raw_path,
                     "query_string": query_string,
                     "headers": self.headers,
                 }

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -193,7 +193,8 @@ class HttpToolsProtocol(asyncio.Protocol):
     def on_url(self, url):
         method = self.parser.get_method()
         parsed_url = httptools.parse_url(url)
-        path = parsed_url.path.decode("ascii")
+        raw_path = parsed_url.path
+        path = raw_path.decode("ascii")
         if "%" in path:
             path = urllib.parse.unquote(path)
         self.url = url
@@ -208,6 +209,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             "method": method.decode("ascii"),
             "root_path": self.root_path,
             "path": path,
+            "raw_path": raw_path,
             "query_string": parsed_url.query if parsed_url.query else b"",
             "headers": self.headers,
         }

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -99,6 +99,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             "client": self.client,
             "root_path": self.root_path,
             "path": unquote(path_portion),
+            "raw_path": path_portion,
             "query_string": query_string.encode("ascii"),
             "headers": asgi_headers,
             "subprotocols": subprotocols,

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -124,7 +124,7 @@ class WSProtocol(asyncio.Protocol):
         self.connect_event = event
         headers = [(b"host", event.host.encode())]
         headers += [(key.lower(), value) for key, value in event.extra_headers]
-        path, _, query_string = event.target.partition("?")
+        raw_path, _, query_string = event.target.partition("?")
         self.scope = {
             "type": "websocket",
             "http_version": "1.1",
@@ -132,7 +132,8 @@ class WSProtocol(asyncio.Protocol):
             "server": self.server,
             "client": self.client,
             "root_path": self.root_path,
-            "path": unquote(path),
+            "path": unquote(raw_path),
+            "raw_path": raw_path,
             "query_string": query_string.encode("ascii"),
             "headers": headers,
             "subprotocols": event.subprotocols,


### PR DESCRIPTION
As discussed in https://github.com/django/asgiref/issues/87 and implemented in https://github.com/django/asgiref/pull/92

The PR adding `raw_path` to the ASGI specification will hopefully be merging very shortly. This change to Uvicorn should be considered blocked until the specification has been updated.