### PR TITLE
Fixed uvicorn.run() example to use host= and port=

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -132,7 +132,7 @@ async def app(scope, receive, send):
     ...
 
 if __name__ == "__main__":
-    uvicorn.run(app, "127.0.0.1", 5000, log_level="info")
+    uvicorn.run(app, host="127.0.0.1", port=5000, log_level="info")
 ```
 
 ### Running with Gunicorn


### PR DESCRIPTION
The previous example gave me the following error:

    TypeError: run() takes 1 positional argument but 3 were given