### PR TITLE
Support AF_INET6 address family

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -88,7 +88,7 @@ class MockTransport:
             "sockname": self.sockname,
             "peername": self.peername,
             "sslcontext": self.sslcontext,
-        }[key]
+        }.get(key)
 
     def write(self, data):
         assert not self.closed

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -27,10 +27,14 @@ def test_get_local_addr_with_socket():
     transport = MockTransport({"socket": MockSocket(family=socket.AF_IPX)})
     assert get_local_addr(transport) == None
 
-    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET6, sockname=["::1", 123])})
+    transport = MockTransport(
+        {"socket": MockSocket(family=socket.AF_INET6, sockname=["::1", 123])}
+    )
     assert get_local_addr(transport) == ("::1", 123)
 
-    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET, sockname=["123.45.6.7", 123])})
+    transport = MockTransport(
+        {"socket": MockSocket(family=socket.AF_INET, sockname=["123.45.6.7", 123])}
+    )
     assert get_local_addr(transport) == ("123.45.6.7", 123)
 
 
@@ -38,10 +42,14 @@ def test_get_remote_addr_with_socket():
     transport = MockTransport({"socket": MockSocket(family=socket.AF_IPX)})
     assert get_remote_addr(transport) == None
 
-    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET6, peername=["::1", 123])})
+    transport = MockTransport(
+        {"socket": MockSocket(family=socket.AF_INET6, peername=["::1", 123])}
+    )
     assert get_remote_addr(transport) == ("::1", 123)
 
-    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET, peername=["123.45.6.7", 123])})
+    transport = MockTransport(
+        {"socket": MockSocket(family=socket.AF_INET, peername=["123.45.6.7", 123])}
+    )
     assert get_remote_addr(transport) == ("123.45.6.7", 123)
 
 

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -1,4 +1,18 @@
+import socket
 from uvicorn.protocols.utils import get_local_addr, get_remote_addr
+
+
+class MockSocket:
+    def __init__(self, family, peername=None, sockname=None):
+        self.peername = peername
+        self.sockname = sockname
+        self.family = family
+
+    def getpeername(self):
+        return self.peername
+
+    def getsockname(self):
+        return self.sockname
 
 
 class MockTransport:
@@ -6,7 +20,29 @@ class MockTransport:
         self.info = info
 
     def get_extra_info(self, info_type):
-        return self.info[info_type]
+        return self.info.get(info_type)
+
+
+def test_get_local_addr_with_socket():
+    transport = MockTransport({"socket": MockSocket(family=socket.AF_IPX)})
+    assert get_local_addr(transport) == None
+
+    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET6, sockname=["::1", 123])})
+    assert get_local_addr(transport) == ("::1", 123)
+
+    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET, sockname=["123.45.6.7", 123])})
+    assert get_local_addr(transport) == ("123.45.6.7", 123)
+
+
+def test_get_remote_addr_with_socket():
+    transport = MockTransport({"socket": MockSocket(family=socket.AF_IPX)})
+    assert get_remote_addr(transport) == None
+
+    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET6, peername=["::1", 123])})
+    assert get_remote_addr(transport) == ("::1", 123)
+
+    transport = MockTransport({"socket": MockSocket(family=socket.AF_INET, peername=["123.45.6.7", 123])})
+    assert get_remote_addr(transport) == ("123.45.6.7", 123)
 
 
 def test_get_local_addr():

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,24 +1,32 @@
 import socket
 
 
-def get_socket_addr(transport, remote):
-    socket_info = transport.get_extra_info("socket")
-    if remote:
+def get_remote_addr(transport):
+    socket_info = transport.get_extra_info("socket"). 
+    if socket_info is not None:
         info = socket_info.getpeername()
-    else:
-        info = socket_info.getsockname()
-    family = socket_info.family
-    if family in (socket.AF_INET, socket.AF_INET6):
+        family = socket_info.family
+        if family in (socket.AF_INET, socket.AF_INET6):
+            return (str(info[0]), int(info[1]))
+        return None
+    info = transport.get_extra_info("peername")
+    if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:
         return (str(info[0]), int(info[1]))
     return None
 
 
-def get_remote_addr(transport):
-    return get_socket_addr(transport, True)
-
-
 def get_local_addr(transport):
-    return get_socket_addr(transport, False)
+    socket_info = transport.get_extra_info("socket"). 
+    if socket_info is not None:
+        info = socket_info.getsockname()
+        family = socket_info.family
+        if family in (socket.AF_INET, socket.AF_INET6):
+            return (str(info[0]), int(info[1]))
+        return None
+    info = transport.get_extra_info("sockname")
+    if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:
+        return (str(info[0]), int(info[1]))
+    return None
 
 
 def is_ssl(transport):

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,15 +1,24 @@
-def get_remote_addr(transport):
-    info = transport.get_extra_info("peername")
-    if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:
+import socket
+
+
+def get_socket_addr(transport, remote):
+    socket_info = transport.get_extra_info("socket")
+    if remote:
+        info = socket_info.getpeername()
+    else:
+        info = socket_info.getsockname()
+    family = socket_info.family
+    if family in (socket.AF_INET, socket.AF_INET6):
         return (str(info[0]), int(info[1]))
     return None
+
+
+def get_remote_addr(transport):
+    return get_socket_addr(transport, True)
 
 
 def get_local_addr(transport):
-    info = transport.get_extra_info("sockname")
-    if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:
-        return (str(info[0]), int(info[1]))
-    return None
+    return get_socket_addr(transport, False)
 
 
 def is_ssl(transport):

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -2,7 +2,7 @@ import socket
 
 
 def get_remote_addr(transport):
-    socket_info = transport.get_extra_info("socket"). 
+    socket_info = transport.get_extra_info("socket")
     if socket_info is not None:
         info = socket_info.getpeername()
         family = socket_info.family
@@ -16,7 +16,7 @@ def get_remote_addr(transport):
 
 
 def get_local_addr(transport):
-    socket_info = transport.get_extra_info("socket"). 
+    socket_info = transport.get_extra_info("socket")
     if socket_info is not None:
         info = socket_info.getsockname()
         family = socket_info.family


### PR DESCRIPTION
Closes https://github.com/encode/uvicorn/issues/313 . 

As stated here https://docs.python.org/2/library/socket.html#socket.AF_INET6, "For AF_INET6 address family, a four-tuple (host, port, flowinfo, scopeid) is used", so there should be no possible problems with type conversion on row 12 of this PR. So I think, that there is no need for additional tests, already existing should be enough to cover this.