### PR TITLE
Fix usage of pytest.raises

### DIFF
--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -4,28 +4,28 @@ from uvicorn.importer import ImportFromStringError, import_from_string
 
 
 def test_invalid_format():
-    with pytest.raises(ImportFromStringError) as exc:
+    with pytest.raises(ImportFromStringError) as exc_info:
         import_from_string("example:")
     expected = 'Import string "example:" must be in format "<module>:<attribute>".'
-    assert expected in str(exc)
+    assert expected in str(exc_info.value)
 
 
 def test_invalid_module():
-    with pytest.raises(ImportFromStringError) as exc:
+    with pytest.raises(ImportFromStringError) as exc_info:
         import_from_string("module_does_not_exist:myattr")
     expected = 'Could not import module "module_does_not_exist".'
-    assert expected in str(exc)
+    assert expected in str(exc_info.value)
 
 
 def test_invalid_attr():
-    with pytest.raises(ImportFromStringError) as exc:
+    with pytest.raises(ImportFromStringError) as exc_info:
         import_from_string("tempfile:attr_does_not_exist")
     expected = 'Attribute "attr_does_not_exist" not found in module "tempfile".'
-    assert expected in str(exc)
+    assert expected in str(exc_info.value)
 
 
 def test_internal_import_error():
-    with pytest.raises(ImportError) as exc:
+    with pytest.raises(ImportError):
         import_from_string("tests.importer.raise_import_error:myattr")
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -323,9 +323,9 @@ def test_missing_handshake(protocol_cls):
 
     with run_server(App, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
-        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc:
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
             loop.run_until_complete(connect(url))
-        assert exc.value.status_code == 500
+        assert exc_info.value.status_code == 500
         loop.close()
 
 
@@ -343,9 +343,9 @@ def test_send_before_handshake(protocol_cls):
 
     with run_server(App, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
-        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc:
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
             loop.run_until_complete(connect(url))
-        assert exc.value.status_code == 500
+        assert exc_info.value.status_code == 500
         loop.close()
 
 
@@ -365,9 +365,9 @@ def test_duplicate_handshake(protocol_cls):
 
     with run_server(App, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
-        with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
+        with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
             loop.run_until_complete(connect(url))
-        assert exc.value.code == 1006
+        assert exc_info.value.code == 1006
         loop.close()
 
 
@@ -388,9 +388,9 @@ def test_asgi_return_value(protocol_cls):
 
     with run_server(app, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
-        with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
+        with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
             loop.run_until_complete(connect(url))
-        assert exc.value.code == 1006
+        assert exc_info.value.code == 1006
         loop.close()
 
 
@@ -414,9 +414,9 @@ def test_app_close(protocol_cls):
 
     with run_server(app, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
-        with pytest.raises(websockets.exceptions.ConnectionClosed) as exc:
+        with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
             loop.run_until_complete(websocket_session(url))
-        assert exc.value.code == 1000
+        assert exc_info.value.code == 1000
         loop.close()
 
 


### PR DESCRIPTION
We were using `pytest.raises` and relying on the str representation of the returned object, rather than the str representation of the exception itself. Their str representation changed in the latest release.