### PR TITLE
Fix windows OSError: [WinError 10022] An invalid argument was supplie…

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -345,17 +345,22 @@ class Server:
             # We use this when the server is run from a Gunicorn worker.
             self.servers = []
             for sock in sockets:
-                family = sock.family
-                host, port = sock.getsockname()
-                sock.close()
-                server = await loop.create_server(
-                    create_protocol, 
-                    host=host, 
-                    port=port, 
-                    family=family, 
-                    ssl=config.ssl,
-                    reuse_address=True
-                )
+                if os.name == 'nt':
+                    family = sock.family
+                    host, port = sock.getsockname()
+                    sock.close()
+                    server = await loop.create_server(
+                        create_protocol, 
+                        host=host, 
+                        port=port, 
+                        family=family, 
+                        ssl=config.ssl,
+                        reuse_address=True
+                    )
+                else:
+                    server = await loop.create_server(
+                        create_protocol, sock=sock, ssl=config.ssl
+                    )
                 self.servers.append(server)
 
         elif config.fd is not None:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -345,8 +345,16 @@ class Server:
             # We use this when the server is run from a Gunicorn worker.
             self.servers = []
             for sock in sockets:
+                family = sock.family
+                host, port = sock.getsockname()
+                sock.close()
                 server = await loop.create_server(
-                    create_protocol, sock=sock, ssl=config.ssl
+                    create_protocol, 
+                    host=host, 
+                    port=port, 
+                    family=family, 
+                    ssl=config.ssl,
+                    reuse_address=True
                 )
                 self.servers.append(server)
 


### PR DESCRIPTION
This solves the issue #342 of running multiple workers on Windows.

Specifically it avoid the sock.listen issue by closing the socket in the worker, and then letting asyncio.create_server reopen the socket using the same host, port and other configuration information from the inherited socket from the parent.

```
INFO: Started server process [36716]
INFO: Waiting for application startup.
Process Process-8:
Traceback (most recent call last):
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\multiprocessing\process.py", line 297, in _bootstrap
    self.run()
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\multiprocessing\process.py", line 99, in run
    self._target(*self._args, **self._kwargs)
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\site-packages\uvicorn\main.py", line 307, in run
    loop.run_until_complete(self.serve(sockets=sockets))
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\asyncio\base_events.py", line 584, in run_until_complete
    return future.result()
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\site-packages\uvicorn\main.py", line 322, in serve
    await self.startup(sockets=sockets)
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\site-packages\uvicorn\main.py", line 349, in startup
    create_protocol, sock=sock, ssl=config.ssl
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\asyncio\base_events.py", line 1397, in create_server
    server._start_serving()
  File "c:\ProgramData\anaconda3\envs\py37.test\lib\asyncio\base_events.py", line 287, in _start_serving
    sock.listen(self._backlog)
OSError: [WinError 10022] An invalid argument was supplied
INFO: Started server process [41732]
```