### PR TITLE
Pin 'websockets' to 7.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ h11
 # Optional
 httptools
 uvloop
-websockets>=6.0
+websockets==7.*
 wsproto==0.13.*
 
 # Testing

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
This PR pins websockets to 7.x, since various tests have started failing with 8.x, and the setup.py is *anyway* pinning it to `7.x`.

There appear to also be a number of failures on the windows build - anyone fancy digging into when and how those have started occuring?