### PR TITLE
Add config tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,12 +63,12 @@ Sflxx+6bI4XMh0AsZhgtdW4=
 
 @pytest.fixture(scope="function")
 def certfile_and_keyfile(tmp_path):
-    certfile = str(tmp_path / 'cert.pem')
-    with open(certfile, 'bw') as fout:
+    certfile = str(tmp_path / "cert.pem")
+    with open(certfile, "bw") as fout:
         fout.write(CERTIFICATE)
 
-    keyfile = str(tmp_path / 'key.pem')
-    with open(keyfile, 'bw') as fout:
+    keyfile = str(tmp_path / "key.pem")
+    with open(keyfile, "bw") as fout:
         fout.write(PRIVATE_KEY)
 
     return certfile, keyfile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,12 +63,12 @@ Sflxx+6bI4XMh0AsZhgtdW4=
 
 @pytest.fixture(scope="function")
 def certfile_and_keyfile(tmp_path):
-    certfile = tmp_path / "cert.pem"
-    with open(certfile, "bw") as fout:
+    certfile = str(tmp_path / 'cert.pem')
+    with open(certfile, 'bw') as fout:
         fout.write(CERTIFICATE)
 
-    keyfile = tmp_path / "key.pem"
-    with open(keyfile, "bw") as fout:
+    keyfile = str(tmp_path / 'key.pem')
+    with open(keyfile, 'bw') as fout:
         fout.write(PRIVATE_KEY)
 
     return certfile, keyfile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,17 +62,13 @@ Sflxx+6bI4XMh0AsZhgtdW4=
 
 
 @pytest.fixture(scope="function")
-def certfile_and_keyfile():
+def certfile_and_keyfile(tmp_path):
+    certfile = tmp_path / "cert.pem"
+    with open(certfile, "bw") as fout:
+        fout.write(CERTIFICATE)
 
-    certfile = tempfile.NamedTemporaryFile(suffix=".pem")
-    certfile.write(CERTIFICATE)
-    certfile.seek(0)
+    keyfile = tmp_path / "key.pem"
+    with open(keyfile, "bw") as fout:
+        fout.write(PRIVATE_KEY)
 
-    keyfile = tempfile.NamedTemporaryFile(suffix=".pem")
-    keyfile.write(PRIVATE_KEY)
-    keyfile.seek(0)
-
-    yield certfile, keyfile
-
-    certfile.close()
-    keyfile.close()
+    return certfile, keyfile

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -20,7 +20,7 @@ def mock_signal(handle_exit):
 
 def test_statreload(certfile_and_keyfile):
     certfile, keyfile = certfile_and_keyfile
-    config = Config(app=None, ssl_certfile=certfile.name, ssl_keyfile=keyfile.name)
+    config = Config(app=None, ssl_certfile=certfile, ssl_keyfile=keyfile)
 
     server = Server(config)
     type(server).run = lambda self: None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,3 +65,11 @@ def test_socket_bind():
     config.load()
 
     assert isinstance(config.bind_socket(), socket.socket)
+
+
+def test_ssl_config(certfile_and_keyfile):
+    certfile, keyfile = certfile_and_keyfile
+    config = Config(app=asgi_app, ssl_certfile=certfile.name, ssl_keyfile=keyfile.name)
+    config.load()
+
+    assert bool(config.is_ssl) is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,4 +72,4 @@ def test_ssl_config(certfile_and_keyfile):
     config = Config(app=asgi_app, ssl_certfile=certfile.name, ssl_keyfile=keyfile.name)
     config.load()
 
-    assert bool(config.is_ssl) is True
+    assert config.is_ssl is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,7 @@ def test_proxy_headers():
 
 def test_app_unimportable():
     config = Config(app="no.such:app")
-    with pytest.raises(ModuleNotFoundError):
+    with pytest.raises(ImportError):
         config.load()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,7 +69,7 @@ def test_socket_bind():
 
 def test_ssl_config(certfile_and_keyfile):
     certfile, keyfile = certfile_and_keyfile
-    config = Config(app=asgi_app, ssl_certfile=certfile.name, ssl_keyfile=keyfile.name)
+    config = Config(app=asgi_app, ssl_certfile=certfile, ssl_keyfile=keyfile)
     config.load()
 
     assert config.is_ssl is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,67 @@
+import logging
+import socket
+
+import pytest
+
+from uvicorn import protocols
+from uvicorn.config import Config
+from uvicorn.middleware.debug import DebugMiddleware
+from uvicorn.middleware.wsgi import WSGIMiddleware
+
+
+async def asgi_app():
+    pass
+
+
+def wsgi_app():
+    pass
+
+
+def test_debug_app():
+    config = Config(app=asgi_app, debug=True)
+    config.load()
+
+    assert config.debug is True
+    assert isinstance(config.loaded_app, DebugMiddleware)
+
+
+def test_wsgi_app():
+    config = Config(app=wsgi_app, interface="wsgi")
+    config.load()
+
+    assert isinstance(config.loaded_app, WSGIMiddleware)
+    assert config.interface == "wsgi"
+
+
+def test_proxy_headers():
+    config = Config(app=asgi_app, proxy_headers=True)
+    config.load()
+
+    assert config.proxy_headers is True
+
+
+def test_app_unimportable():
+    config = Config(app="no.such:app")
+    with pytest.raises(ModuleNotFoundError):
+        config.load()
+
+
+def test_concrete_http_class():
+    config = Config(app=asgi_app, http=protocols.http.h11_impl.H11Protocol)
+    config.load()
+    assert config.http_protocol_class is protocols.http.h11_impl.H11Protocol
+
+
+def test_logger():
+    logger = logging.getLogger("just-for-tests")
+    config = Config(app=asgi_app, logger=logger)
+    config.load()
+
+    assert config.logger is logger
+
+
+def test_socket_bind():
+    config = Config(app=asgi_app)
+    config.load()
+
+    assert isinstance(config.bind_socket(), socket.socket)

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -48,8 +48,8 @@ def test_run(certfile_and_keyfile):
         app=App,
         loop="asyncio",
         limit_max_requests=1,
-        ssl_keyfile=keyfile.name,
-        ssl_certfile=certfile.name,
+        ssl_keyfile=keyfile,
+        ssl_certfile=certfile,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -143,7 +143,7 @@ class Config:
 
     @property
     def is_ssl(self) -> bool:
-        return self.ssl_keyfile or self.ssl_certfile
+        return bool(self.ssl_keyfile or self.ssl_certfile)
 
     def load(self):
         assert not self.loaded


### PR DESCRIPTION
As mentioned in #102 there was a need for some more test coverage of the config class, which seems like a fairly lowing hanging fruit, possibly low enough that I could manage to pick it.

I used the latest codecov report of the class to see what lines was missing coverage and tried to target those as best I could. I went with the naive way of just asserting what the code returned, so it is not impossible (perhaps likely, even) that I am mistaken about the behaviour of the class.

Locally I have some failing tests in the `test_statreload.py` file, but as I have yet to make any changes to the code itself, I suspect there where there when I cloned the repo. I could have a look at what those are, but I have barely looked past the config class.