### PR TITLE
Raise uvloop version to 0.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
     "h11==0.8.*",
     "websockets==7.*",
     "httptools==0.0.13 ;" + env_marker,
-    "uvloop==0.12.* ;" + env_marker,
+    "uvloop==0.* ;" + env_marker,
 ]
 
 


### PR DESCRIPTION
uvloop 0.13.0 was released a few hours ago. Although it's not *needed* for uvicorn, it's nice for projects which do require the updated uvloop (for instance for better UDP performance) in the same virtualenv.

An alternative would be to loosen the versioning scheme.