### PR TITLE
Fixes for failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
     - if [ "$TRAVIS_OS_NAME" = "windows" ]; then
         choco install python3;
         export PATH=/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH;
-        python -m pip install -U click h11 wsproto==0.13.* websockets;
+        python -m pip install -U click h11 wsproto==0.13.* websockets==7.*;
         python -m pip install -U autoflake black codecov isort pytest pytest-cov requests;
       elif [ "$TRAVIS_PYTHON_VERSION" = "pypy3.5" ]; then
         pip install -U click h11 wsproto==0.13.*;

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -95,6 +95,8 @@ def test_invalid_upgrade(protocol_cls):
                 "missing sec-websocket-key header\n",
                 "missing sec-websocket-version header",  # websockets
                 "missing or empty sec-websocket-key header\n",  # wsproto
+                "failed to open a websocket connection: missing sec-websocket-key header.",
+                "failed to open a websocket connection: missing or empty sec-websocket-key header",
             ]
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -91,11 +91,11 @@ def test_invalid_upgrade(protocol_cls):
             pass  # ok, wsproto 0.13
         else:
             assert response.status_code == 400
-            assert response.text.lower() in [
-                "missing sec-websocket-key header\n",
+            assert response.text.lower().strip().rstrip(".") in [
+                "missing sec-websocket-key header",
                 "missing sec-websocket-version header",  # websockets
-                "missing or empty sec-websocket-key header\n",  # wsproto
-                "failed to open a websocket connection: missing sec-websocket-key header.",
+                "missing or empty sec-websocket-key header",  # wsproto
+                "failed to open a websocket connection: missing sec-websocket-key header",
                 "failed to open a websocket connection: missing or empty sec-websocket-key header",
             ]
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -91,10 +91,10 @@ def test_invalid_upgrade(protocol_cls):
             pass  # ok, wsproto 0.13
         else:
             assert response.status_code == 400
-            assert response.text in [
-                "Missing Sec-WebSocket-Key header\n",
-                "Missing Sec-WebSocket-Version header",  # websockets
-                "Missing or empty Sec-WebSocket-Key header\n",  # wsproto
+            assert response.text.lower() in [
+                "missing sec-websocket-key header\n",
+                "missing sec-websocket-version header",  # websockets
+                "missing or empty sec-websocket-key header\n",  # wsproto
             ]
 
 

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -24,7 +24,8 @@ class StatReload:
     @staticmethod
     def handle_fds(target, fd_stdin, **kwargs):
         """Handle stdin in subprocess for pdb."""
-        sys.stdin = os.fdopen(fd_stdin)
+        if fd_stdin is not None:
+            sys.stdin = os.fdopen(fd_stdin)
         target(**kwargs)
 
     def run(self, target, *args, **kwargs):
@@ -38,8 +39,13 @@ class StatReload:
 
         def get_subprocess():
             spawn = multiprocessing.get_context("spawn")
+            try:
+                fileno = sys.stdin.fileno()
+            except OSError:
+                fileno = None
+
             return spawn.Process(
-                target=self.handle_fds, args=(target, sys.stdin.fileno()), kwargs=kwargs
+                target=self.handle_fds, args=(target, fileno), kwargs=kwargs
             )
 
         process = get_subprocess()


### PR DESCRIPTION
Deal with failing test cases introduced by #397

(No, I'm not sure why I thought the build failures were unrelated)

* Fix for stdin redirection with reloader (for pdb.set_trace)
* Fix for failing windows builds due to unpinned dependency.