### PR TITLE
Parse WSGI ThreadPoolExecuter worker amount via parameter

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -89,6 +89,7 @@ class Config:
         workers=1,
         proxy_headers=False,
         root_path="",
+        thread_pool_worker=10,
         limit_concurrency=None,
         limit_max_requests=None,
         timeout_keep_alive=5,
@@ -120,6 +121,7 @@ class Config:
         self.workers = workers
         self.proxy_headers = proxy_headers
         self.root_path = root_path
+        self.thread_pool_worker = thread_pool_worker
         self.limit_concurrency = limit_concurrency
         self.limit_max_requests = limit_max_requests
         self.timeout_keep_alive = timeout_keep_alive
@@ -199,7 +201,7 @@ class Config:
             self.interface = "asgi3" if use_asgi_3 else "asgi2"
 
         if self.interface == "wsgi":
-            self.loaded_app = WSGIMiddleware(self.loaded_app)
+            self.loaded_app = WSGIMiddleware(self.loaded_app, self.thread_pool_worker)
             self.ws_protocol_class = None
         elif self.interface == "asgi2":
             self.loaded_app = ASGI2Middleware(self.loaded_app)


### PR DESCRIPTION
I recently recognized that the ThreadPoolExecuter worker count for the WSGI-Middleware is hard set to 10, which means even though the worker_connections are set to e.g. 1000 the ThreadPoolExecuter limits my application to 10 sub threads per worker.
By parsing a new parameter into the config and furthermore to the WSGI-Middleware we can gain some more flexibility here, that every developer can decide how high the limit should be by himself.
This could become interesting for heavy I/O bounded functions.

This could look something like this ..

    from uvicorn.workers import UvicornWorker

    class MyAwesomeUvicornWorker(UvicornWorker):
        CONFIG_KWARGS = {"thread_pool_worker": 50}

.. and then call ..

    gunicorn -k MyAwesomeUvicornWorker

_Please correct me if I said something stupid or wrong :D_