### PR TITLE
If the WSGI task blows up, allow the sender task to shut down

### DIFF
--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -90,10 +90,12 @@ class WSGIResponder:
             self.executor, self.wsgi, environ, self.start_response
         )
         sender = self.loop.create_task(self.sender(send))
-        await asyncio.wait_for(wsgi, None)
-        self.send_queue.append(None)
-        self.send_event.set()
-        await asyncio.wait_for(sender, None)
+        try:
+            await asyncio.wait_for(wsgi, None)
+        finally:
+            self.send_queue.append(None)
+            self.send_event.set()
+            await asyncio.wait_for(sender, None)
         if self.exc_info is not None:
             raise self.exc_info[0].with_traceback(self.exc_info[1], self.exc_info[2])
 


### PR DESCRIPTION
This should hopefully fix the CI failures which were observed in PRs #399 and #406.

I have run the test suite 100 times and am no longer observing any failures.

Still, I'm not 100% confident I'm doing the right thing, so comments are welcome.