### PR TITLE
Extracting event loop reference to synchronise with Faust

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,21 @@ if __name__ == "__main__":
     uvicorn.run(app, host="127.0.0.1", port=5000, log_level="info")
 ```
 
+#### Extracting Event Loop to Provide to other Applications
+
+```python
+from fastapi import FastAPI
+from uvicorn import Uvicorn
+from faust import App
+
+app = FastAPI()
+uvicorn = Uvicorn(app, ...)
+faust_app = App(..., loop=uvicorn.get_event_loop())
+
+if __name__ == '__main__':
+    uvicorn.run()
+```
+
 ### Running with Gunicorn
 
 [Gunicorn][gunicorn] is a mature, fully featured server and process manager.

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,7 +144,7 @@ from faust import App
 
 app = FastAPI()
 uvicorn = Uvicorn(app, ...)
-faust_app = App(..., loop=uvicorn.get_event_loop())
+faust_app = App(..., loop=uvicorn.loop)
 
 if __name__ == '__main__':
     uvicorn.run()

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
-from uvicorn.main import Server, main, run
+from uvicorn.main import Server, main, run, Uvicorn
 
 __version__ = "0.8.6"
-__all__ = ["main", "run", "Config", "Server"]
+__all__ = ["main", "run", "Config", "Server", "Uvicorn"]

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -259,24 +259,7 @@ def main(
 
 
 def run(app, **kwargs):
-    config = Config(app, **kwargs)
-    server = Server(config=config)
-
-    if config.reload and not isinstance(app, str):
-        config.logger_instance.warn(
-            "auto-reload only works when app is passed as an import string."
-        )
-
-    if isinstance(app, str) and (config.debug or config.reload):
-        sock = config.bind_socket()
-        supervisor = StatReload(config)
-        supervisor.run(server.run, sockets=[sock])
-    elif config.workers > 1:
-        sock = config.bind_socket()
-        supervisor = Multiprocess(config)
-        supervisor.run(server.run, sockets=[sock])
-    else:
-        server.run()
+    Uvicorn(app, **kwargs).run()
 
 
 class Uvicorn:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -272,11 +272,11 @@ class Uvicorn:
             self.config.logger_instance.warn(
                 "auto-reload only works when app is passed as an import string."
             )
-    
+
     @property
     def loop(self):
         return self.server.get_event_loop()
-    
+
     def run(self):
         if isinstance(self.app, str) and (self.config.debug or self.config.reload):
             sock = self.config.bind_socket()
@@ -313,7 +313,7 @@ class Server:
         self.last_notified = 0
         self.loop = None
         self.event_loop_setup = False
-    
+
     def setup_event_loop(self):
         self.config.setup_event_loop()
         self.event_loop_setup = True

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -295,12 +295,12 @@ class Uvicorn:
     
     def run(self):
         if isinstance(self.app, str) and (self.config.debug or self.config.reload):
-            sock = config.bind_socket()
+            sock = self.config.bind_socket()
             supervisor = StatReload(self.config)
             supervisor.run(self.server.run, sockets=[sock])
         elif self.config.workers > 1:
             sock = self.config.bind_socket()
-            supervisor = Multiprocess(config)
+            supervisor = Multiprocess(self.config)
             supervisor.run(self.server.run, sockets=[sock])
         else:
             self.server.run()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -326,9 +326,6 @@ class Server:
         return self.loop
 
     def run(self, sockets=None, shutdown_servers=True):
-        if not self.event_loop_setup:
-            self.setup_event_loop()
-        
         loop = self.get_event_loop()
         loop.run_until_complete(self.serve(sockets=sockets))
 


### PR DESCRIPTION
This PR is an attempt to add support for Kafka streaming library called Faust. 
The changes introduced are originally implemented by @gitavi, the idea is to have access to loop reference available from Uvicorn instance. Using that, it is then possible to run both Faust's consumers and producers within the same event loop with FastAPI using Uvicorn. 

Here are the main issues on corresponding Faust and FastAPI repositories:
• https://github.com/tiangolo/fastapi/issues/408
• https://github.com/robinhood/faust/issues/399

If there is a different approach on how to achieve it without exposing the loop, or a better way to refactor edit - any comments are welcome! 

Later on if this is merged and approved, I can also help contributing to writing a few documentation notes on integration with Faust and possibly other Kafka clients (I have also tested it with aiokafka!)