### PR TITLE
Fix for https://github.com/encode/uvicorn/issues/183

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -214,7 +214,7 @@ class Config:
         self.loaded = True
 
     def setup_event_loop(self):
-        if self.loop == 'manual':
+        if self.loop == "manual":
             # do not configure an event loop, as the user already configured it
             return
         loop_setup = import_from_string(LOOP_SETUPS[self.loop])

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -214,6 +214,9 @@ class Config:
         self.loaded = True
 
     def setup_event_loop(self):
+        if self.loop == 'manual':
+            # do not configure an event loop, as the user already configured it
+            return
         loop_setup = import_from_string(LOOP_SETUPS[self.loop])
         loop_setup()
 


### PR DESCRIPTION
Hi,
When running programmatically an application with uvicorn, as described in the existing issue #183; any event loop the user configured outside of uvicorn is ignored. This is a problem for example, when an http client is configured as part of the business logic / data access layers when preparing the application used by uvicorn. Currently this doesn't work because dependent coroutines are awaited by a different event loop.

This situation makes debugging impossible when running an application programmatically.

**Proposed solution**:
Support `"manual"` configuration setting for the event loop. If manual, no event loop is configured inside `config.py`, because it means the user already configured the event loop.

```python
import uvicorn
from server import app

uvicorn.run(app, host='127.0.0.1', port=44777, log_level='debug', loop='manual')
```

**Note:** I also took into consideration to check if the `loop` is already an instance of event loop, but I understand this option is not viable because uvicorn wants to support different frameworks (asyncio, trio, curio) - although I am not sure about this.