### PR TITLE
Reenabled black check in Python 3.7

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -13,10 +13,8 @@ set -x
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=uvicorn --cov=tests --cov-report=term-missing ${@}
 ${PREFIX}coverage html
 ${PREFIX}autoflake --recursive uvicorn tests
-if [ "${PYTHON_VERSION}" = '3.7' ]; then
-    echo "Skipping 'black' on 3.7. See issue https://github.com/ambv/black/issues/494"
-elif [ "${PYTHON_VERSION}" = '3.6' ]; then
-    ${PREFIX}black uvicorn tests --check
-elif [ "${PYTHON_VERSION}" = '3.5' ]; then
+if [ "${PYTHON_VERSION}" = '3.5' ]; then
     echo "Skipping black, unavailable on 3.5."
+else
+    ${PREFIX}black uvicorn tests --check
 fi


### PR DESCRIPTION
It will resolve #448 . uvicorn drops Python 3.5 since version 0.8.6. But pypy3.5 is still in our test matrix. We need to upgrade pypy3.5 to pypy3.6.