### PR TITLE
Support Config(loop='none')

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -37,6 +37,7 @@ LIFESPAN = {
     "off": "uvicorn.lifespan.off:LifespanOff",
 }
 LOOP_SETUPS = {
+    "none": None,
     "auto": "uvicorn.loops.auto:auto_loop_setup",
     "asyncio": "uvicorn.loops.asyncio:asyncio_setup",
     "uvloop": "uvicorn.loops.uvloop:uvloop_setup",
@@ -216,7 +217,8 @@ class Config:
 
     def setup_event_loop(self):
         loop_setup = import_from_string(LOOP_SETUPS[self.loop])
-        loop_setup()
+        if loop_setup is not None:
+            loop_setup()
 
     def bind_socket(self):
         sock = socket.socket()


### PR DESCRIPTION
Allows usage such as the following...

```python
from uvicorn import Config, Server

# Do some custom event loop setup here
...

# Run the server
config = Config(app=..., loop="none")  # Alternates are "auto", "asyncio", "uvloop", "iocp"
server = Server(config=config)
server.run()  # Or `await server.serve()` if we're already in an async context.
```