### PR TITLE
Drop shutdown_servers flag

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -301,12 +301,12 @@ class Server:
         self.force_exit = False
         self.last_notified = 0
 
-    def run(self, sockets=None, shutdown_servers=True):
+    def run(self, sockets=None):
         self.config.setup_event_loop()
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.serve(sockets=sockets))
 
-    async def serve(self, sockets=None, shutdown_servers=True):
+    async def serve(self, sockets=None):
         process_id = os.getpid()
 
         config = self.config
@@ -323,7 +323,7 @@ class Server:
         if self.should_exit:
             return
         await self.main_loop()
-        await self.shutdown(shutdown_servers=shutdown_servers)
+        await self.shutdown()
         self.logger.info("Finished server process [{}]".format(process_id))
 
     async def startup(self, sockets=None):
@@ -414,15 +414,14 @@ class Server:
             return self.server_state.total_requests >= self.config.limit_max_requests
         return False
 
-    async def shutdown(self, shutdown_servers=True):
+    async def shutdown(self):
         self.logger.info("Shutting down")
 
         # Stop accepting new connections.
-        if shutdown_servers:
-            for server in self.servers:
-                server.close()
-            for server in self.servers:
-                await server.wait_closed()
+        for server in self.servers:
+            server.close()
+        for server in self.servers:
+            await server.wait_closed()
 
         # Request shutdown on all existing connections.
         for connection in list(self.server_state.connections):


### PR DESCRIPTION
Drops the `.run(shutdown_servers=False)` flag.

It's not obvious why this API is available. We don't use it anyplace, it's not documented anyplace, and I don't see that it's obviously a piece of API that we ought to expose.