### PR TITLE
Clearer startup messaging

### DIFF
--- a/uvicorn/__main__.py
+++ b/uvicorn/__main__.py
@@ -1,5 +1,4 @@
 import uvicorn
 
-
 if __name__ == "__main__":
     uvicorn.main()

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -29,6 +29,8 @@ class LifespanOn:
         if self.startup_failed or (self.error_occured and self.config.lifespan == "on"):
             self.logger.error("Application startup failed. Exiting.")
             self.should_exit = True
+        else:
+            self.logger.info("Application startup complete.")
 
     async def shutdown(self):
         if self.error_occured:
@@ -36,6 +38,7 @@ class LifespanOn:
         self.logger.info("Waiting for application shutdown.")
         await self.receive_queue.put({"type": "lifespan.shutdown"})
         await self.shutdown_event.wait()
+        self.logger.info("Application shutdown complete.")
 
     async def main(self):
         try:

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from gunicorn.workers.base import Worker
+
 from uvicorn.config import Config
 from uvicorn.main import Server
 


### PR DESCRIPTION
Closes #450

```shell
$ uvicorn example:app
INFO: Started server process [86542]
INFO: Waiting for application startup.
INFO: Application startup complete.
INFO: Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
^C
INFO: Shutting down
INFO: Waiting for application shutdown.
INFO: Application shutdown complete.
INFO: Finished server process [86542]
```