### PR TITLE
Cleaner messaging when port binding fails.

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -225,7 +225,11 @@ class Config:
     def bind_socket(self):
         sock = socket.socket()
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((self.host, self.port))
+        try:
+            sock.bind((self.host, self.port))
+        except OSError as exc:
+            self.logger_instance.error(exc)
+            sys.exit(1)
         sock.set_inheritable(True)
 
         if platform.system() == "Windows" and (self.workers > 1 or self.should_reload):

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -368,9 +368,13 @@ class Server:
 
         else:
             # Standard case. Create a socket from a host/port pair.
-            server = await loop.create_server(
-                create_protocol, host=config.host, port=config.port, ssl=config.ssl
-            )
+            try:
+                server = await loop.create_server(
+                    create_protocol, host=config.host, port=config.port, ssl=config.ssl
+                )
+            except OSError as exc:
+                self.logger.error(exc)
+                sys.exit(1)
             protocol_name = "https" if config.ssl else "http"
             message = "Uvicorn running on %s://%s:%d (Press CTRL+C to quit)"
             self.logger.info(message % (protocol_name, config.host, config.port))

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -329,11 +329,6 @@ class Server:
     async def startup(self, sockets=None):
         config = self.config
 
-        await self.lifespan.startup()
-        if self.lifespan.should_exit:
-            self.should_exit = True
-            return
-
         create_protocol = functools.partial(
             config.http_protocol_class, config=config, server_state=self.server_state
         )
@@ -381,7 +376,11 @@ class Server:
             self.logger.info(message % (protocol_name, config.host, config.port))
             self.servers = [server]
 
-        self.started = True
+        await self.lifespan.startup()
+        if self.lifespan.should_exit:
+            self.should_exit = True
+        else:
+            self.started = True
 
     async def main_loop(self):
         counter = 0


### PR DESCRIPTION
Closes #435.

* Run application startup *after* port binding occurs.
* If port binding fails, exit with an error message, not an exception traceback, since this is an expected possible state.