### PR TITLE
Don't reconfigure logger on each access of config.logger_instance.

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -247,6 +247,6 @@ class Config:
 
     @property
     def logger_instance(self):
-        if self.logger is not None:
-            return self.logger
-        return get_logger(self.log_level)
+        if self.logger is None:
+            self.logger = get_logger(self.log_level)
+        return self.logger


### PR DESCRIPTION
Refs #357

I'm *only* addressing the "configuration applied multiple times" here, and *not* also the "cannot pickle logger instances in 3.6".

It's not clear to me that we're handling things in the right way here wrt. passing a logger instance. We can always just get the logger instance by logger.getLogger("uvicorn") - which is what we *ought* to be doing, rather than saving the object instance, and having it (fail) to pickle when multiprocessing/reloading is in play. Really what we *want* to be passing is just something like a logger *configuration*, rather than a logger *instance*.

Short version: I think the logging needs a more comprehensive review either way, but in the meantime lets *at least* fix the obvious error here.