### PR TITLE
Shutdown explicitly provided sockets cleanly

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -323,7 +323,7 @@ class Server:
         if self.should_exit:
             return
         await self.main_loop()
-        await self.shutdown()
+        await self.shutdown(sockets=sockets)
         self.logger.info("Finished server process [{}]".format(process_id))
 
     async def startup(self, sockets=None):
@@ -419,10 +419,12 @@ class Server:
             return self.server_state.total_requests >= self.config.limit_max_requests
         return False
 
-    async def shutdown(self):
+    async def shutdown(self, sockets=None):
         self.logger.info("Shutting down")
 
         # Stop accepting new connections.
+        for socket in sockets or []:
+            socket.close()
         for server in self.servers:
             server.close()
         for server in self.servers:

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -54,9 +54,7 @@ class UvicornWorker(Worker):
         self.config.app = self.wsgi
         server = Server(config=self.config)
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(
-            server.serve(sockets=self.sockets, shutdown_servers=False)
-        )
+        loop.run_until_complete(server.serve(sockets=self.sockets))
 
     async def callback_notify(self):
         self.notify()


### PR DESCRIPTION
We'd removed `shutdown_servers` in #457, but it was actually being using by the gunicorn worker class. This PR stops using it from the worker class, but still gives nice clean shutdowns without socket errors.