### PR TITLE
Add support for `--forwarded-allow-ips`

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -11,7 +11,7 @@ async def app(scope, receive, send):
     await response(scope, receive, send)
 
 
-app = ProxyHeadersMiddleware(app)
+app = ProxyHeadersMiddleware(app, trusted_hosts="*")
 
 
 def test_proxy_headers():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import pytest
 from uvicorn import protocols
 from uvicorn.config import Config
 from uvicorn.middleware.debug import DebugMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 
 
@@ -17,7 +18,7 @@ def wsgi_app():
 
 
 def test_debug_app():
-    config = Config(app=asgi_app, debug=True)
+    config = Config(app=asgi_app, debug=True, proxy_headers=False)
     config.load()
 
     assert config.debug is True
@@ -25,7 +26,7 @@ def test_debug_app():
 
 
 def test_wsgi_app():
-    config = Config(app=wsgi_app, interface="wsgi")
+    config = Config(app=wsgi_app, interface="wsgi", proxy_headers=False)
     config.load()
 
     assert isinstance(config.loaded_app, WSGIMiddleware)
@@ -33,10 +34,11 @@ def test_wsgi_app():
 
 
 def test_proxy_headers():
-    config = Config(app=asgi_app, proxy_headers=True)
+    config = Config(app=asgi_app)
     config.load()
 
     assert config.proxy_headers is True
+    assert isinstance(config.loaded_app, ProxyHeadersMiddleware)
 
 
 def test_app_unimportable():

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -11,27 +11,35 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 
 
 class ProxyHeadersMiddleware:
-    def __init__(self, app, num_proxies=1):
+    def __init__(self, app, trusted_hosts="127.0.0.1"):
         self.app = app
-        self.num_proxies = num_proxies
+        if isinstance(trusted_hosts, str):
+            self.trusted_hosts = [item.strip() for item in trusted_hosts.split(",")]
+        else:
+            self.trusted_hosts = trusted_hosts
+        self.always_trust = "*" in self.trusted_hosts
 
     async def __call__(self, scope, receive, send):
         if scope["type"] in ("http", "websocket"):
-            headers = dict(scope["headers"])
+            client_addr = scope.get("client")
+            client_host = client_addr[0] if client_addr else None
 
-            if b"x-forwarded-proto" in headers:
-                # Determine if the incoming request was http or https based on
-                # the X-Forwarded-Proto header.
-                x_forwarded_proto = headers[b"x-forwarded-proto"].decode("ascii")
-                scope["scheme"] = x_forwarded_proto.strip()
+            if self.always_trust or client_host in self.trusted_hosts:
+                headers = dict(scope["headers"])
 
-            if b"x-forwarded-for" in headers:
-                # Determine the client address from the last trusted IP in the
-                # X-Forwarded-For header. We've lost the connecting client's port
-                # information by now, so only include the host.
-                x_forwarded_for = headers[b"x-forwarded-for"].decode("ascii")
-                host = x_forwarded_for.split(",")[-self.num_proxies].strip()
-                port = 0
-                scope["client"] = (host, port)
+                if b"x-forwarded-proto" in headers:
+                    # Determine if the incoming request was http or https based on
+                    # the X-Forwarded-Proto header.
+                    x_forwarded_proto = headers[b"x-forwarded-proto"].decode("ascii")
+                    scope["scheme"] = x_forwarded_proto.strip()
 
-        await self.app(scope, receive, send)
+                if b"x-forwarded-for" in headers:
+                    # Determine the client address from the last trusted IP in the
+                    # X-Forwarded-For header. We've lost the connecting client's port
+                    # information by now, so only include the host.
+                    x_forwarded_for = headers[b"x-forwarded-for"].decode("ascii")
+                    host = x_forwarded_for.split(",")[-1].strip()
+                    port = 0
+                    scope["client"] = (host, port)
+
+        return await self.app(scope, receive, send)


### PR DESCRIPTION
We now support `--forwarded-allow-ips`, and default to populating it from the `FORWARDED_ALLOW_IPS` environment variable, or `"127.0.0.1"`.

This allows us to get the client https & host correct by default without having to determine if `--proxy-headers` should be set or not.