### PR TITLE
Include status phrase in access logs

### DIFF
--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -1,3 +1,4 @@
+import http
 import logging
 import sys
 
@@ -81,11 +82,17 @@ class AccessFormatter(ColourizedFormatter):
 
     def get_status_code(self, record):
         status_code = record.__dict__["status_code"]
+        try:
+            status_phrase = http.HTTPStatus(status_code).phrase
+        except ValueError:
+            status_phrase = ""
+        status_and_phrase = "%s %s" % (status_code, status_phrase)
+
         if self.use_colors:
-            default = lambda code: str(status_code)
+            default = lambda code: status_and_phrase
             func = self.status_code_colours.get(status_code // 100, default)
-            return func(status_code)
-        return str(status_code)
+            return func(status_and_phrase)
+        return status_and_phrase
 
     def formatMessage(self, record):
         scope = record.__dict__["scope"]


### PR DESCRIPTION
Include the HTTP status phrase for more friendly access logging.

![Screen Shot 2019-10-29 at 15 05 46](https://user-images.githubusercontent.com/647359/67780209-a9d93e00-fa5d-11e9-9209-106ff4bfda58.png)
