### PR TITLE
Update requirements for Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       python: "3.6"
     - os: linux
       python: "3.7"
+    - os: linux
+      python: "3.8"
 
 install:
     - if [ "$TRAVIS_OS_NAME" = "windows" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ h11
 
 # Optional
 httptools
-uvloop
+uvloop==0.14.0rc2
 websockets==8.*
 wsproto==0.13.*
 
 # Testing
 autoflake
-black; python_version >= '3.6'
+black
 codecov
 isort
 pytest

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ requirements = [
     "h11==0.8.*",
     "websockets==8.*",
     "httptools==0.0.13 ;" + env_marker,
-    "uvloop==0.* ;" + env_marker,
+    "uvloop==0.14.0rc2 ;" + env_marker,
 ]
 
 
@@ -63,7 +63,7 @@ setup(
     install_requires=requirements,
     data_files = [("", ["LICENSE.md"])],
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],


### PR DESCRIPTION
Since uvloop 0.14.0rc2 is now available, we can add 3.8 support.

We'll pin to a more generic version once 0.14 proper is released.

Closes #453.