### PR TITLE
Support --env-file

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -180,6 +180,7 @@ class Config:
 
         if env_file is not None:
             from dotenv import load_dotenv
+
             logger.info("Loading environment from '%s'", env_file)
             load_dotenv(dotenv_path=env_file)
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -50,13 +50,6 @@ LOOP_SETUPS = {
 }
 INTERFACES = ["auto", "asgi3", "asgi2", "wsgi"]
 
-try:
-    DEFAULT_WORKERS = int(os.environ.get("WEB_CONCURRENCY", 1))
-except ValueError:
-    DEFAULT_WORKERS = 1
-
-DEFAULT_FORWARDED_IPS = os.environ.get("FORWARDED_ALLOW_IPS", "127.0.0.1")
-
 
 # Fallback to 'ssl.PROTOCOL_SSLv23' in order to support Python < 3.5.3.
 SSL_PROTOCOL_VERSION = getattr(ssl, "PROTOCOL_TLS", ssl.PROTOCOL_SSLv23)
@@ -119,6 +112,7 @@ class Config:
         http="auto",
         ws="auto",
         lifespan="auto",
+        env_file=None,
         log_config=LOGGING_CONFIG,
         log_level=None,
         access_log=True,
@@ -126,9 +120,9 @@ class Config:
         debug=False,
         reload=False,
         reload_dirs=None,
-        workers=DEFAULT_WORKERS,
+        workers=None,
         proxy_headers=True,
-        forwarded_allow_ips=DEFAULT_FORWARDED_IPS,
+        forwarded_allow_ips=None,
         root_path="",
         limit_concurrency=None,
         limit_max_requests=None,
@@ -158,9 +152,9 @@ class Config:
         self.interface = interface
         self.debug = debug
         self.reload = reload
-        self.workers = workers
+        self.workers = workers or 1
         self.proxy_headers = proxy_headers
-        self.forwarded_allow_ips = forwarded_allow_ips
+        self.forwarded_allow_ips = forwarded_allow_ips or "127.0.0.1"
         self.root_path = root_path
         self.limit_concurrency = limit_concurrency
         self.limit_max_requests = limit_max_requests
@@ -176,13 +170,24 @@ class Config:
         self.headers = headers if headers else []  # type: List[str]
         self.encoded_headers = None  # type: List[Tuple[bytes, bytes]]
 
+        self.loaded = False
+        self.configure_logging()
+
         if reload_dirs is None:
             self.reload_dirs = sys.path
         else:
             self.reload_dirs = reload_dirs
 
-        self.loaded = False
-        self.configure_logging()
+        if env_file is not None:
+            from dotenv import load_dotenv
+            logger.info("Loading environment from '%s'", env_file)
+            load_dotenv(dotenv_path=env_file)
+
+        if workers is None and "WEB_CONCURRENCY" in os.environ:
+            self.workers = int(os.environ["WEB_CONCURRENCY"])
+
+        if forwarded_allow_ips is None and "FORWARDED_ALLOW_IPS" in os.environ:
+            self.forwarded_allow_ips = os.environ["FORWARDED_ALLOW_IPS"]
 
     @property
     def is_ssl(self) -> bool:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -13,8 +13,6 @@ from email.utils import formatdate
 import click
 
 from uvicorn.config import (
-    DEFAULT_FORWARDED_IPS,
-    DEFAULT_WORKERS,
     HTTP_PROTOCOLS,
     INTERFACES,
     LIFESPAN,
@@ -74,7 +72,7 @@ logger = logging.getLogger("uvicorn.error")
 )
 @click.option(
     "--workers",
-    default=DEFAULT_WORKERS,
+    default=None,
     type=int,
     help="Number of worker processes. Defaults to the $WEB_CONCURRENCY environment variable if available. Not valid with --reload.",
 )
@@ -114,6 +112,13 @@ logger = logging.getLogger("uvicorn.error")
     show_default=True,
 )
 @click.option(
+    "--env-file",
+    type=click.Path(exists=True),
+    default=None,
+    help="Environment configuration file.",
+    show_default=True,
+)
+@click.option(
     "--log-config",
     type=click.Path(exists=True),
     default=None,
@@ -142,7 +147,7 @@ logger = logging.getLogger("uvicorn.error")
 @click.option(
     "--forwarded-allow-ips",
     type=str,
-    default=DEFAULT_FORWARDED_IPS,
+    default=None,
     help="Comma seperated list of IPs to trust with proxy headers. Defaults to the $FORWARDED_ALLOW_IPS environment variable if available, or '127.0.0.1'.",
 )
 @click.option(
@@ -229,6 +234,7 @@ def main(
     reload: bool,
     reload_dirs: typing.List[str],
     workers: int,
+    env_file: str,
     log_config: str,
     log_level: str,
     access_log: bool,
@@ -258,6 +264,7 @@ def main(
         "http": http,
         "ws": ws,
         "lifespan": lifespan,
+        "env_file": env_file,
         "log_config": LOGGING_CONFIG if log_config is None else log_config,
         "log_level": log_level,
         "access_log": access_log,


### PR DESCRIPTION
Requires https://github.com/theskumar/python-dotenv

```shell
$ pip install python-dotenv
$ uvicorn example:app --env-file .env
INFO:	Loading environment from '.env'
INFO:	Started server process [73666]
INFO:	Uvicorn running on http://0.0.0.0:5000 (Press CTRL+C to quit)
...
```

Having the envfile loading available as part of the server run command, rather than in the codebase itself is cleaner, and means that it can eg. be omitted from the `Procfile`, but included if running `uvicorn` locally.