### PR TITLE
Add 'trace' log level

### DIFF
--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -1,9 +1,9 @@
-import logging
-
 import pytest
 
 from tests.client import TestClient
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
+
+TRACE_LOG_LEVEL = 5
 
 
 def test_message_logger(caplog):
@@ -12,15 +12,17 @@ def test_message_logger(caplog):
         await send({"type": "http.response.start", "status": 200, "headers": []})
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
-    caplog.set_level(logging.DEBUG, logger="uvicorn.error")
+    caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
+    caplog.set_level(TRACE_LOG_LEVEL)
+
     app = MessageLoggerMiddleware(app)
     client = TestClient(app)
     response = client.get("/")
     assert response.status_code == 200
     messages = [record.msg % record.args for record in caplog.records]
     assert sum(["ASGI [1] Started" in message for message in messages]) == 1
-    assert sum(["ASGI [1] Sent" in message for message in messages]) == 1
-    assert sum(["ASGI [1] Received" in message for message in messages]) == 2
+    assert sum(["ASGI [1] Send" in message for message in messages]) == 2
+    assert sum(["ASGI [1] Receive" in message for message in messages]) == 1
     assert sum(["ASGI [1] Completed" in message for message in messages]) == 1
     assert sum(["ASGI [1] Raised exception" in message for message in messages]) == 0
 
@@ -29,14 +31,15 @@ def test_message_logger_exc(caplog):
     async def app(scope, receive, send):
         raise RuntimeError()
 
-    caplog.set_level(logging.DEBUG, logger="uvicorn.error")
+    caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
+    caplog.set_level(TRACE_LOG_LEVEL)
     app = MessageLoggerMiddleware(app)
     client = TestClient(app)
     with pytest.raises(RuntimeError):
         client.get("/")
     messages = [record.msg % record.args for record in caplog.records]
     assert sum(["ASGI [1] Started" in message for message in messages]) == 1
-    assert sum(["ASGI [1] Sent" in message for message in messages]) == 0
-    assert sum(["ASGI [1] Received" in message for message in messages]) == 0
+    assert sum(["ASGI [1] Send" in message for message in messages]) == 0
+    assert sum(["ASGI [1] Receive" in message for message in messages]) == 0
     assert sum(["ASGI [1] Completed" in message for message in messages]) == 0
     assert sum(["ASGI [1] Raised exception" in message for message in messages]) == 1

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -4,6 +4,8 @@ import sys
 
 import click
 
+TRACE_LOG_LEVEL = 5
+
 
 class ColourizedFormatter(logging.Formatter):
     """
@@ -15,7 +17,8 @@ class ColourizedFormatter(logging.Formatter):
     """
 
     level_name_colors = {
-        logging.DEBUG: lambda level_name: click.style(str(level_name), fg="blue"),
+        TRACE_LOG_LEVEL: lambda level_name: click.style(str(level_name), fg="blue"),
+        logging.DEBUG: lambda level_name: click.style(str(level_name), fg="cyan"),
         logging.INFO: lambda level_name: click.style(str(level_name), fg="green"),
         logging.WARNING: lambda level_name: click.style(str(level_name), fg="yellow"),
         logging.ERROR: lambda level_name: click.style(str(level_name), fg="red"),

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -27,6 +27,8 @@ STATUS_PHRASES = {
 
 HIGH_WATER_LIMIT = 65536
 
+TRACE_LOG_LEVEL = 5
+
 
 class FlowControl:
     def __init__(self, transport):
@@ -123,16 +125,16 @@ class H11Protocol(asyncio.Protocol):
         self.client = get_remote_addr(transport)
         self.scheme = "https" if is_ssl(transport) else "http"
 
-        if self.logger.level <= logging.DEBUG:
+        if self.logger.level <= TRACE_LOG_LEVEL:
             prefix = "%s:%d - " % tuple(self.client) if self.client else ""
-            self.logger.debug("%sConnected", prefix)
+            self.logger.log(TRACE_LOG_LEVEL, "%sConnection made", prefix)
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
-        if self.logger.level <= logging.DEBUG:
+        if self.logger.level <= TRACE_LOG_LEVEL:
             prefix = "%s:%d - " % tuple(self.client) if self.client else ""
-            self.logger.debug("%sDisconnected", prefix)
+            self.logger.log(TRACE_LOG_LEVEL, "%Connection lost", prefix)
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -28,6 +28,8 @@ STATUS_LINE = {
 
 HIGH_WATER_LIMIT = 65536
 
+TRACE_LOG_LEVEL = 5
+
 
 class FlowControl:
     def __init__(self, transport):
@@ -127,16 +129,16 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.client = get_remote_addr(transport)
         self.scheme = "https" if is_ssl(transport) else "http"
 
-        if self.logger.level <= logging.DEBUG:
+        if self.logger.level <= TRACE_LOG_LEVEL:
             prefix = "%s:%d - " % tuple(self.client) if self.client else ""
-            self.logger.debug("%sConnected", prefix)
+            self.logger.log(TRACE_LOG_LEVEL, "%sConnection made", prefix)
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
-        if self.logger.level <= logging.DEBUG:
+        if self.logger.level <= TRACE_LOG_LEVEL:
             prefix = "%s:%d - " % tuple(self.client) if self.client else ""
-            self.logger.debug("%sDisconnected", prefix)
+            self.logger.log(TRACE_LOG_LEVEL, "%sConnection lost", prefix)
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True


### PR DESCRIPTION
Adds a new log level, TRACE, which is a level below DEBUG.

Here's why I like this...

**INFO** Output for stuff such as Process startup, Database connected, Access logs.
*Typically suitable for production.*

![Screenshot 2019-10-31 at 15 04 08](https://user-images.githubusercontent.com/647359/67958842-b8575f00-fbef-11e9-8cd7-76b35f738890.png)

**DEBUG** Output for stuff such as SQL on database accesses, Outgoing HTTP requests, Cache lookups, SMTP requests, Background tasks.
*Really useful during development, without presenting too much info. Everything you'd want to see to get a good idea of what I/O the system is performing on each request.*

![Screenshot 2019-10-31 at 15 03 06](https://user-images.githubusercontent.com/647359/67958763-9bbb2700-fbef-11e9-9646-38aff40ca71f.png)

**TRACE** ASGI messages & other low level stuff
*For when you really need to dig into something obscure, or understand exactly whats happening under the hood.*

![Screenshot 2019-10-31 at 15 07 28](https://user-images.githubusercontent.com/647359/67959156-3156b680-fbf0-11e9-865b-0da48aae8cb1.png)

I can see this fitting in really well as a rule of thumb for other components, too. Eg. I'd like to see `httpx` issuing one-line-per-request at DEBUG level, or comprehensive logging of state changes at TRACE level. Looking at a web stack as a whole it feels like a natural split to me.