### PR TITLE
--reload-dir now defaults to CWD, instead of sys.path

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -178,7 +178,7 @@ class Config:
         self.configure_logging()
 
         if reload_dirs is None:
-            self.reload_dirs = sys.path
+            self.reload_dirs = [os.getcwd()]
         else:
             self.reload_dirs = reload_dirs
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -68,7 +68,7 @@ logger = logging.getLogger("uvicorn.error")
     "--reload-dir",
     "reload_dirs",
     multiple=True,
-    help="Set reload directories explicitly, instead of using 'sys.path'.",
+    help="Set reload directories explicitly, instead of using the current working directory.",
 )
 @click.option(
     "--workers",


### PR DESCRIPTION
Previously `--reload-dir` was defaulting to `sys.path`.

This seems excessive to me - we probably don't need to default to checking for reloads of python modules located anywhere other than under the current working directory.

I think we should just change the default to `os.getcwd()`.