### PR TITLE
Version 0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.10.6
+
+* Exit if `workers` or `reload` are use without an app import string style.
+* Reorganise supervisor processes to properly hand over sockets on windows.
+
+## 0.10.5
+
+* Update uvloop dependency to 0.14+
+
 ## 0.10.4
 
 * Error clearly when `workers=<NUM>` is used with app instance, instead of an app import string.

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.10.5"
+__version__ = "0.10.6"
 __all__ = ["main", "run", "Config", "Server"]

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -299,6 +299,7 @@ def run(app, **kwargs):
         logger.warn(
             "You must pass the application as an import string to enable 'reload' or 'workers'."
         )
+        sys.exit(1)
 
     if config.should_reload:
         sock = config.bind_socket()


### PR DESCRIPTION
* Bump version.
* Hard exit if `workers` or `reload` is used without an app import string style.