### PR TITLE
Don't serve requests until startup complete

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -370,6 +370,11 @@ class Server:
         )
 
     async def startup(self, sockets=None):
+        await self.lifespan.startup()
+        if self.lifespan.should_exit:
+            self.should_exit = True
+            return
+
         config = self.config
 
         create_protocol = functools.partial(
@@ -435,12 +440,8 @@ class Server:
                 extra={"color_message": color_message},
             )
             self.servers = [server]
-
-        await self.lifespan.startup()
-        if self.lifespan.should_exit:
-            self.should_exit = True
-        else:
-            self.started = True
+            
+        self.started = True
 
     async def main_loop(self):
         counter = 0

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -441,7 +441,7 @@ class Server:
                 extra={"color_message": color_message},
             )
             self.servers = [server]
-            
+
         self.started = True
 
     async def main_loop(self):

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -424,6 +424,7 @@ class Server:
                 )
             except OSError as exc:
                 logger.error(exc)
+                await self.lifespan.shutdown()
                 sys.exit(1)
             protocol_name = "https" if config.ssl else "http"
             message = "Uvicorn running on %s://%s:%d (Press CTRL+C to quit)"


### PR DESCRIPTION
one potential solution to https://github.com/encode/starlette/issues/733, where uvicorn _does_ process requests before the lifespan startup event is complete