### PR TITLE
Upgrade h11 dependency to 0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ env_marker = (
 
 requirements = [
     "click==7.*",
-    "h11==0.8.*",
+    "h11==0.9.*",
     "websockets==8.*",
     "httptools==0.0.13 ;" + env_marker,
     "uvloop>=0.14.0 ;" + env_marker,


### PR DESCRIPTION
Upgrading is not required but I don't see any reason not to upgrade (I might be missing something).

All dependencies were pinned in [#324](https://github.com/encode/uvicorn/pull/324) with the main intent of pinning the click version to fix an issue: #320.

Local tests are passing successfully.

