### PR TITLE
Handle signals

### DIFF
--- a/tests/client.py
+++ b/tests/client.py
@@ -99,7 +99,11 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
         response_started = False
         raw_kwargs = {"body": io.BytesIO()}
 
-        loop = asyncio.get_event_loop()
+        if not asyncio.get_event_loop().is_closed():
+            loop = asyncio.get_event_loop()
+        else:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
         try:
             loop.run_until_complete(self.app(scope, receive, send))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,10 @@
+import asyncio
 import threading
 import time
-import asyncio
+import typing
 
 import requests
+from requests.adapters import HTTPAdapter
 
 from uvicorn.config import Config
 from uvicorn.main import Server
@@ -121,3 +123,82 @@ def test_run_with_shutdown():
     server.should_exit = True
     thread.join()
     assert exc is None
+
+
+def test_run_signal():
+    class App:
+        def __init__(self, scope):
+            if scope["type"] != "http":
+                raise Exception()
+
+        async def __call__(self, receive, send):
+            await send({"type": "http.response.start", "status": 204, "headers": []})
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    config = Config(app=App, loop="asyncio", limit_max_requests=1, exit_signals=None)
+    server = Server(config=config)
+    thread = threading.Thread(target=server.run)
+    thread.start()
+    while not server.started:
+        time.sleep(0.01)
+    response = requests.get("http://127.0.0.1:8000")
+    assert response.status_code == 204
+    thread.join()
+
+
+def test_run_signal_multi_threads():
+    class App:
+        def __init__(self, scope):
+            if scope["type"] != "http":
+                raise Exception()
+
+        async def __call__(self, receive, send):
+            await send({"type": "http.response.start", "status": 204, "headers": []})
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    def join_t(*threads: threading.Thread) -> typing.List[None]:
+        return [t.join() for t in threads]
+
+    def start_threads(*threads: threading.Thread) -> typing.List[None]:
+        return [t.start() for t in threads]
+
+    def event_thread(
+        worker: typing.Awaitable, loop, *args, **kwargs
+    ) -> threading.Thread:
+        def _worker(*args, **kwargs):
+            try:
+                loop.run_until_complete(worker(*args, **kwargs))
+            except Exception as e:
+                print(e)
+            finally:
+                loop.close()
+
+        return threading.Thread(target=_worker, args=args, kwargs=kwargs)
+
+    threads_count = 10
+    loops = [asyncio.new_event_loop() for i in range(threads_count)]
+    for loop in loops:
+        asyncio.set_event_loop(loop)
+    configs = [
+        Config(
+            app=App,
+            port=10000 + i,
+            loop=loops[i],
+            limit_max_requests=1,
+            exit_signals=None,
+        )
+        for i in range(threads_count)
+    ]
+    servers = [Server(config=configs[i]) for i in range(threads_count)]
+    workers = [
+        event_thread(servers[i].serve, loop=loops[i]) for i in range(threads_count)
+    ]
+    start_threads(*workers)
+    time.sleep(1)
+    for x in range(threads_count):
+        port = 10000 + x
+        s = requests.Session()
+        s.mount(f"http://127.0.0.1:{port}", HTTPAdapter(max_retries=1))
+        response = s.get(f"http://127.0.0.1:{port}")
+        assert response.status_code == 204
+    join_t(*workers)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -3,6 +3,7 @@ import inspect
 import logging
 import logging.config
 import os
+import signal
 import socket
 import ssl
 import sys
@@ -141,6 +142,7 @@ class Config:
         ssl_ca_certs=None,
         ssl_ciphers="TLSv1",
         headers=None,
+        exit_signals=(signal.SIGINT, signal.SIGTERM),
     ):
         self.app = app
         self.host = host
@@ -175,6 +177,7 @@ class Config:
         self.ssl_ciphers = ssl_ciphers
         self.headers = headers if headers else []  # type: List[str]
         self.encoded_headers = None  # type: List[Tuple[bytes, bytes]]
+        self.handled_signals = exit_signals or []
 
         self.loaded = False
         self.configure_logging()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -559,13 +559,12 @@ class Server:
 
     def install_signal_handlers(self):
         loop = asyncio.get_event_loop()
-
         try:
-            for sig in HANDLED_SIGNALS:
+            for sig in self.config.handled_signals:
                 loop.add_signal_handler(sig, self.handle_exit, sig, None)
         except NotImplementedError as exc:
             # Windows
-            for sig in HANDLED_SIGNALS:
+            for sig in self.config.handled_signals:
                 signal.signal(sig, self.handle_exit)
 
     def handle_exit(self, sig, frame):


### PR DESCRIPTION
attempt to replace https://github.com/encode/uvicorn/pull/402

I added 2 new tests (`test_run_signal` and `test_run_signal_multi_threads`)  that make use of the flag and therefore don't need to use the `CustomServer` class that override signal handling, I guess it's a test only workaround.
```
    class CustomServer(Server):
        def install_signal_handlers(self):
            pass
```

~~I would need / love guidance in how to properly handle one of the tests here, namely `test_run_signal_multi_threads`, because I have currenlty an issue:~~

~~- `test_run_signal_multi_threads` in essence spawns 10 threads, run uvicorn in them with  each time a new loop, the test works fine independently however it needs an `import asyncio` to set loops. And **this single import break about 80 other tests** while on its own the test passes fine and we can have 10 uvicorn servers running in 10 threads with 10 loops...well~~

~~So I left the PR in a state where all tests pass but this one because of the missing import. 
Hope it makes sense~~


ok I found the fix:  because of the tests I added, the `_ASGIAdapter`  had a closed loop it tried to use and therefore failed, so a simple test on it and all tests pass
