### PR TITLE
Fixes bug where --log-config disables uvicorn loggers

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -219,8 +219,7 @@ class Config:
                 logging.config.dictConfig(self.log_config)
             else:
                 logging.config.fileConfig(
-                    self.log_config,
-                    disable_existing_loggers=False
+                    self.log_config, disable_existing_loggers=False
                 )
 
         if self.log_level is not None:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -218,7 +218,10 @@ class Config:
             if isinstance(self.log_config, dict):
                 logging.config.dictConfig(self.log_config)
             else:
-                logging.config.fileConfig(self.log_config)
+                logging.config.fileConfig(
+                    self.log_config,
+                    disable_existing_loggers=False
+                )
 
         if self.log_level is not None:
             if isinstance(self.log_level, str):


### PR DESCRIPTION
Fixes #511 

### Example

**`logging_config.ini`**
```
[loggers]
keys=root

[handlers]
keys=h

[formatters]
keys=f

[logger_root]
level=INFO
handlers=h

[handler_h]
class=StreamHandler
level=INFO
formatter=f
args=(sys.stderr,)

[formatter_f]
format=%(asctime)s %(name)s %(levelname)-4s %(message)s
```

**`fastapi_scratch.py`**
```
import logging
from fastapi import FastAPI

logger = logging.getLogger(__name__)
app = FastAPI()

@app.on_event("startup")
async def startup():
    logger.warning('Raising an exception on startup')
    raise Exception("Nope!")
```

### Current Behavior on `master`

```
uvicorn scratch_fastapi:app --log-config=logging_config.ini
```
```
2019-12-04 11:56:43,681 scratch_fastapi WARNING Raising an exception on startup
```

### Behavior with this PR

```
uvicorn scratch_fastapi:app --log-config=logging_config.ini
```
```
2019-12-04 12:00:05,646 uvicorn.error INFO Started server process [7523]
2019-12-04 12:00:05,651 uvicorn.error INFO Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
2019-12-04 12:00:05,652 uvicorn.error INFO Waiting for application startup.
2019-12-04 12:00:05,652 scratch_fastapi WARNING Raising an exception on startup
2019-12-04 12:00:05,654 uvicorn.error ERROR Traceback (most recent call last):
  File "/Users/peter/.virtualenvs/JR/lib/python3.7/site-packages/starlette/routing.py", line 473, in __call__
    await self.startup()
  File "/Users/peter/.virtualenvs/JR/lib/python3.7/site-packages/starlette/routing.py", line 457, in startup
    await handler()
  File "./scratch_fastapi.py", line 10, in startup
    raise Exception("Nope!")
Exception: Nope!

2019-12-04 12:00:05,655 uvicorn.error ERROR Application startup failed. Exiting.
```
