### PR TITLE
Add `--version` flag.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,6 @@ setup(
     entry_points="""
     [console_scripts]
     uvicorn=uvicorn.main:main
+    uvicorn.version=uvicorn.main:version
     """
 )

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,5 @@ setup(
     entry_points="""
     [console_scripts]
     uvicorn=uvicorn.main:main
-    uvicorn.version=uvicorn.main:version
     """
 )

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -1,6 +1,3 @@
-import sys
-
-
 def auto_loop_setup():
     try:
         import uvloop

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -2,6 +2,7 @@ import asyncio
 import functools
 import logging
 import os
+import platform
 import signal
 import socket
 import ssl
@@ -12,6 +13,7 @@ from email.utils import formatdate
 
 import click
 
+import uvicorn
 from uvicorn.config import (
     HTTP_PROTOCOLS,
     INTERFACES,
@@ -38,6 +40,19 @@ HANDLED_SIGNALS = (
 )
 
 logger = logging.getLogger("uvicorn.error")
+
+
+@click.command()
+def version():
+    click.echo(
+        "Running uvicorn %s with %s %s on %s"
+        % (
+            uvicorn.__version__,
+            platform.python_implementation(),
+            platform.python_version(),
+            platform.system(),
+        )
+    )
 
 
 @click.command()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -42,8 +42,9 @@ HANDLED_SIGNALS = (
 logger = logging.getLogger("uvicorn.error")
 
 
-@click.command()
-def version():
+def print_version(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
     click.echo(
         "Running uvicorn %s with %s %s on %s"
         % (
@@ -53,6 +54,7 @@ def version():
             platform.system(),
         )
     )
+    ctx.exit()
 
 
 @click.command()
@@ -239,6 +241,9 @@ def version():
     "headers",
     multiple=True,
     help="Specify custom default HTTP response headers as a Name:Value pair",
+)
+@click.option(
+    "--version", is_flag=True, callback=print_version, expose_value=False, is_eager=True
 )
 def main(
     app,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -243,7 +243,12 @@ def print_version(ctx, param, value):
     help="Specify custom default HTTP response headers as a Name:Value pair",
 )
 @click.option(
-    "--version", is_flag=True, callback=print_version, expose_value=False, is_eager=True
+    "--version",
+    is_flag=True,
+    callback=print_version,
+    expose_value=False,
+    is_eager=True,
+    help="Display the uvicorn version and exit.",
 )
 def main(
     app,


### PR DESCRIPTION
attempts at https://github.com/encode/uvicorn/issues/476

~~there are many ways to add the functionality, I choose not to touch to the only existing command (main) and add a new entrypoint `uvicorn.version`
the alternative would be to add a `click.option("--version"....)` and inside the main function do a if version then echo the version else run as usual~~

```
(venv) ➜  uvicorn git:(version) ✗ uvicorn.version 
Running uvicorn 0.10.8 with CPython 3.8.0 on Linux
```
