### PR TITLE
Add --reload-extension option to specify which files are watched.

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,6 +36,8 @@ Options:
   --reload                        Enable auto-reload.
   --reload-dir TEXT               Set reload directories explicitly, instead
                                   of using the current working directory.
+  --reload-extension TEXT         Set reloaded file extensions explicitly,
+                                  instead of only watching .py.
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available. Not valid with --reload.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,8 @@ Options:
   --reload                        Enable auto-reload.
   --reload-dir TEXT               Set reload directories explicitly, instead
                                   of using the current working directory.
+  --reload-extension TEXT         Set reloaded file extensions explicitly,
+                                  instead of only watching .py.
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available. Not valid with --reload.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -19,7 +19,8 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 ## Development
 
 * `--reload` - Enable auto-reload.
-* `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default all directories in `sys.path` will be watched.
+* `--reload-dir <path>` - Specify which directories to watch for file changes. May be used multiple times. If unused, then by default all directories in `sys.path` will be watched.
+* `--reload-extension <extension>` - Specify which extensions to watch (eg: `.py`. May be used multiple times. If unused, then by default only `.py` files will be watched.
 
 ## Production
 

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -30,21 +31,38 @@ def test_statreload():
     sys.platform.startswith("win"),
     reason="Skipping reload test on Windows, due to low mtime resolution.",
 )
-def test_should_reload(tmpdir):
-    update_file = Path(os.path.join(str(tmpdir), "example.py"))
+@pytest.mark.parametrize(
+    "extensions,testfile,expected",
+    [
+        (None, "test.py", True),
+        (None, "test.graphql", False),
+        ([".py"], "test.py", True),
+        ([".py", ".graphql"], "test.py", True),
+        ([".py", ".graphql"], "test.graphql", True),
+        ([".py", ".graphql"], "test.html", False),
+    ],
+)
+def test_should_reload(extensions, testfile, expected, tmpdir):
+    update_file = Path(os.path.join(str(tmpdir), testfile))
     update_file.touch()
 
     working_dir = os.getcwd()
     os.chdir(str(tmpdir))
     try:
-        config = Config(app=None, reload=True)
+        config = Config(app=None, reload=True, reload_extensions=extensions)
         reloader = StatReload(config, target=run, sockets=[])
         reloader.signal_handler(sig=signal.SIGINT, frame=None)
         reloader.startup()
-
         assert not reloader.should_restart()
+
+        # This sleep is needed to avoid unreliable tests.
+        # Relying on timing in tests is a bad idea but I'm not sure
+        # how to do better in this case since we are actually testing
+        # if StatReload's understanding of mtime is correct so we are
+        # bound by it's precision.
+        time.sleep(0.01)
         update_file.touch()
-        assert reloader.should_restart()
+        assert reloader.should_restart() is expected
 
         reloader.restart()
         reloader.shutdown()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -125,6 +125,7 @@ class Config:
         debug=False,
         reload=False,
         reload_dirs=None,
+        reload_extensions=None,
         workers=None,
         proxy_headers=True,
         forwarded_allow_ips=None,
@@ -182,6 +183,11 @@ class Config:
             self.reload_dirs = [os.getcwd()]
         else:
             self.reload_dirs = reload_dirs
+
+        if reload_extensions is None:
+            self.reload_extensions = [".py"]
+        else:
+            self.reload_extensions = reload_extensions
 
         if env_file is not None:
             from dotenv import load_dotenv

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -71,6 +71,12 @@ logger = logging.getLogger("uvicorn.error")
     help="Set reload directories explicitly, instead of using the current working directory.",
 )
 @click.option(
+    "--reload-extension",
+    "reload_extensions",
+    multiple=True,
+    help="Set reloaded file extensions explicitly, instead of only watching .py.",
+)
+@click.option(
     "--workers",
     default=None,
     type=int,
@@ -239,6 +245,7 @@ def main(
     debug: bool,
     reload: bool,
     reload_dirs: typing.List[str],
+    reload_extensions: typing.List[str],
     workers: int,
     env_file: str,
     log_config: str,
@@ -278,6 +285,7 @@ def main(
         "debug": debug,
         "reload": reload,
         "reload_dirs": reload_dirs if reload_dirs else None,
+        "reload_extensions": reload_extensions if reload_extensions else None,
         "workers": workers,
         "proxy_headers": proxy_headers,
         "forwarded_allow_ips": forwarded_allow_ips,

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -72,7 +72,7 @@ class StatReload:
         logger.info(message, extra={"color_message": color_message})
 
     def should_restart(self):
-        for filename in self.iter_py_files():
+        for filename in self.iter_watched_files():
             try:
                 mtime = os.path.getmtime(filename)
             except OSError as exc:  # pragma: nocover
@@ -91,9 +91,10 @@ class StatReload:
                 return True
         return False
 
-    def iter_py_files(self):
+    def iter_watched_files(self):
         for reload_dir in self.config.reload_dirs:
-            for subdir, dirs, files in os.walk(reload_dir):
-                for file in files:
-                    if file.endswith(".py"):
-                        yield subdir + os.sep + file
+            for extension in self.config.reload_extensions:
+                for subdir, dirs, files in os.walk(reload_dir):
+                    for file in files:
+                        if file.endswith(extension):
+                            yield subdir + os.sep + file


### PR DESCRIPTION
This pull request ads the option `--reload-extension` to specify which extensions should be watched. The default behavior doesn't change and is still only watching `.py` files.

This is useful in projects using non-python files that change during development (for example graphql `schema.sdl` files, or configuration files.) 

I updated the tests so that combinations of extensions and file changes are tested (as well as the default behaviors.) I had to add a `time.sleep()` to the tests because we are actually testing if the system detects the time change and on my machine the tests were failing often due to the the `Path.touch()` being too fast and close to each other.

I also updated the documentation to the best of my ability but not being super familiar with the project I might have forgotten something, please point it out and I will fix it!
