### PR TITLE
Watch all files for reload not only `.py` files.

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -19,7 +19,7 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 ## Development
 
 * `--reload` - Enable auto-reload.
-* `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default all directories in `sys.path` will be watched.
+* `--reload-dir <path>` - Specify which directories to watch for file changes. May be used multiple times. If unused, then by default all directories in `sys.path` will be watched.
 
 ## Production
 

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -41,8 +42,14 @@ def test_should_reload(tmpdir):
         reloader = StatReload(config, target=run, sockets=[])
         reloader.signal_handler(sig=signal.SIGINT, frame=None)
         reloader.startup()
-
         assert not reloader.should_restart()
+
+        # This sleep is needed to avoid unreliable tests. Relying on
+        # timing in tests is a bad idea but I'm not sure how to do
+        # better in this case since we are actually testing if
+        # StatReload's understanding of mtime is correct so we are
+        # bound by it's precision.
+        time.sleep(0.01)
         update_file.touch()
         assert reloader.should_restart()
 

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -95,5 +95,4 @@ class StatReload:
         for reload_dir in self.config.reload_dirs:
             for subdir, dirs, files in os.walk(reload_dir):
                 for file in files:
-                    if file.endswith(".py"):
-                        yield subdir + os.sep + file
+                    yield subdir + os.sep + file


### PR DESCRIPTION
Follow up to https://github.com/encode/uvicorn/pull/519

This pull request **changes** the default behavior so that all files in the reload directories are watched and not only `.py` files. (See discussion on #519 as to why we want this instead of specifying which extensions to watch.)

This is useful in projects using non-python files that change during development (for example graphql schema.sdl files, or configuration files.)

The downside is that people using the default configuration that now watches all files in the current working directory which might include files that change often and should not cause a reload. Such files could include:
  - `.git`: committing and other git operations could cause reloads.
  - logfiles: If during development logs are kept in the current working directory they will cause infinite reloads of the server.
  - data files, test databases: it is not uncommon during development to use sqlite or json files to store state between runs, those might reasonably be in the current working directory.
  - IDE configuration, backup, cache, etc.

All of the above can be solved by specifying `--reload-dir` but that requires the user to do something they didn't have to before.

I'm not sure what the **correct** solution is in this case, maybe following `.gitignore` but that seems awfully out of scope for uvicorn.
