### PR TITLE
Docker signal

### DIFF
--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -81,11 +81,11 @@ async def app(scope, receive, send):
 """
 
 
-data = [(DOCKERFILE), (DOCKERFILE_RELOAD)]
+data = [(DOCKERFILE, "uv"), (DOCKERFILE_RELOAD, "uvr")]
 
 
-@pytest.mark.parametrize("dockerfile", data)
-def test_docker(tmpdir_factory, dockerfile):
+@pytest.mark.parametrize("dockerfile, tag", data)
+def test_docker(tmpdir_factory, dockerfile, tag):
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
     appdir = tmpdir_factory.mktemp("app")
@@ -95,7 +95,7 @@ def test_docker(tmpdir_factory, dockerfile):
         f.write(APPFILE)
     client: DockerClient = docker.from_env()
     image, _ = client.images.build(
-        path=".", dockerfile=appdir / "Dockerfile", tag=f"{dockerfile}"
+        path=".", dockerfile=appdir / "Dockerfile", tag=tag
     )
     container = client.containers.run(
         image,

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -70,7 +70,7 @@ WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
 """
 
-APPFILE="""
+APPFILE = """
 async def app(scope, receive, send):
     message = await receive()
     await send({"type": "http.response.start", "status": 200, "headers": []})
@@ -79,7 +79,7 @@ async def app(scope, receive, send):
 """
 
 
-data = [(DOCKERFILE),(DOCKERFILE_RELOAD)]
+data = [(DOCKERFILE), (DOCKERFILE_RELOAD)]
 
 
 @pytest.mark.parametrize("dockerfile", data)
@@ -103,10 +103,12 @@ def test_docker(tmpdir_factory, dockerfile):
     )
     try:
         time.sleep(1)
-        assert container.status == 'created'
+        assert container.status == "created"
         time.sleep(1)
         assert "Application startup complete" in container.logs().decode()
-        logger.info(f"number of process in container top: {len(container.top()['Processes'])}")
+        logger.info(
+            f"number of process in container top: {len(container.top()['Processes'])}"
+        )
         logger.info(container.top()["Processes"])
         container.kill(signal=signal.SIGINT)
         time.sleep(1)

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -58,14 +58,16 @@ def test_should_reload(tmpdir):
 
 DOCKERFILE = """
 FROM python:3.7-buster
-RUN pip install uvicorn==0.10.8
+RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
+RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
 WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000"]
 """
 
 DOCKERFILE_RELOAD = """
 FROM python:3.7-buster
-RUN pip install uvicorn==0.10.8
+RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
+RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
 WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
 """
@@ -93,7 +95,7 @@ def test_docker(tmpdir_factory, dockerfile):
         f.write(APPFILE)
     client: DockerClient = docker.from_env()
     image, _ = client.images.build(
-        path=".", dockerfile=appdir / "Dockerfile", tag=f"uvicorn_docker"
+        path=".", dockerfile=appdir / "Dockerfile", tag=f"{dockerfile}"
     )
     container = client.containers.run(
         image,

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -77,7 +77,7 @@ FROM python:3.7-buster
 RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
 RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
 WORKDIR /app
-CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--workers", 2]
+CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--workers", "2"]
 """
 
 APPFILE = """

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -1,13 +1,9 @@
-import logging
 import os
 import signal
 import sys
-import time
 from pathlib import Path
 
-import docker
 import pytest
-from docker import DockerClient
 
 from uvicorn.config import Config
 from uvicorn.supervisors import StatReload
@@ -54,77 +50,3 @@ def test_should_reload(tmpdir):
         reloader.shutdown()
     finally:
         os.chdir(working_dir)
-
-
-DOCKERFILE = """
-FROM python:3.7-buster
-RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@bd5dd14c3e669d272bc29b1f3fb164e56ce3258b#egg=uvicorn
-WORKDIR /app
-CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000"]
-"""
-
-DOCKERFILE_RELOAD = """
-FROM python:3.7-buster
-RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@bd5dd14c3e669d272bc29b1f3fb164e56ce3258b#egg=uvicorn
-WORKDIR /app
-CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
-"""
-
-DOCKERFILE_WORKER = """
-FROM python:3.7-buster
-RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@bd5dd14c3e669d272bc29b1f3fb164e56ce3258b#egg=uvicorn
-WORKDIR /app
-CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--workers", "2"]
-"""
-
-APPFILE = """
-async def app(scope, receive, send):
-    message = await receive()
-    await send({"type": "http.response.start", "status": 200, "headers": []})
-    await send({"type": "http.response.body", "body": b"", "more_body": False})
-
-"""
-
-
-data = [(DOCKERFILE, "uv"), (DOCKERFILE_RELOAD, "uvr"), (DOCKERFILE_WORKER, "uvw")]
-
-
-@pytest.mark.parametrize("dockerfile, tag", data)
-def test_docker(tmpdir_factory, dockerfile, tag):
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
-    appdir = tmpdir_factory.mktemp("app")
-    with open(appdir / "Dockerfile", "w") as f:
-        f.write(dockerfile)
-    with open(appdir / "app.py", "w") as f:
-        f.write(APPFILE)
-    client: DockerClient = docker.from_env()
-    image, _ = client.images.build(path=".", dockerfile=appdir / "Dockerfile", tag=tag)
-    container = client.containers.run(
-        image,
-        name="uvicorn_docker",
-        detach=True,
-        volumes={appdir: {"bind": "/app", "mode": "rw"}},
-    )
-    try:
-        time.sleep(1)
-        assert container.status == "created"
-        time.sleep(1)
-        assert "Application startup complete" in container.logs().decode()
-        logger.info(
-            f"number of process in container top: {len(container.top()['Processes'])}"
-        )
-        logger.info(container.top()["Processes"])
-        container.kill(signal=signal.SIGINT)
-        time.sleep(1)
-        logger.info(container.logs().decode())
-        time.sleep(1)
-    except Exception as e:
-        logger.info(e)
-    finally:
-
-        container.stop()
-        container.remove()

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -1,9 +1,13 @@
+import logging
 import os
 import signal
 import sys
+import time
 from pathlib import Path
 
+import docker
 import pytest
+from docker import DockerClient
 
 from uvicorn.config import Config
 from uvicorn.supervisors import StatReload
@@ -50,3 +54,67 @@ def test_should_reload(tmpdir):
         reloader.shutdown()
     finally:
         os.chdir(working_dir)
+
+
+DOCKERFILE = """
+FROM python:3.7-buster
+RUN pip install uvicorn==0.10.8
+WORKDIR /app
+CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000"]
+"""
+
+DOCKERFILE_RELOAD = """
+FROM python:3.7-buster
+RUN pip install uvicorn==0.10.8
+WORKDIR /app
+CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
+"""
+
+APPFILE="""
+async def app(scope, receive, send):
+    message = await receive()
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+"""
+
+
+data = [(DOCKERFILE),(DOCKERFILE_RELOAD)]
+
+
+@pytest.mark.parametrize("dockerfile", data)
+def test_docker(tmpdir_factory, dockerfile):
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    appdir = tmpdir_factory.mktemp("app")
+    with open(appdir / "Dockerfile", "w") as f:
+        f.write(dockerfile)
+    with open(appdir / "app.py", "w") as f:
+        f.write(APPFILE)
+    client: DockerClient = docker.from_env()
+    image, _ = client.images.build(
+        path=".", dockerfile=appdir / "Dockerfile", tag=f"uvicorn_docker"
+    )
+    container = client.containers.run(
+        image,
+        name="uvicorn_docker",
+        detach=True,
+        volumes={appdir: {"bind": "/app", "mode": "rw"}},
+    )
+    try:
+        time.sleep(1)
+        assert container.status == 'created'
+        time.sleep(1)
+        assert "Application startup complete" in container.logs().decode()
+        logger.info(f"number of process in container top: {len(container.top()['Processes'])}")
+        logger.info(container.top()["Processes"])
+        container.kill(signal=signal.SIGINT)
+        time.sleep(1)
+        logger.info(container.logs().decode())
+        time.sleep(1)
+    except Exception as e:
+        logger.info(e)
+    finally:
+
+        container.stop()
+        container.remove()

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -75,7 +75,7 @@ CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
 DOCKERFILE_WORKER = """
 FROM python:3.7-buster
 RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@852cef442bc19d5ccb982a149b8529f4d358f223#egg=uvicorn
+RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
 WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--workers", "2"]
 """

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -59,7 +59,7 @@ def test_should_reload(tmpdir):
 DOCKERFILE = """
 FROM python:3.7-buster
 RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
+RUN pip install git+https://github.com/euri10/uvicorn.git@bd5dd14c3e669d272bc29b1f3fb164e56ce3258b#egg=uvicorn
 WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000"]
 """
@@ -67,7 +67,7 @@ CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000"]
 DOCKERFILE_RELOAD = """
 FROM python:3.7-buster
 RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
+RUN pip install git+https://github.com/euri10/uvicorn.git@bd5dd14c3e669d272bc29b1f3fb164e56ce3258b#egg=uvicorn
 WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
 """
@@ -75,7 +75,7 @@ CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
 DOCKERFILE_WORKER = """
 FROM python:3.7-buster
 RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
+RUN pip install git+https://github.com/euri10/uvicorn.git@bd5dd14c3e669d272bc29b1f3fb164e56ce3258b#egg=uvicorn
 WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--workers", "2"]
 """

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -75,7 +75,7 @@ CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--reload"]
 DOCKERFILE_WORKER = """
 FROM python:3.7-buster
 RUN apt update && apt-get install -y git --no-install-recommends && rm -rf /var/lib/apt/lists/* && apt-get clean
-RUN pip install git+https://github.com/euri10/uvicorn.git@docker_signal#egg=uvicorn
+RUN pip install git+https://github.com/euri10/uvicorn.git@852cef442bc19d5ccb982a149b8529f4d358f223#egg=uvicorn
 WORKDIR /app
 CMD ["uvicorn", "app:app", "--host=0.0.0.0", "--port=5000", "--workers", "2"]
 """

--- a/uvicorn/supervisors/interface.py
+++ b/uvicorn/supervisors/interface.py
@@ -1,0 +1,50 @@
+import logging
+import os
+import signal
+import threading
+
+logger = logging.getLogger("uvicorn.error")
+
+
+class ProcessTracker:
+    def __init__(self):
+        self.child_pids = []
+        self.should_exit = threading.Event()
+
+    def signal_handler(self, sig, frame):
+        """
+        A signal handler that is registered with the parent process.
+        """
+        for child_pid in self.child_pids:
+            try:
+                os.kill(child_pid, signal.SIGINT)
+                finished = os.waitpid(child_pid, 0)
+            except Exception as e:
+                logger.error(f"Could not kill child PID {child_pid}: {e}")
+        self.should_exit.set()
+
+    def signal_handler2(self, sig, frame):
+        """
+        A signal handler that is registered with the parent process.
+        """
+        logger.info(f"Handling signal: {sig}")
+        for child_pid in self.child_pids:
+            logger.debug(f"Attempt at killing child PID {child_pid}")
+            try:
+                os.kill(child_pid, signal.SIGINT)
+                (pid, status) = os.waitpid(child_pid, 0)
+                if pid == child_pid:
+                    logger.debug(f"{pid}: {status}")
+                    if os.WIFEXITED(status):
+                        logger.debug(
+                            "process returning status exited via the exit() system call"
+                        )
+                    elif os.WIFSIGNALED(status):
+                        logger.debug(
+                            "process returning status was terminated by a signal"
+                        )
+                    elif os.WIFSTOPPED(status):
+                        logger.debug("process returning status was stopped")
+            except Exception as e:
+                logger.error(f"Cant kill child PID {child_pid}: {e}")
+        self.should_exit.set()

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -29,12 +29,13 @@ class Multiprocess:
         """
         A signal handler that is registered with the parent process.
         """
+        logger.info(f"children: {self.child_pids}")
         for child_pid in self.child_pids:
             try:
                 os.kill(child_pid, signal.SIGINT)
                 finished = os.waitpid(child_pid, 0)
             except Exception as e:
-                logger.error("cant kill server")
+                logger.error(f"cant kill server: {e}")
         self.should_exit.set()
 
     def run(self):
@@ -58,6 +59,7 @@ class Multiprocess:
             )
             process.start()
             self.processes.append(process)
+        for process in self.processes:
             self.child_pids.append(process.pid)
 
     def shutdown(self):

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -29,13 +29,12 @@ class Multiprocess:
         """
         A signal handler that is registered with the parent process.
         """
-        logger.info(f"children: {self.child_pids}")
         for child_pid in self.child_pids:
             try:
                 os.kill(child_pid, signal.SIGINT)
                 finished = os.waitpid(child_pid, 0)
             except Exception as e:
-                logger.error(f"cant kill server: {e}")
+                logger.error(f"Cant kill child PID {child_pid}: {e}")
         self.should_exit.set()
 
     def run(self):

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -35,7 +35,7 @@ class StatReload:
                 os.kill(child_pid, signal.SIGINT)
                 finished = os.waitpid(child_pid, 0)
             except Exception as e:
-                logger.error("cant kill server")
+                logger.error(f"Cant kill child PID {child_pid}: {e}")
         self.should_exit.set()
 
     def run(self):

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -72,7 +72,6 @@ class StatReload:
         self.process.start()
 
     def shutdown(self):
-        logger.info(f"is set {self.should_exit.is_set()}")
         self.process.join()
         message = "Stopping reloader process [{}]".format(str(self.pid))
         color_message = "Stopping reloader process [{}]".format(

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -1,12 +1,12 @@
 import logging
 import os
 import signal
-import threading
 from pathlib import Path
 
 import click
 
 from uvicorn.subprocess import get_subprocess
+from uvicorn.supervisors.interface import ProcessTracker
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
@@ -16,27 +16,14 @@ HANDLED_SIGNALS = (
 logger = logging.getLogger("uvicorn.error")
 
 
-class StatReload:
+class StatReload(ProcessTracker):
     def __init__(self, config, target, sockets):
+        super().__init__()
         self.config = config
         self.target = target
         self.sockets = sockets
-        self.should_exit = threading.Event()
         self.pid = os.getpid()
         self.mtimes = {}
-        self.child_pids = []
-
-    def signal_handler(self, sig, frame):
-        """
-        A signal handler that is registered with the parent process.
-        """
-        for child_pid in self.child_pids:
-            try:
-                os.kill(child_pid, signal.SIGINT)
-                finished = os.waitpid(child_pid, 0)
-            except Exception as e:
-                logger.error(f"Cant kill child PID {child_pid}: {e}")
-        self.should_exit.set()
 
     def run(self):
         self.startup()

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from gunicorn.workers.base import Worker
+
 from uvicorn.config import Config
 from uvicorn.main import Server
 


### PR DESCRIPTION
Attempt to fix #364 by keeping a list of child pids and killing them gracefully

The test added is ugly for several reasons, it has cache issues, it sleeps, well it's not good imho and served more as a debug tool, I kept it just in case you want to try but would remove it for sure.
Should you want me to keep it it would need some more work, both in travis and in the test. So it runs locally but will make travis fail, let me know if you want me to add it for real.

with the change a container using the  `--reload` flag is gracefully stopped with ctrl+c
same for the `--worker` flag