### PR TITLE
Version 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.11.0
+
+* Fix reload/multiprocessing on Windows with Python 3.8.
+* Drop IOCP support. (Required for fix above.)
+* Add `uvicorn --version` flag.
+* Add `--use-colors` and `--no-use-colors` flags.
+* Display port correctly, when auto port selection isused with `--port=0`.
+
 ## 0.10.8
 
 * Fix reload/multiprocessing error.

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.10.8"
+__version__ = "0.11.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
* Fix reload/multiprocessing on Windows with Python 3.8.
* Drop IOCP support. (Required for fix above.)
* Add `uvicorn --version` flag.
* Add `--use-colors` and `--no-use-colors` flags.
* Display port correctly, when auto port selection isused with `--port=0`.