### PR TITLE
Version 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.11.1
+
+* Use a more liberal `h11` dependency. Either `0.8.*` or `0.9.*``.
+
 ## 0.11.0
 
 * Fix reload/multiprocessing on Windows with Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ env_marker = (
 
 requirements = [
     "click==7.*",
-    "h11==0.9.*",
+    "h11>=0.8,<0.10",
     "websockets==8.*",
     "httptools==0.0.13 ;" + env_marker,
     "uvloop>=0.14.0 ;" + env_marker,

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
More liberal `h11` dependency, to support either `0.8.*` or `0.9.*`.