### PR TITLE
color codes in windows console not escaped

### DIFF
--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -32,6 +32,7 @@ class ColourizedFormatter(logging.Formatter):
             self.use_colors = use_colors
         else:
             self.use_colors = sys.stdout.isatty()
+        click.clear()
         super().__init__(fmt=fmt, datefmt=datefmt, style=style)
 
     def color_level_name(self, level_name, level_no):


### PR DESCRIPTION
Fixes https://github.com/tiangolo/fastapi/issues/815 that should have been reported upstream

There are many ways to handle the case obviously, I choose to use click.clear() since we use already click.style and because it already performs the os check and issues the right command for that.

