### PR TITLE
Add statreload config option reload_types

### DIFF
--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -27,6 +27,9 @@ def test_statreload():
 
 
 def test_should_reload(tmpdir):
+    """
+    Basic test to reload when a .py file is updated.
+    """
     update_file = Path(os.path.join(str(tmpdir), "example.py"))
     update_file.touch()
 
@@ -41,6 +44,79 @@ def test_should_reload(tmpdir):
         assert not reloader.should_restart()
         time.sleep(0.1)
         update_file.touch()
+        assert reloader.should_restart()
+
+        reloader.restart()
+        reloader.shutdown()
+    finally:
+        os.chdir(working_dir)
+
+
+def test_should_respect_reload_dirs(tmpdir):
+    """
+    Test to verify that the reload_dirs config option is respected.
+    """
+    inner_path = os.path.join(str(tmpdir), "inner_dir", "inner.py")
+    os.makedirs(os.path.dirname(inner_path), exist_ok=True)
+    inner_update_file = Path(inner_path)
+    inner_update_file.touch()
+
+    outer_update_file = Path(os.path.join(str(tmpdir), "outer.py"))
+    outer_update_file.touch()
+
+    working_dir = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        config = Config(app=None, reload=True, reload_dirs=["inner_dir"])
+        reloader = StatReload(config, target=run, sockets=[])
+        reloader.signal_handler(sig=signal.SIGINT, frame=None)
+        reloader.startup()
+
+        assert not reloader.should_restart()
+        time.sleep(0.1)
+        inner_update_file.touch()
+        assert reloader.should_restart()
+
+        reloader.restart()
+
+        assert not reloader.should_restart()
+        time.sleep(0.1)
+        outer_update_file.touch()
+        assert not reloader.should_restart()
+
+        reloader.shutdown()
+    finally:
+        os.chdir(working_dir)
+
+
+def test_should_respect_reload_types(tmpdir):
+    """
+    Test to verify that the reload_types config option is respected.
+    """
+    py_update_file = Path(os.path.join(str(tmpdir), "example.py"))
+    py_update_file.touch()
+
+    elm_update_file = Path(os.path.join(str(tmpdir), "example.elm"))
+    elm_update_file.touch()
+
+    working_dir = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        config = Config(app=None, reload=True, reload_types=[".py", ".elm"])
+        reloader = StatReload(config, target=run, sockets=[])
+        reloader.signal_handler(sig=signal.SIGINT, frame=None)
+        reloader.startup()
+
+        assert not reloader.should_restart()
+        time.sleep(0.1)
+        py_update_file.touch()
+        assert reloader.should_restart()
+
+        reloader.restart()
+
+        assert not reloader.should_restart()
+        time.sleep(0.1)
+        elm_update_file.touch()
         assert reloader.should_restart()
 
         reloader.restart()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -124,6 +124,7 @@ class Config:
         debug=False,
         reload=False,
         reload_dirs=None,
+        reload_types=None,
         workers=None,
         proxy_headers=True,
         forwarded_allow_ips=None,
@@ -183,6 +184,11 @@ class Config:
             self.reload_dirs = [os.getcwd()]
         else:
             self.reload_dirs = reload_dirs
+
+        if reload_types is None:
+            self.reload_types = [".py"]
+        else:
+            self.reload_types = reload_types
 
         if env_file is not None:
             from dotenv import load_dotenv

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -88,6 +88,12 @@ def print_version(ctx, param, value):
     help="Set reload directories explicitly, instead of using the current working directory.",
 )
 @click.option(
+    "--reload-types",
+    "reload_types",
+    multiple=True,
+    help="Specify the types of files that tigger reloads, instead of only reloading when .py files are changed.",
+)
+@click.option(
     "--workers",
     default=None,
     type=int,
@@ -270,6 +276,7 @@ def main(
     debug: bool,
     reload: bool,
     reload_dirs: typing.List[str],
+    reload_types: typing.List[str],
     workers: int,
     env_file: str,
     log_config: str,
@@ -311,6 +318,7 @@ def main(
         "debug": debug,
         "reload": reload,
         "reload_dirs": reload_dirs if reload_dirs else None,
+        "reload_types": reload_types if reload_types else None,
         "workers": workers,
         "proxy_headers": proxy_headers,
         "forwarded_allow_ips": forwarded_allow_ips,

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -95,5 +95,5 @@ class StatReload:
         for reload_dir in self.config.reload_dirs:
             for subdir, dirs, files in os.walk(reload_dir):
                 for file in files:
-                    if file.endswith(".py"):
+                    if any(file.endswith(x) for x in self.config.reload_types):
                         yield subdir + os.sep + file


### PR DESCRIPTION
Solves #528 
Helps #102 

`reload_types` is a config option that allows the specification of multiple file suffixes to be monitored.