### PR TITLE
Check that socket exists on shutdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ def get_version(package):
     """
     Return package version as listed in `__version__` in `init.py`.
     """
-    path = os.path.join(package, '__init__.py')
-    init_py = open(path, 'r', encoding='utf8').read()
+    path = os.path.join(package, "__init__.py")
+    init_py = open(path, "r", encoding="utf8").read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
 
@@ -22,16 +22,18 @@ def get_long_description():
     """
     Return the README.
     """
-    return open('README.md', 'r', encoding='utf8').read()
+    return open("README.md", "r", encoding="utf8").read()
 
 
 def get_packages(package):
     """
     Return root package and all sub-packages.
     """
-    return [dirpath
-            for dirpath, dirnames, filenames in os.walk(package)
-            if os.path.exists(os.path.join(dirpath, '__init__.py'))]
+    return [
+        dirpath
+        for dirpath, dirnames, filenames in os.walk(package)
+        if os.path.exists(os.path.join(dirpath, "__init__.py"))
+    ]
 
 
 env_marker = (
@@ -50,34 +52,34 @@ requirements = [
 
 
 setup(
-    name='uvicorn',
-    version=get_version('uvicorn'),
-    url='https://github.com/encode/uvicorn',
-    license='BSD',
-    description='The lightning-fast ASGI server.',
+    name="uvicorn",
+    version=get_version("uvicorn"),
+    url="https://github.com/encode/uvicorn",
+    license="BSD",
+    description="The lightning-fast ASGI server.",
     long_description=get_long_description(),
-    long_description_content_type='text/markdown',
-    author='Tom Christie',
-    author_email='tom@tomchristie.com',
-    packages=get_packages('uvicorn'),
+    long_description_content_type="text/markdown",
+    author="Tom Christie",
+    author_email="tom@tomchristie.com",
+    packages=get_packages("uvicorn"),
     install_requires=requirements,
-    data_files = [("", ["LICENSE.md"])],
+    data_files=[("", ["LICENSE.md"])],
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Topic :: Internet :: WWW/HTTP',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
+        "Development Status :: 4 - Beta",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Topic :: Internet :: WWW/HTTP",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     entry_points="""
     [console_scripts]
     uvicorn=uvicorn.main:main
-    """
+    """,
 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ import asyncio
 import requests
 
 from uvicorn.config import Config
-from uvicorn.main import Server, run
+from uvicorn.main import Server
 
 
 def test_run():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,11 @@
 import threading
 import time
+import asyncio
 
 import requests
 
 from uvicorn.config import Config
-from uvicorn.main import Server
+from uvicorn.main import Server, run
 
 
 def test_run():
@@ -80,3 +81,43 @@ def test_run_reload():
     response = requests.get("http://127.0.0.1:8000")
     assert response.status_code == 204
     thread.join()
+
+
+def test_run_with_shutdown():
+    class App:
+        def __init__(self, scope):
+            if scope["type"] != "http":
+                raise Exception()
+
+        async def __call__(self, receive, send):
+            while True:
+                time.sleep(1)
+
+    class CustomServer(Server):
+        def install_signal_handlers(self):
+            pass
+
+    config = Config(app=App, loop="asyncio", workers=2, limit_max_requests=1)
+    server = CustomServer(config=config)
+    sock = config.bind_socket()
+    exc = True
+
+    def safe_run():
+        nonlocal exc, server
+        try:
+            exc = None
+            config.setup_event_loop()
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(server.serve(sockets=[sock]))
+        except Exception as e:
+            exc = e
+
+    thread = threading.Thread(target=safe_run)
+    thread.start()
+
+    while not server.started:
+        time.sleep(0.01)
+
+    server.should_exit = True
+    thread.join()
+    assert exc is None

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -527,10 +527,11 @@ class Server:
         logger.info("Shutting down")
 
         # Stop accepting new connections.
-        for socket in sockets or []:
-            socket.close()
         for server in self.servers:
             server.close()
+        for socket in sockets or []:
+            if socket != None:
+                socket.close()
         for server in self.servers:
             await server.wait_closed()
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -530,8 +530,7 @@ class Server:
         for server in self.servers:
             server.close()
         for socket in sockets or []:
-            if socket != None:
-                socket.close()
+            socket.close()
         for server in self.servers:
             await server.wait_closed()
 


### PR DESCRIPTION
- Reverses the order during `Server.shutdown()` such that a server (which may have a reference to sockets) is closed first followed by a safe close of any remaining sockets.
- Adds a test ensuring when binding to a socket (usually done in `main,py run()`) that `server.serve(sockets=[sock])` does not raise any exceptions (as seen in #565).
- black formatting for `setup.py`

Closes #565