### PR TITLE
Add search for a trusted host in ProxyHeadersMiddleware

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -52,7 +52,7 @@ async def test_proxy_headers_trusted_hosts(trusted_hosts, response_text):
             ["127.0.0.1", "10.0.2.1", "192.168.0.2"],
             "Remote: https://1.2.3.4:0",
         ),
-        # order isn't matter
+        # order doesn't matter
         (
             ["10.0.2.1", "192.168.0.2", "127.0.0.1"],
             "Remote: https://1.2.3.4:0",

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -13,34 +13,79 @@ async def app(scope, receive, send):
     await response(scope, receive, send)
 
 
-app = ProxyHeadersMiddleware(app, trusted_hosts="*")
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trusted_hosts", "response_text"),
+    [
+        # always trust
+        ("*", "Remote: https://1.2.3.4:0"),
+        # trusted proxy
+        ("127.0.0.1", "Remote: https://1.2.3.4:0"),
+        (["127.0.0.1"], "Remote: https://1.2.3.4:0"),
+        # trusted proxy list
+        (["127.0.0.1", "10.0.0.1"], "Remote: https://1.2.3.4:0"),
+        ("127.0.0.1, 10.0.0.1", "Remote: https://1.2.3.4:0"),
+        # request from untrusted proxy
+        ("192.168.0.1", "Remote: http://127.0.0.1:123"),
+    ],
+)
+async def test_proxy_headers_trusted_hosts(trusted_hosts, response_text):
+    app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
+    async with httpx.AsyncClient(
+        app=app_with_middleware, base_url="http://testserver"
+    ) as client:
+        headers = {"X-Forwarded-Proto": "https", "X-Forwarded-For": "1.2.3.4"}
+        response = await client.get("/", headers=headers)
+
+    assert response.status_code == 200
+    assert response.text == response_text
 
 
 @pytest.mark.asyncio
-async def test_proxy_headers():
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
-        headers = {"X-Forwarded-Proto": "https", "X-Forwarded-For": "1.2.3.4"}
+@pytest.mark.parametrize(
+    ("trusted_hosts", "response_text"),
+    [
+        # always trust
+        ("*", "Remote: https://1.2.3.4:0"),
+        # all proxies are trusted
+        (
+            ["127.0.0.1", "10.0.2.1", "192.168.0.2"],
+            "Remote: https://1.2.3.4:0",
+        ),
+        # order isn't matter
+        (
+            ["10.0.2.1", "192.168.0.2", "127.0.0.1"],
+            "Remote: https://1.2.3.4:0",
+        ),
+        # should set first untrusted as remote address
+        (["192.168.0.2", "127.0.0.1"], "Remote: https://10.0.2.1:0"),
+    ],
+)
+async def test_proxy_headers_multiple_proxies(trusted_hosts, response_text):
+    app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
+    async with httpx.AsyncClient(
+        app=app_with_middleware, base_url="http://testserver"
+    ) as client:
+        headers = {
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-For": "1.2.3.4, 10.0.2.1, 192.168.0.2",
+        }
         response = await client.get("/", headers=headers)
-    assert response.status_code == 200
-    assert response.text == "Remote: https://1.2.3.4:0"
 
-
-@pytest.mark.asyncio
-async def test_proxy_headers_no_port():
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
-        headers = {"X-Forwarded-Proto": "https", "X-Forwarded-For": "1.2.3.4"}
-        response = await client.get("/", headers=headers)
     assert response.status_code == 200
-    assert response.text == "Remote: https://1.2.3.4:0"
+    assert response.text == response_text
 
 
 @pytest.mark.asyncio
 async def test_proxy_headers_invalid_x_forwarded_for():
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+    app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
+    async with httpx.AsyncClient(
+        app=app_with_middleware, base_url="http://testserver"
+    ) as client:
         headers = httpx.Headers(
             {
                 "X-Forwarded-Proto": "https",
-                "X-Forwarded-For": "\xf0\xfd\xfd\xfd, 1.2.3.4",
+                "X-Forwarded-For": "1.2.3.4, \xf0\xfd\xfd\xfd",
             },
             encoding="latin-1",
         )

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -8,6 +8,7 @@ the connecting client, rather that the connecting proxy.
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
+from typing import List
 
 
 class ProxyHeadersMiddleware:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -34,11 +34,11 @@ class ProxyHeadersMiddleware:
                     scope["scheme"] = x_forwarded_proto.strip()
 
                 if b"x-forwarded-for" in headers:
-                    # Determine the client address from the last trusted IP in the
+                    # Determine the client address from the first trusted IP in the
                     # X-Forwarded-For header. We've lost the connecting client's port
                     # information by now, so only include the host.
                     x_forwarded_for = headers[b"x-forwarded-for"].decode("latin1")
-                    host = x_forwarded_for.split(",")[-1].strip()
+                    host = x_forwarded_for.split(",")[0].strip()
                     port = 0
                     scope["client"] = (host, port)
 


### PR DESCRIPTION
Fixes #590 

If we have `*` in trusted proxies we should return the first host in the `X-Forwarded-For` as the client address.

In other cases, we should iterate over `X-Forwarded-For` hosts backward and return the first host which isn't included in trusted proxies