### PR TITLE
Add support for `forwarded-allow-ips` to gunicorn worker

### DIFF
--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from gunicorn.workers.base import Worker
+
 from uvicorn.config import Config
 from uvicorn.main import Server
 
@@ -32,6 +33,7 @@ class UvicornWorker(Worker):
             "timeout_notify": self.timeout,
             "callback_notify": self.callback_notify,
             "limit_max_requests": self.max_requests,
+            "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
         }
 
         if self.cfg.is_ssl:


### PR DESCRIPTION
Fixes #589 