### PR TITLE
WIP: ability to blur some headers values in access logs to avoid leaking sensitive info

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -200,9 +200,7 @@ def test_request_logging2(path, protocol_cls, caplog):
     caplog.set_level(logging.INFO, logger="uvicorn.access")
     logging.getLogger("uvicorn.access").propagate = True
 
-    app = Response(
-        "Hello, world", media_type="text/plain",
-    )
+    app = Response("Hello, world", media_type="text/plain",)
 
     protocol = get_connected_protocol(app, protocol_cls, log_config=None)
     protocol.data_received(get_request_with_query_string)
@@ -221,10 +219,9 @@ def test_request_logging2(path, protocol_cls, caplog):
     protocol.loop.run_one()
 
     assert '"GET {} HTTP/1.1" 200'.format(path) in caplog.records[1].message
-    assert [
-        (b"host", b"example.org"),
-        (b"authorization", b"****"),
-    ] == caplog.records[1].scope["headers"]
+    assert [(b"host", b"example.org"), (b"authorization", b"****"),] == caplog.records[
+        1
+    ].scope["headers"]
 
 
 scopeblurred = [
@@ -258,14 +255,14 @@ scopeblurred = [
             "query_string": b"",
             "headers": [(b"host", b"example.org"), (b"authorization", b"****")],
         },
-        [b"authorization"]
+        [b"authorization"],
     )
 ]
 
 
 @pytest.mark.parametrize("original_scope,blurred_scope,blurme", scopeblurred)
 def test_blurred_scope(original_scope, blurred_scope, blurme):
-   assert blurscope(original_scope, blurme) == blurred_scope
+    assert blurscope(original_scope, blurme) == blurred_scope
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
+import asyncio
 import threading
 import time
-import asyncio
 
 import requests
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -141,6 +141,7 @@ class Config:
         ssl_ca_certs=None,
         ssl_ciphers="TLSv1",
         headers=None,
+        exclude_scope_keys=None,
     ):
         self.app = app
         self.host = host
@@ -175,7 +176,7 @@ class Config:
         self.ssl_ciphers = ssl_ciphers
         self.headers = headers if headers else []  # type: List[str]
         self.encoded_headers = None  # type: List[Tuple[bytes, bytes]]
-
+        self.exclude_scope_keys = exclude_scope_keys
         self.loaded = False
         self.configure_logging()
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -87,6 +87,7 @@ class H11Protocol(asyncio.Protocol):
         self.logger = logging.getLogger("uvicorn.error")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
+        self.exclude_scope_keys = config.exclude_scope_keys
         self.conn = h11.Connection(h11.SERVER)
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
@@ -227,7 +228,8 @@ class H11Protocol(asyncio.Protocol):
                     logger=self.logger,
                     access_logger=self.access_logger,
                     access_log=self.access_log,
-                    default_headers=self.default_headers,
+                    exclude_scope_keys = self.exclude_scope_keys,
+                default_headers=self.default_headers,
                     message_event=self.message_event,
                     on_response=self.on_response_complete,
                 )
@@ -351,6 +353,7 @@ class RequestResponseCycle:
         logger,
         access_logger,
         access_log,
+        exclude_scope_keys,
         default_headers,
         message_event,
         on_response,
@@ -360,8 +363,9 @@ class RequestResponseCycle:
         self.transport = transport
         self.flow = flow
         self.logger = logger
-        self.access_logger = logger
+        self.access_logger = access_logger
         self.access_log = access_log
+        self.exclude_scope_keys = exclude_scope_keys
         self.default_headers = default_headers
         self.message_event = message_event
         self.on_response = on_response

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -11,7 +11,7 @@ from uvicorn.protocols.utils import (
     get_path_with_query_string,
     get_remote_addr,
     is_ssl,
-)
+    blurscope)
 
 
 def _get_status_phrase(status_code):
@@ -448,6 +448,10 @@ class RequestResponseCycle:
             headers = self.default_headers + message.get("headers", [])
 
             if self.access_log:
+                if self.exclude_scope_keys is not None:
+                    blurred_scope = blurscope(self.scope, self.exclude_scope_keys)
+                else:
+                    blurred_scope = self.scope
                 self.access_logger.info(
                     '%s - "%s %s HTTP/%s" %d',
                     get_client_addr(self.scope),
@@ -455,7 +459,7 @@ class RequestResponseCycle:
                     get_path_with_query_string(self.scope),
                     self.scope["http_version"],
                     status_code,
-                    extra={"status_code": status_code, "scope": self.scope},
+                    extra={"status_code": status_code, "scope": blurred_scope},
                 )
 
             # Write response status line and headers

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -6,12 +6,13 @@ from urllib.parse import unquote
 import h11
 
 from uvicorn.protocols.utils import (
+    blurscope,
     get_client_addr,
     get_local_addr,
     get_path_with_query_string,
     get_remote_addr,
     is_ssl,
-    blurscope)
+)
 
 
 def _get_status_phrase(status_code):
@@ -228,8 +229,8 @@ class H11Protocol(asyncio.Protocol):
                     logger=self.logger,
                     access_logger=self.access_logger,
                     access_log=self.access_log,
-                    exclude_scope_keys = self.exclude_scope_keys,
-                default_headers=self.default_headers,
+                    exclude_scope_keys=self.exclude_scope_keys,
+                    default_headers=self.default_headers,
                     message_event=self.message_event,
                     on_response=self.on_response_complete,
                 )

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -6,12 +6,13 @@ import urllib
 import httptools
 
 from uvicorn.protocols.utils import (
+    blurscope,
     get_client_addr,
     get_local_addr,
     get_path_with_query_string,
     get_remote_addr,
     is_ssl,
-    blurscope)
+)
 
 
 def _get_status_line(status_code):

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,5 +1,5 @@
 import socket
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 
 def get_remote_addr(transport):

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,4 +1,5 @@
 import socket
+from typing import Dict, Any, List
 
 
 def get_remote_addr(transport):
@@ -55,3 +56,12 @@ def get_path_with_query_string(scope):
             path_with_query_string, scope["query_string"].decode("ascii")
         )
     return path_with_query_string
+
+
+def blurscope(original_scope: Dict[str, Any], blurme: List[bytes]):
+    blurred_scope = original_scope
+    for idx, header_tuple in enumerate(original_scope["headers"]):
+        for bm in blurme:
+            if header_tuple[0] == bm:
+                blurred_scope["headers"][idx] = (bm, b"****")
+    return blurred_scope


### PR DESCRIPTION
rough draft for #551 

It adds a config kwarg `exclude_scope_keys` that takes a list of bytes

so if you pass for instance `exclude_scope_keys=[b"authorization"]` you're getting access logs with the headers values whose key match authorization replaced by `****`, no bearer tokens leaked.

I just wrote one test and there are some further checks that should be made, but I just wanted to see if in current state that would be something to work more on.
 