### PR TITLE
Access logger variable fixed, should_upgrade never used

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -200,7 +200,6 @@ class H11Protocol(asyncio.Protocol):
                     "headers": self.headers,
                 }
 
-                should_upgrade = False
                 for name, value in self.headers:
                     if name == b"connection":
                         tokens = [token.lower().strip() for token in value.split(b",")]
@@ -360,7 +359,7 @@ class RequestResponseCycle:
         self.transport = transport
         self.flow = flow
         self.logger = logger
-        self.access_logger = logger
+        self.access_logger = access_logger
         self.access_log = access_log
         self.default_headers = default_headers
         self.message_event = message_event


### PR DESCRIPTION
Small fix in h11 implementation, one variable is never used, the other was assigned incorrectly