### PR TITLE
Cleanup fixes for watchdog reload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = [
     "uvloop>=0.14.0 ;" + env_marker,
 ]
 
-extras_require = {"watchdogreload": ["watchdog>0.10,<0.11"]},
+extras_require = {"watchdogreload": ["watchdog>0.10,<0.11"]}
 
 
 setup(

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -36,13 +36,6 @@ class BaseReload:
                 self.restart()
         self.shutdown()
 
-    def run(self):
-        self.startup()
-        while not self.should_exit.wait(0.25):
-            if self.should_restart():
-                self.restart()
-        self.shutdown()
-
     def startup(self):
         message = "Started reloader process [{}]".format(str(self.pid))
         color_message = "Started reloader process [{}]".format(


### PR DESCRIPTION
Cleanup for #609 

- `.run()` method on `BaseReloader` was duplicated. (Could have been detected by flake8, but it's not part of the toolchain here. Has it been removed?)
- `setup.py` is broken due to a typo on the `extras_require` declaration:

```console
    ERROR: Command errored out with exit status 1:
     command: /Users/florimond.manca/Developer/encode-projects/uvicorn/venv/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/Users/florimond.manca/Developer/encode-projects/uvicorn/setup.py'"'"'; __file__='"'"'/Users/florimond.manca/Developer/encode-projects/uvicorn/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /Users/florimond.manca/Developer/encode-projects/uvicorn/
    Complete output (1 lines):
    error in uvicorn setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```