### PR TITLE
Add flake8 to linters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ install:
         choco install python3;
         export PATH=/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH;
         python -m pip install -U click h11 wsproto==0.13.* websockets==8.*;
-        python -m pip install -U autoflake black codecov isort pytest pytest-cov requests watchdog;
+        python -m pip install -U autoflake black codecov flake8 isort pytest pytest-cov requests watchdog;
       elif [ "$TRAVIS_PYTHON_VERSION" = "pypy3" ]; then
         pip install -U click h11 wsproto==0.13.*;
-        pip install -U autoflake codecov isort pytest pytest-cov requests watchdog;
+        pip install -U autoflake codecov flake8 isort pytest pytest-cov requests watchdog;
       else
         pip install -U -r requirements.txt;
       fi;

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ wsproto==0.13.*
 autoflake
 black
 codecov
+flake8
 isort
 pytest
 pytest-cov

--- a/scripts/test
+++ b/scripts/test
@@ -13,6 +13,7 @@ set -x
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=uvicorn --cov=tests --cov-report=term-missing ${@}
 ${PREFIX}coverage html
 ${PREFIX}autoflake --recursive uvicorn tests
+${PREFIX}flake8 uvicorn tests
 if [ "${TRAVIS_PYTHON_VERSION}" = "pypy3" ]; then
     echo "Skipping 'black' on pypy3.6-7.1.1. See issue https://bitbucket.org/pypy/pypy/issues/2985"
 else

--- a/scripts/test
+++ b/scripts/test
@@ -13,7 +13,7 @@ set -x
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=uvicorn --cov=tests --cov-report=term-missing ${@}
 ${PREFIX}coverage html
 ${PREFIX}autoflake --recursive uvicorn tests
-${PREFIX}flake8 uvicorn tests
+${PREFIX}flake8 uvicorn tests --ignore=W503,E203,E501,E731
 if [ "${TRAVIS_PYTHON_VERSION}" = "pypy3" ]; then
     echo "Skipping 'black' on pypy3.6-7.1.1. See issue https://bitbucket.org/pypy/pypy/issues/2985"
 else

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-ignore = W503, E203, E501, E731
-max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore = W503, E203, E501, E731
+max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 
 import os
 import re
-import sys
-import platform
 
 from setuptools import setup
 
@@ -50,7 +48,7 @@ requirements = [
     "uvloop>=0.14.0 ;" + env_marker,
 ]
 
-extras_require = {"watchdogreload": ["watchdog>0.10,<0.11"]},
+extras_require = {"watchdogreload": ["watchdog>0.10,<0.11"]}
 
 
 setup(

--- a/tests/importer/raise_import_error.py
+++ b/tests/importer/raise_import_error.py
@@ -2,4 +2,4 @@
 
 myattr = 123
 
-import does_not_exist
+import does_not_exist  # noqa

--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -8,7 +8,7 @@ TRACE_LOG_LEVEL = 5
 
 def test_message_logger(caplog):
     async def app(scope, receive, send):
-        message = await receive()
+        await receive()
         await send({"type": "http.response.start", "status": 200, "headers": []})
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -35,7 +35,7 @@ def raise_exception(environ, start_response):
 def return_exc_info(environ, start_response):
     try:
         raise RuntimeError("Something went wrong")
-    except:
+    except RuntimeError:
         status = "500 Internal Server Error"
         output = b"Internal Server Error"
         headers = [
@@ -68,7 +68,7 @@ def test_wsgi_exception():
     app = WSGIMiddleware(raise_exception)
     client = TestClient(app)
     with pytest.raises(RuntimeError):
-        response = client.get("/")
+        client.get("/")
 
 
 def test_wsgi_exc_info():

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1,14 +1,12 @@
 import asyncio
 import logging
 
-import h11
 import pytest
 
 from tests.response import Response
 from uvicorn.config import Config
 from uvicorn.main import ServerState
 from uvicorn.protocols.http.h11_impl import H11Protocol
-from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
 try:
     from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -26,7 +26,7 @@ class MockTransport:
 
 def test_get_local_addr_with_socket():
     transport = MockTransport({"socket": MockSocket(family=socket.AF_IPX)})
-    assert get_local_addr(transport) == None
+    assert get_local_addr(transport) is None
 
     transport = MockTransport(
         {"socket": MockSocket(family=socket.AF_INET6, sockname=["::1", 123])}
@@ -41,7 +41,7 @@ def test_get_local_addr_with_socket():
 
 def test_get_remote_addr_with_socket():
     transport = MockTransport({"socket": MockSocket(family=socket.AF_IPX)})
-    assert get_remote_addr(transport) == None
+    assert get_remote_addr(transport) is None
 
     transport = MockTransport(
         {"socket": MockSocket(family=socket.AF_INET6, peername=["::1", 123])}
@@ -56,7 +56,7 @@ def test_get_remote_addr_with_socket():
 
 def test_get_local_addr():
     transport = MockTransport({"sockname": "path/to/unix-domain-socket"})
-    assert get_local_addr(transport) == None
+    assert get_local_addr(transport) is None
 
     transport = MockTransport({"sockname": ["123.45.6.7", 123]})
     assert get_local_addr(transport) == ("123.45.6.7", 123)
@@ -64,7 +64,7 @@ def test_get_local_addr():
 
 def test_get_remote_addr():
     transport = MockTransport({"peername": None})
-    assert get_remote_addr(transport) == None
+    assert get_remote_addr(transport) is None
 
     transport = MockTransport({"peername": ["123.45.6.7", 123]})
     assert get_remote_addr(transport) == ("123.45.6.7", 123)

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -227,7 +227,7 @@ def test_send_and_close_connection(protocol_cls):
             is_open = True
             try:
                 await websocket.recv()
-            except:
+            except Exception:
                 is_open = False
             return (data, is_open)
 
@@ -299,7 +299,7 @@ def test_send_after_protocol_close(protocol_cls):
             is_open = True
             try:
                 await websocket.recv()
-            except:
+            except Exception:
                 is_open = False
             return (data, is_open)
 
@@ -363,7 +363,7 @@ def test_duplicate_handshake(protocol_cls):
 
     async def connect(url):
         async with websockets.connect(url) as websocket:
-            data = await websocket.recv()
+            _ = await websocket.recv()
 
     with run_server(App, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
@@ -386,7 +386,7 @@ def test_asgi_return_value(protocol_cls):
 
     async def connect(url):
         async with websockets.connect(url) as websocket:
-            data = await websocket.recv()
+            _ = await websocket.recv()
 
     with run_server(app, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -3,8 +3,6 @@ import signal
 import time
 from pathlib import Path
 
-import pytest
-
 from uvicorn.config import Config
 from uvicorn.supervisors.statreload import StatReload
 

--- a/tests/supervisors/test_watchdogreload.py
+++ b/tests/supervisors/test_watchdogreload.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 from uvicorn.config import Config
-from uvicorn.main import Server
 from uvicorn.supervisors.watchdogreload import WatchdogReload
 
 

--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -28,7 +28,7 @@ except ImportError:  # pragma: no cover
 
 
 def test_loop_auto():
-    loop = auto_loop_setup()
+    auto_loop_setup()
     policy = asyncio.get_event_loop_policy()
     assert isinstance(policy, asyncio.events.BaseDefaultEventLoopPolicy)
     expected_loop = "asyncio" if uvloop is None else "uvloop"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,3 @@
-import pytest
-
 from tests.client import TestClient
 
 

--- a/uvicorn/importer.py
+++ b/uvicorn/importer.py
@@ -28,7 +28,7 @@ def import_from_string(import_str):
     try:
         for attr_str in attrs_str.split("."):
             instance = getattr(instance, attr_str)
-    except AttributeError as exc:
+    except AttributeError:
         message = 'Attribute "{attrs_str}" not found in module "{module_str}".'
         raise ImportFromStringError(
             message.format(attrs_str=attrs_str, module_str=module_str)

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -1,7 +1,7 @@
 def auto_loop_setup():
     try:
-        import uvloop
-    except ImportError as exc:  # pragma: no cover
+        import uvloop  # noqa
+    except ImportError:  # pragma: no cover
         from uvicorn.loops.asyncio import asyncio_setup as loop_setup
 
         loop_setup()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -529,8 +529,8 @@ class Server:
         # Stop accepting new connections.
         for server in self.servers:
             server.close()
-        for socket in sockets or []:
-            socket.close()
+        for sock in sockets or []:
+            sock.close()
         for server in self.servers:
             await server.wait_closed()
 
@@ -563,7 +563,7 @@ class Server:
         try:
             for sig in HANDLED_SIGNALS:
                 loop.add_signal_handler(sig, self.handle_exit, sig, None)
-        except NotImplementedError as exc:
+        except NotImplementedError:
             # Windows
             for sig in HANDLED_SIGNALS:
                 signal.signal(sig, self.handle_exit)

--- a/uvicorn/protocols/http/auto.py
+++ b/uvicorn/protocols/http/auto.py
@@ -1,6 +1,6 @@
 try:
-    import httptools
-except ImportError as exc:  # pragma: no cover
+    import httptools  # noqa
+except ImportError:  # pragma: no cover
     from uvicorn.protocols.http.h11_impl import H11Protocol
 
     AutoHTTPProtocol = H11Protocol

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -17,7 +17,7 @@ from uvicorn.protocols.utils import (
 def _get_status_phrase(status_code):
     try:
         return http.HTTPStatus(status_code).phrase.encode()
-    except ValueError as exc:
+    except ValueError:
         return b""
 
 
@@ -142,7 +142,7 @@ class H11Protocol(asyncio.Protocol):
             event = h11.ConnectionClosed()
             try:
                 self.conn.send(event)
-            except h11.LocalProtocolError as exc:
+            except h11.LocalProtocolError:
                 # Premature client disconnect
                 pass
 
@@ -165,7 +165,7 @@ class H11Protocol(asyncio.Protocol):
         while True:
             try:
                 event = self.conn.next_event()
-            except h11.RemoteProtocolError as exc:
+            except h11.RemoteProtocolError:
                 msg = "Invalid HTTP request received."
                 self.logger.warning(msg)
                 self.transport.close()
@@ -200,7 +200,6 @@ class H11Protocol(asyncio.Protocol):
                     "headers": self.headers,
                 }
 
-                should_upgrade = False
                 for name, value in self.headers:
                     if name == b"connection":
                         tokens = [token.lower().strip() for token in value.split(b",")]

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -17,7 +17,7 @@ from uvicorn.protocols.utils import (
 def _get_status_line(status_code):
     try:
         phrase = http.HTTPStatus(status_code).phrase.encode()
-    except ValueError as exc:
+    except ValueError:
         phrase = b""
     return b"".join([b"HTTP/1.1 ", str(status_code).encode(), b" ", phrase, b"\r\n"])
 
@@ -156,11 +156,11 @@ class HttpToolsProtocol(asyncio.Protocol):
 
         try:
             self.parser.feed_data(data)
-        except httptools.HttpParserError as exc:
+        except httptools.HttpParserError:
             msg = "Invalid HTTP request received."
             self.logger.warning(msg)
             self.transport.close()
-        except httptools.HttpParserUpgrade as exc:
+        except httptools.HttpParserUpgrade:
             self.handle_upgrade()
 
     def handle_upgrade(self):

--- a/uvicorn/protocols/websockets/auto.py
+++ b/uvicorn/protocols/websockets/auto.py
@@ -1,9 +1,9 @@
 try:
-    import websockets
-except ImportError as exc:  # pragma: no cover
+    import websockets  # noqa
+except ImportError:  # pragma: no cover
     try:
-        import wsproto
-    except ImportError as exc:
+        import wsproto  # noqa
+    except ImportError:
         AutoWebSocketsProtocol = None
     else:
         from uvicorn.protocols.websockets.wsproto_impl import WSProtocol

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -36,13 +36,6 @@ class BaseReload:
                 self.restart()
         self.shutdown()
 
-    def run(self):
-        self.startup()
-        while not self.should_exit.wait(0.25):
-            if self.should_restart():
-                self.restart()
-        self.shutdown()
-
     def startup(self):
         message = "Started reloader process [{}]".format(str(self.pid))
         color_message = "Started reloader process [{}]".format(

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -16,7 +16,7 @@ class StatReload(BaseReload):
         for filename in self.iter_py_files():
             try:
                 mtime = os.path.getmtime(filename)
-            except OSError as exc:  # pragma: nocover
+            except OSError:  # pragma: nocover
                 continue
 
             old_time = self.mtimes.get(filename)


### PR DESCRIPTION
This PR is a proposal to add `flake8` to the uvicorn toolchain.

HTTPX and other projects have shown me that having a linter (and not only a formatting fixer) is invualuable for catching subtle bugs and ensuring code quality as a whole. Eg #618 could have been avoided with `flake8` installed.

In any case, happy to pull down if that's not something we want — the original set of check tools added via #290 sticked to black, autoflake and isort, because that's what is in Starlette. (But I'd advocate for adding `flake8` to Starlette, too.)