### PR TITLE
Don't propagate logs to parent loggers in Gunicorn worker

### DIFF
--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -20,10 +20,12 @@ class UvicornWorker(Worker):
         logger = logging.getLogger("uvicorn.error")
         logger.handlers = self.log.error_log.handlers
         logger.setLevel(self.log.error_log.level)
+        logger.propagate = False
 
         logger = logging.getLogger("uvicorn.access")
         logger.handlers = self.log.access_log.handlers
         logger.setLevel(self.log.access_log.level)
+        logger.propagate = False
 
         config_kwargs = {
             "app": None,


### PR DESCRIPTION
Fixes #614, cc @tlc

This PR fixes an integration issue with Gunicorn where uvicorn logs would be duplicated if root handlers are present (eg if user code calls `logging.info()` & co).

Logs for the repro example in https://github.com/encode/uvicorn/issues/614#issuecomment-612077580 are now correct:

```console
$ gunicorn -k uvicorn.workers.UvicornWorker debug.issue_614:app
[2020-04-10 17:47:12 +0200] [78461] [INFO] Starting gunicorn 20.0.4
[2020-04-10 17:47:12 +0200] [78461] [INFO] Listening at: http://127.0.0.1:8000 (78461)
[2020-04-10 17:47:12 +0200] [78461] [INFO] Using worker: uvicorn.workers.UvicornWorker
[2020-04-10 17:47:12 +0200] [78463] [INFO] Booting worker with pid: 78463
[2020-04-10 17:47:13 +0200] [78463] [INFO] Started server process [78463]
[2020-04-10 17:47:13 +0200] [78463] [INFO] Waiting for application startup.
[2020-04-10 17:47:13 +0200] [78463] [INFO] Application startup complete.
```

Note: adding `"propagate": False` to the default `LOGGING_CONFIG` didn't work, because logging is already configured by Gunicorn by the point `Config()` calls `logging.dictConfig()`. (Not sure this wouldn't be something we should do, but it doesn't help with #614 so I left it out.)