### PR TITLE
Flake8 config file for project

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+ignore =
+    # Conflict W504 with old style W503. One of these things.
+    W503,
+    # The restriction on the length of strings.
+    E501
+exclude =
+    # Git certainly doesn't need to be checked.
+    .git,
+    # Bytecode directories to skiping.
+    __pycache__,
+    # Eggs from installation, they can not escape!
+    *.egg-info
+# Maximum number of conditions within one function.
+max-complexity = 32

--- a/.flake8
+++ b/.flake8
@@ -7,6 +7,8 @@ ignore =
 exclude =
     # Git certainly doesn't need to be checked.
     .git,
+    # Virtual environment doesn't need to be checked too.
+    venv,
     # Bytecode directories to skiping.
     __pycache__,
     # Eggs from installation, they can not escape!

--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,10 @@
 ignore =
     # Conflict W504 with old style W503. One of these things.
     W503,
+    # Whitespace before ':'.
+    E203,
+    # Do not assign a lambda expression, use a def. 
+    E731,
     # The restriction on the length of strings.
     E501
 exclude =

--- a/scripts/test
+++ b/scripts/test
@@ -13,7 +13,8 @@ set -x
 PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=uvicorn --cov=tests --cov-report=term-missing ${@}
 ${PREFIX}coverage html
 ${PREFIX}autoflake --recursive uvicorn tests
-${PREFIX}flake8 uvicorn tests --ignore=W503,E203,E501,E731
+# Flake8 configuration in the file ".flake8" of the root directory.
+${PREFIX}flake8 uvicorn tests
 if [ "${TRAVIS_PYTHON_VERSION}" = "pypy3" ]; then
     echo "Skipping 'black' on pypy3.6-7.1.1. See issue https://bitbucket.org/pypy/pypy/issues/2985"
 else


### PR DESCRIPTION
I found that the Flake8 parameters are hard-coded only in tests, but not used in the developer IDE. Therefore, I offer this universal option for convenience. Now you may be run command "flake8" without parameters in the root directory for checking a code or configure your IDE for automation with it.