### PR TITLE
ReadMe updated for uvloop if trying to build in a docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Install using `pip`:
 $ pip install uvicorn
 ```
 
+If trying to install in a docker image add this to `Dockerfile`:
+```
+RUN apk add build-base
+```
+
+
 Create an application, in `example.py`:
 
 ```python


### PR DESCRIPTION
If users trying to install in docker image they will get this error:

`ERROR: Failed building wheel for uvloop`

We can solve this problem by adding `RUN apk add build-base` in docker file.