### PR TITLE
Fix to get correct client ip behind proxy

### DIFF
--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -38,7 +38,7 @@ class ProxyHeadersMiddleware:
                     # X-Forwarded-For header. We've lost the connecting client's port
                     # information by now, so only include the host.
                     x_forwarded_for = headers[b"x-forwarded-for"].decode("ascii")
-                    host = x_forwarded_for.split(",")[-1].strip()
+                    host = x_forwarded_for.split(",")[0].strip()
                     port = 0
                     scope["client"] = (host, port)
 


### PR DESCRIPTION
According to Wikipedia [X-Forwarded-For](https://en.wikipedia.org/wiki/X-Forwarded-For):

> The general format of the field is:
>
> X-Forwarded-For: client, proxy1, proxy2[2]
> where the value is a comma+space separated list of IP addresses, the left-most being the original client, and each successive proxy that passed the request adding the IP address where it received the request from.

Therefore, in order to get the client address we need the leftmost ip, i.e first ip in the list.