### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+---
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    name: "Publish release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "actions/setup-python@v1"
+        with:
+          python-version: 3.7
+      - name: "Publish"
+        run: "scripts/publish"
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -2,8 +2,6 @@
 name: Test Suite
 
 on:
-  push:
-    branches: ["master"]
   pull_request:
     branches: ["master"]
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,31 +1,29 @@
 #!/bin/sh -e
 
-export VERSION=`cat uvicorn/__init__.py | grep __version__ | sed "s/__version__ = //" | sed "s/'//g"`
-export PREFIX=""
 if [ -d 'venv' ] ; then
-    export PREFIX="venv/bin/"
+    PREFIX="venv/bin/"
+else
+    PREFIX=""
 fi
 
-if ! command -v "${PREFIX}twine" &>/dev/null ; then
-    echo "Unable to find the 'twine' command."
-    echo "Install from PyPI, using '${PREFIX}pip install twine'."
+if [ ! -z "$GITHUB_ACTIONS" ]; then
+  git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git config --local user.name "GitHub Action"
+
+  VERSION=`grep __version__ ./uvicorn/__init__.py | grep -o '[0-9][^"]*'`
+
+  if [ "refs/tags/${VERSION}" != "${GITHUB_REF}" ] ; then
+    echo "GitHub Ref '${GITHUB_REF}' did not match package version '${VERSION}'"
     exit 1
+  fi
 fi
 
-if ! command -v "${PREFIX}wheel" &>/dev/null ; then
-    echo "Unable to find the 'wheel' command."
-    echo "Install from PyPI, using '${PREFIX}pip install wheel'."
-    exit 1
-fi
+set -x
 
 find uvicorn -type f -name "*.py[co]" -delete
 find uvicorn -type d -name __pycache__ -delete
 
+${PREFIX}pip install twine wheel mkdocs mkdocs-material mkautodoc
 ${PREFIX}python setup.py sdist bdist_wheel
 ${PREFIX}twine upload dist/*
-
-echo "You probably want to also tag the version now:"
-echo "git tag -a ${VERSION} -m 'version ${VERSION}'"
-echo "git push --tags"
-
-rm -r dist
+${PREFIX}mkdocs gh-deploy --force


### PR DESCRIPTION
Hi @encode/maintainers,

So, this PR is the start of rolling out GitHub Action based releases across the encode repos.
The great thing here is that we'll be able to create releases directly through GitHub, and anyone on the maintainer team will be able to do so.

I've turned on a bunch of settings that'll help us enforce a really careful, deliberate flow...

<img width="726" alt="Screenshot 2020-04-28 at 15 29 45" src="https://user-images.githubusercontent.com/647359/80499611-1ed1f580-8965-11ea-9d8c-6619f55b170c.png">

So:

* Everything *has* to come through a PR.
* All PRs *have* to have an approval review, including those from admins.
* Tests have to pass.
* Branches have to be up to date, which is nice since we then we only have to run tests on PRs, not also against the final "merge to master".

We'll have to see how this goes. We can make adjustments as needed, but seems like a great start.

I'm going to also issue a release PR alongside this, and we can use that to run a release, and check that there's nothing missing in the flow here.

I'll need a review from someone before I'm able to merge this.
