### PR TITLE
Version 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 0.11.4
 
 * Use `watchgod`, if installed, for watching code changes.
 * Reload application when any files in watched directories change, not just `.py` files.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 ---
 
-[![Build Status](https://travis-ci.org/encode/uvicorn.svg?branch=master)](https://travis-ci.org/encode/uvicorn)
-[![Coverage](https://codecov.io/gh/encode/uvicorn/branch/master/graph/badge.svg)](https://codecov.io/gh/encode/uvicorn)
+[![Build Status](https://github.com/encode/uvicorn/workflows/Test%20Suite/badge.svg)](https://github.com/encode/uvicorn/actions)
 [![Package version](https://badge.fury.io/py/uvicorn.svg)](https://pypi.python.org/pypi/uvicorn)
 
 **Documentation**: [https://www.uvicorn.org](https://www.uvicorn.org)

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,15 @@
 <em>The lightning-fast ASGI server.</em>
 </p>
 
+<p align="center">
+<a href="https://github.com/encode/uvicorn/actions">
+    <img src="https://github.com/encode/uvicorn/workflows/Test%20Suite/badge.svg" alt="Test Suite">
+</a>
+<a href="https://pypi.org/project/uvicorn/">
+    <img src="https://badge.fury.io/py/uvicorn.svg" alt="Package version">
+</a>
+</p>
+
 ---
 
 # Introduction

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.11.3"
+__version__ = "0.11.4"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
* Use `watchgod`, if installed, for watching code changes.
* Reload application when any files in watched directories change, not just `.py` files.

Requires #653 first, so that we've got GitHub actions setup to handle publishing new versions.

I've drafted a release, ready to publish once this has been merged... https://github.com/encode/uvicorn/releases/tag/untagged-d09964eb56f9304a4a91