### PR TITLE
Test those docs snippets

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,8 +36,8 @@ $ pip install uvicorn
 
 Create an application, in `example.py`:
 
-```python
-{!./src/index.py!}
+```python hl_lines="4"
+{!./src/index/example.py!}
 ```
 
 Run the server:
@@ -128,14 +128,8 @@ To run uvicorn directly from your application...
 
 **example.py**:
 
-```python
-import uvicorn
-
-async def app(scope, receive, send):
-    ...
-
-if __name__ == "__main__":
-    uvicorn.run("example:app", host="127.0.0.1", port=5000, log_level="info")
+```python hl_lines="19 20"
+{!./src/index/example.py!}
 ```
 
 ### Running with Gunicorn

--- a/docs/index.md
+++ b/docs/index.md
@@ -220,7 +220,6 @@ An incoming HTTP request might have a connection `scope` like this:
 
 The instance coroutine communicates back to the server by sending messages to the `send` coroutine.
 
-{!src/index_asgi_app.py}
 ```python
 await send({
     'type': 'http.response.start',

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,19 +37,7 @@ $ pip install uvicorn
 Create an application, in `example.py`:
 
 ```python
-async def app(scope, receive, send):
-    assert scope['type'] == 'http'
-    await send({
-        'type': 'http.response.start',
-        'status': 200,
-        'headers': [
-            [b'content-type', b'text/plain'],
-        ]
-    })
-    await send({
-        'type': 'http.response.body',
-        'body': b'Hello, world!',
-    })
+{!./src/index_asgi_app.py!}
 ```
 
 Run the server:
@@ -232,6 +220,7 @@ An incoming HTTP request might have a connection `scope` like this:
 
 The instance coroutine communicates back to the server by sending messages to the `send` coroutine.
 
+{!src/index_asgi_app.py}
 ```python
 await send({
     'type': 'http.response.start',

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ $ pip install uvicorn
 Create an application, in `example.py`:
 
 ```python
-{!./src/index_asgi_app.py!}
+{!./src/index.py!}
 ```
 
 Run the server:

--- a/docs/src/index.py
+++ b/docs/src/index.py
@@ -1,4 +1,4 @@
-async def app(scope, receive, send):
+async def example_app(scope, receive, send):
     assert scope['type'] == 'http'
     await send({
         'type': 'http.response.start',

--- a/docs/src/index/example.py
+++ b/docs/src/index/example.py
@@ -1,4 +1,7 @@
-async def example_app(scope, receive, send):
+import uvicorn
+
+
+async def app(scope, receive, send):
     assert scope['type'] == 'http'
     await send({
         'type': 'http.response.start',
@@ -11,3 +14,7 @@ async def example_app(scope, receive, send):
         'type': 'http.response.body',
         'body': b'Hello, world!',
     })
+
+
+if __name__ == "__main__":
+    uvicorn.run("example:app", host="127.0.0.1", port=5000, log_level="info")

--- a/docs/src/index_asgi_app.py
+++ b/docs/src/index_asgi_app.py
@@ -1,0 +1,13 @@
+async def app(scope, receive, send):
+    assert scope['type'] == 'http'
+    await send({
+        'type': 'http.response.start',
+        'status': 200,
+        'headers': [
+            [b'content-type', b'text/plain'],
+        ]
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': b'Hello, world!',
+    })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ pages:
 markdown_extensions:
   - markdown.extensions.codehilite:
       guess_lang: false
+  - markdown_include.include:
+      base_path: docs
 
 extra_javascript:
   - 'js/chat.js'

--- a/scripts/test
+++ b/scripts/test
@@ -7,7 +7,8 @@ fi
 
 set -x
 
-PYTHONPATH=. ${PREFIX}pytest --ignore venv --cov=uvicorn --cov=tests --cov-report=term-missing ${@}
+export PYTHONPATH=./docs/src
+${PREFIX}pytest --ignore venv --cov=uvicorn --cov=tests --cov=docs/src --cov-report=term-missing ${@}
 ${PREFIX}coverage html
 ${PREFIX}autoflake --recursive uvicorn tests
 ${PREFIX}flake8 uvicorn tests --ignore=W503,E203,E501,E731

--- a/tests/client.py
+++ b/tests/client.py
@@ -99,7 +99,11 @@ class _ASGIAdapter(requests.adapters.HTTPAdapter):
         response_started = False
         raw_kwargs = {"body": io.BytesIO()}
 
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except Exception:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
         try:
             loop.run_until_complete(self.app(scope, receive, send))

--- a/tests/test_docs_src/test_index.py
+++ b/tests/test_docs_src/test_index.py
@@ -1,0 +1,9 @@
+from docs.src.index import example_app
+from tests.client import TestClient
+
+
+def test_index_app():
+    client = TestClient(example_app, base_url="http://testserver")
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.text == "Hello, world!"

--- a/tests/test_docs_src/test_index.py
+++ b/tests/test_docs_src/test_index.py
@@ -1,9 +1,9 @@
-from docs.src.index import example_app
+from docs.src.index.example import app
 from tests.client import TestClient
 
 
 def test_index_app():
-    client = TestClient(example_app, base_url="http://testserver")
+    client = TestClient(app, base_url="http://testserver")
     response = client.get("/")
     assert response.status_code == 200
     assert response.text == "Hello, world!"


### PR DESCRIPTION
draft on testing examples / snippets in docs.

it essentially boils down to:

1. remove the snippets from the markdown
2. put them into a .py in `docs/src`
3. include the .py file in the md with help of the newly added `markdown-include`
3. adds a test on the snippets in `tests`

after doing it I found it's not that useful since the docs has a low number of examples so not sure it's worth it.
that sid examples could be expanded, I think in particular of logging where there seem to be lots of recurrent questions.

side-note: what would be amazing though is a markdown extension like shpinx-click to take care of the `uvicorn --help` in docs automatically but that's another story...