### PR TITLE
Revert "Reload when other files than py are changes, small test maintenance"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.11.4
 
 * Use `watchgod`, if installed, for watching code changes.
-* Reload application when any files in watched directories change, not just `.py` files.
 
 ## 0.11.3
 

--- a/tests/supervisors/__init__.py
+++ b/tests/supervisors/__init__.py
@@ -1,5 +1,0 @@
-WATCHED_FILES = (
-    "example.py",
-    "example.html",
-    "example.graphql",
-)

--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -3,12 +3,8 @@ import signal
 import time
 from pathlib import Path
 
-import pytest
-
 from uvicorn.config import Config
 from uvicorn.supervisors.statreload import StatReload
-
-from . import WATCHED_FILES
 
 
 def run(sockets):
@@ -28,9 +24,8 @@ def test_statreload():
     reloader.run()
 
 
-@pytest.mark.parametrize("filename", WATCHED_FILES)
-def test_should_reload_when_watched_file_is_changed(tmpdir, filename):
-    update_file = Path(tmpdir) / filename
+def test_should_reload(tmpdir):
+    update_file = Path(os.path.join(str(tmpdir), "example.py"))
     update_file.touch()
 
     working_dir = os.getcwd()
@@ -45,29 +40,6 @@ def test_should_reload_when_watched_file_is_changed(tmpdir, filename):
         time.sleep(0.1)
         update_file.touch()
         assert reloader.should_restart()
-
-        reloader.restart()
-        reloader.shutdown()
-    finally:
-        os.chdir(working_dir)
-
-
-def test_should_not_reload_when_dot_file_is_changed(tmpdir):
-    update_file = Path(tmpdir) / ".dotted"
-    update_file.touch()
-
-    working_dir = os.getcwd()
-    os.chdir(str(tmpdir))
-    try:
-        config = Config(app=None, reload=True)
-        reloader = StatReload(config, target=run, sockets=[])
-        reloader.signal_handler(sig=signal.SIGINT, frame=None)
-        reloader.startup()
-
-        assert not reloader.should_restart()
-        time.sleep(0.1)
-        update_file.touch()
-        assert not reloader.should_restart()
 
         reloader.restart()
         reloader.shutdown()

--- a/tests/supervisors/test_watchgodreload.py
+++ b/tests/supervisors/test_watchgodreload.py
@@ -3,12 +3,8 @@ import signal
 import time
 from pathlib import Path
 
-import pytest
-
 from uvicorn.config import Config
 from uvicorn.supervisors.watchgodreload import WatchGodReload
-
-from . import WATCHED_FILES
 
 
 def run(sockets):
@@ -22,9 +18,9 @@ def test_watchgodreload(certfile_and_keyfile):
     reloader.run()
 
 
-@pytest.mark.parametrize("filename", WATCHED_FILES)
-def test_should_reload_when_file_is_changed(tmpdir, filename):
-    update_file = Path(tmpdir) / filename
+def test_should_reload_when_python_file_is_changed(tmpdir):
+    file = "example.py"
+    update_file = Path(os.path.join(str(tmpdir), file))
     update_file.touch()
 
     working_dir = os.getcwd()
@@ -47,7 +43,8 @@ def test_should_reload_when_file_is_changed(tmpdir, filename):
 
 
 def test_should_not_reload_when_dot_file_is_changed(tmpdir):
-    update_file = Path(tmpdir) / ".dotted"
+    file = ".dotted"
+    update_file = Path(os.path.join(str(tmpdir), file))
     update_file.touch()
 
     working_dir = os.getcwd()

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -14,7 +14,7 @@ class StatReload(BaseReload):
         self.mtimes = {}
 
     def should_restart(self):
-        for filename in self.iter_files():
+        for filename in self.iter_py_files():
             try:
                 mtime = os.path.getmtime(filename)
             except OSError:  # pragma: nocover
@@ -33,9 +33,9 @@ class StatReload(BaseReload):
                 return True
         return False
 
-    def iter_files(self):
+    def iter_py_files(self):
         for reload_dir in self.config.reload_dirs:
             for subdir, dirs, files in os.walk(reload_dir):
                 for file in files:
-                    if not file.startswith("."):
+                    if file.endswith(".py"):
                         yield subdir + os.sep + file


### PR DESCRIPTION
Reverts encode/uvicorn#646

I think that just reverting this and issuing a release is probably the best first step. We can then follow up later with a different tack. (Eg. perhaps allow a filename pattern to be passed as config).

I think we want to get this and #658 in, and then issue a re-release right?