### PR TITLE
Use trace on asgi logger

### DIFF
--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -5,7 +5,6 @@ from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 
 
-
 def test_message_logger(caplog):
     async def app(scope, receive, send):
         await receive()

--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -1,9 +1,9 @@
 import pytest
 
 from tests.client import TestClient
+from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 
-TRACE_LOG_LEVEL = 5
 
 
 def test_message_logger(caplog):

--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -1,4 +1,3 @@
-import logging
 import platform
 import sys
 import threading

--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -94,7 +94,7 @@ def test_trace_logging(http_protocol, capsys):
     reason="Skipping test on Windows and PyPy",
 )
 @pytest.mark.parametrize("http_protocol", [("h11"), ("httptools")])
-def test_access_logging(capsys, caplog, http_protocol):
+def test_access_logging(capsys, http_protocol):
     class App:
         def __init__(self, scope):
             if scope["type"] != "http":

--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -8,7 +8,6 @@ import pytest
 import requests
 
 from uvicorn import Config, Server
-from uvicorn.config import TRACE_LOG_LEVEL
 
 test_logging_config = {
     "version": 1,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -18,7 +18,6 @@ from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 
-
 LOG_LEVELS = {
     "critical": logging.CRITICAL,
     "error": logging.ERROR,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -11,13 +11,13 @@ from typing import List, Tuple
 import click
 
 from uvicorn.importer import ImportFromStringError, import_from_string
+from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.middleware.asgi2 import ASGI2Middleware
 from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 
-TRACE_LOG_LEVEL = 5
 
 LOG_LEVELS = {
     "critical": logging.CRITICAL,

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -1,13 +1,13 @@
 import logging
 
+from uvicorn.logging import TRACE_LOG_LEVEL
+
 PLACEHOLDER_FORMAT = {
     "body": "<{length} bytes>",
     "bytes": "<{length} bytes>",
     "text": "<{length} chars>",
     "headers": "<...>",
 }
-TRACE_LOG_LEVEL = 5
-
 
 def message_with_placeholders(message):
     """

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -9,6 +9,7 @@ PLACEHOLDER_FORMAT = {
     "headers": "<...>",
 }
 
+
 def message_with_placeholders(message):
     """
     Return an ASGI message, with any body-type content omitted and replaced

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -125,12 +125,20 @@ class H11Protocol(asyncio.Protocol):
         self.client = get_remote_addr(transport)
         self.scheme = "https" if is_ssl(transport) else "http"
 
-        self.asgi_logger.log(TRACE_LOG_LEVEL, "%sConnection made", "%s:%d - " % tuple(self.client) if self.client else "")
+        self.asgi_logger.log(
+            TRACE_LOG_LEVEL,
+            "%sConnection made",
+            "%s:%d - " % tuple(self.client) if self.client else "",
+        )
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
-        self.asgi_logger.log(TRACE_LOG_LEVEL, "%sConnection lost",  "%s:%d - " % tuple(self.client) if self.client else "")
+        self.asgi_logger.log(
+            TRACE_LOG_LEVEL,
+            "%sConnection lost",
+            "%s:%d - " % tuple(self.client) if self.client else "",
+        )
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -129,12 +129,20 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.client = get_remote_addr(transport)
         self.scheme = "https" if is_ssl(transport) else "http"
 
-        self.asgi_logger.log(TRACE_LOG_LEVEL, "%sConnection made", "%s:%d - " % tuple(self.client) if self.client else "")
+        self.asgi_logger.log(
+            TRACE_LOG_LEVEL,
+            "%sConnection made",
+            "%s:%d - " % tuple(self.client) if self.client else "",
+        )
 
     def connection_lost(self, exc):
         self.connections.discard(self)
 
-        self.asgi_logger.log(TRACE_LOG_LEVEL, "%sConnection lost", "%s:%d - " % tuple(self.client) if self.client else "")
+        self.asgi_logger.log(
+            TRACE_LOG_LEVEL,
+            "%sConnection lost",
+            "%s:%d - " % tuple(self.client) if self.client else "",
+        )
 
         if self.cycle and not self.cycle.response_complete:
             self.cycle.disconnected = True


### PR DESCRIPTION
This PR does 2 things,

1. use uvicorn.asgi logger in h11 and httptools protocols instead of uvicorn.error for trace logs
2. put TRACE_LOG_LEVEL in a single place and import it when needed instead of having it copied everywhere

currently the `Connection made` and `Connection lost` messages are written to uvicorn.error

edit: now I have doubts and maybe it's intentional to have to messages at the trace level on the uvicorn.error
