### PR TITLE
Don't override the root logger

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -83,7 +83,7 @@ LOGGING_CONFIG = {
         },
     },
     "loggers": {
-        "": {"handlers": ["default"], "level": "INFO"},
+        "uvicorn": {"handlers": ["default"], "level": "INFO"},
         "uvicorn.error": {"level": "INFO"},
         "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
     },


### PR DESCRIPTION
Overriding the root logger is probably not intended here. 

This is just a PR for the fix proposed in https://github.com/encode/uvicorn/issues/630