### PR TITLE
Add server_name and protocol_name to config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,10 @@ import socket
 import pytest
 
 from uvicorn import protocols
-from uvicorn_core.config import Config
-from uvicorn_core.middleware.debug import DebugMiddleware
-from uvicorn_core.middleware.proxy_headers import ProxyHeadersMiddleware
-from uvicorn_core.middleware.wsgi import WSGIMiddleware
+from uvicorn.config import Config
+from uvicorn.middleware.debug import DebugMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from uvicorn.middleware.wsgi import WSGIMiddleware
 
 
 async def asgi_app():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,7 +50,7 @@ def test_app_unimportable():
 def test_concrete_http_class():
     config = Config(app=asgi_app, http=protocols.http.h11_impl.H11Protocol)
     config.load()
-    assert config.http_protocol_class is protocols.http.h11_impl.H11Protocol
+    assert config.protocol_class is protocols.http.h11_impl.H11Protocol
 
 
 def test_socket_bind():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,10 @@ import socket
 import pytest
 
 from uvicorn import protocols
-from uvicorn.config import Config
-from uvicorn.middleware.debug import DebugMiddleware
-from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
-from uvicorn.middleware.wsgi import WSGIMiddleware
+from uvicorn_core.config import Config
+from uvicorn_core.middleware.debug import DebugMiddleware
+from uvicorn_core.middleware.proxy_headers import ProxyHeadersMiddleware
+from uvicorn_core.middleware.wsgi import WSGIMiddleware
 
 
 async def asgi_app():
@@ -50,7 +50,7 @@ def test_app_unimportable():
 def test_concrete_http_class():
     config = Config(app=asgi_app, http=protocols.http.h11_impl.H11Protocol)
     config.load()
-    assert config.protocol_class is protocols.http.h11_impl.H11Protocol
+    assert config.http_protocol_class is protocols.http.h11_impl.H11Protocol
 
 
 def test_socket_bind():

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -141,6 +141,8 @@ class Config:
         ssl_ca_certs=None,
         ssl_ciphers="TLSv1",
         headers=None,
+        protocol_name="auto",
+        server_name="Uvicorn",
     ):
         self.app = app
         self.host = host
@@ -175,7 +177,8 @@ class Config:
         self.ssl_ciphers = ssl_ciphers
         self.headers = headers if headers else []  # type: List[str]
         self.encoded_headers = None  # type: List[Tuple[bytes, bytes]]
-
+        self.protocol_name = protocol_name
+        self.server_name = server_name
         self.loaded = False
         self.configure_logging()
 
@@ -322,15 +325,19 @@ class Config:
             sys.exit(1)
         sock.set_inheritable(True)
 
-        message = "Uvicorn running on %s://%s:%d (Press CTRL+C to quit)"
+        message = "%s running on %s://%s:%d (Press CTRL+C to quit)"
         color_message = (
-            "Uvicorn running on "
+            "%s running on "
             + click.style("%s://%s:%d", bold=True)
             + " (Press CTRL+C to quit)"
         )
-        protocol_name = "https" if self.is_ssl else "http"
+        if self.protocol_name == "auto":
+            protocol_name = "https" if self.is_ssl else "http"
+        else:
+            protocol_name = self.protocol_name
         logger.info(
             message,
+            self.server_name,
             protocol_name,
             self.host,
             self.port,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -50,7 +50,7 @@ LOOP_SETUPS = {
     "uvloop": "uvicorn.loops.uvloop:uvloop_setup",
 }
 INTERFACES = ["auto", "asgi3", "asgi2", "wsgi"]
-PROTOCOLS = ["auto", "http", "https"]
+PROTOCOL_NAMES = ["auto", "http", "https"]
 
 
 # Fallback to 'ssl.PROTOCOL_SSLv23' in order to support Python < 3.5.3.

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -50,7 +50,6 @@ LOOP_SETUPS = {
     "uvloop": "uvicorn.loops.uvloop:uvloop_setup",
 }
 INTERFACES = ["auto", "asgi3", "asgi2", "wsgi"]
-PROTOCOL_NAMES = ["auto", "http", "https"]
 
 
 # Fallback to 'ssl.PROTOCOL_SSLv23' in order to support Python < 3.5.3.
@@ -142,7 +141,6 @@ class Config:
         ssl_ca_certs=None,
         ssl_ciphers="TLSv1",
         headers=None,
-        protocol_class="auto",
         protocol_name="auto",
         server_name="Uvicorn",
     ):
@@ -181,7 +179,6 @@ class Config:
         self.encoded_headers = None  # type: List[Tuple[bytes, bytes]]
         self.protocol_name = protocol_name
         self.server_name = server_name
-        self.protocol_class = protocol_class
         self.loaded = False
         self.configure_logging()
 
@@ -268,11 +265,10 @@ class Config:
             else [(b"server", b"uvicorn")] + encoded_headers
         )  # type: List[Tuple[bytes, bytes]]
 
-        if self.protocol_class == "auto":
-            if isinstance(self.http, str):
-                self.protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])
-            else:
-                self.protocol_class = self.http
+        if isinstance(self.http, str):
+            self.protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])
+        else:
+            self.protocol_class = self.http
 
         if isinstance(self.ws, str):
             self.ws_protocol_class = import_from_string(WS_PROTOCOLS[self.ws])

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -266,9 +266,9 @@ class Config:
         )  # type: List[Tuple[bytes, bytes]]
 
         if isinstance(self.http, str):
-            self.protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])
+            self.http_protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])
         else:
-            self.protocol_class = self.http
+            self.http_protocol_class = self.http
 
         if isinstance(self.ws, str):
             self.ws_protocol_class = import_from_string(WS_PROTOCOLS[self.ws])

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -427,7 +427,7 @@ class Server:
         config = self.config
 
         create_protocol = functools.partial(
-            config.http_protocol_class, config=config, server_state=self.server_state
+            config.protocol_class, config=config, server_state=self.server_state
         )
 
         loop = asyncio.get_event_loop()
@@ -448,8 +448,8 @@ class Server:
             server = await loop.create_server(
                 create_protocol, sock=sock, ssl=config.ssl, backlog=config.backlog
             )
-            message = "Uvicorn running on socket %s (Press CTRL+C to quit)"
-            logger.info(message % str(sock.getsockname()))
+            message = "%s running on socket %s (Press CTRL+C to quit)"
+            logger.info(message, config.server_name, str(sock.getsockname()))
             self.servers = [server]
 
         elif config.uds is not None:
@@ -461,8 +461,8 @@ class Server:
                 create_protocol, path=config.uds, ssl=config.ssl, backlog=config.backlog
             )
             os.chmod(config.uds, uds_perms)
-            message = "Uvicorn running on unix socket %s (Press CTRL+C to quit)"
-            logger.info(message % config.uds)
+            message = "%s running on unix socket %s (Press CTRL+C to quit)"
+            logger.info(message, config.server_name, config.uds)
             self.servers = [server]
 
         else:
@@ -482,14 +482,18 @@ class Server:
             port = config.port
             if port == 0:
                 port = server.sockets[0].getsockname()[1]
-            protocol_name = "https" if config.ssl else "http"
-            message = "Uvicorn running on %s://%s:%d (Press CTRL+C to quit)"
+            if config.protocol_name == "auto":
+                protocol_name = "https" if config.ssl else "http"
+            else:
+                protocol_name = config.protocol_name
+            message = "%s running on %s://%s:%d (Press CTRL+C to quit)"
             color_message = (
-                "Uvicorn running on "
+                "%s running on "
                 + click.style("%s://%s:%d", bold=True)
                 + " (Press CTRL+C to quit)"
             )
             logger.info(
+                config.server_name,
                 message,
                 protocol_name,
                 config.host,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -352,7 +352,7 @@ def main(
         "headers": list([header.split(":") for header in headers]),
         "use_colors": use_colors,
         "server_name": server_name,
-        "protocol_name": protocol_name
+        "protocol_name": protocol_name,
     }
     run(**kwargs)
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -445,7 +445,7 @@ class Server:
         config = self.config
 
         create_protocol = functools.partial(
-            config.protocol_class, config=config, server_state=self.server_state
+            config.http_protocol_class, config=config, server_state=self.server_state
         )
 
         loop = asyncio.get_event_loop()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -129,6 +129,20 @@ def print_version(ctx, param, value):
     show_default=True,
 )
 @click.option(
+    "--protocol-name",
+    type=str,
+    default="auto",
+    help="Protocol name to display in logs.",
+    show_default=True,
+)
+@click.option(
+    "--server-name",
+    type=str,
+    default="auto",
+    help="Server name ot display in logs.",
+    show_default=True,
+)
+@click.option(
     "--env-file",
     type=click.Path(exists=True),
     default=None,
@@ -298,6 +312,8 @@ def main(
     headers: typing.List[str],
     use_colors: bool,
     app_dir: str,
+    server_name: str,
+    protocol_name: str,
 ):
     sys.path.insert(0, app_dir)
 
@@ -335,6 +351,8 @@ def main(
         "ssl_ciphers": ssl_ciphers,
         "headers": list([header.split(":") for header in headers]),
         "use_colors": use_colors,
+        "server_name": server_name,
+        "protocol_name": protocol_name
     }
     run(**kwargs)
 
@@ -493,8 +511,8 @@ class Server:
                 + " (Press CTRL+C to quit)"
             )
             logger.info(
-                config.server_name,
                 message,
+                config.server_name,
                 protocol_name,
                 config.host,
                 port,


### PR DESCRIPTION
Sorry that this is a semi duplicate of https://github.com/encode/uvicorn/pull/694, however, I accidently changed the base on the other and now cannot reopen it.

Originally that pr renamed `http` to `protocol` and `http_protocol_class` to `protocol_class` to be more generic. These changes have been removed since those are bigger decisions.

This would make serving other protocols behind uvicorn possible. It is a very small change for a very large impact which would make uvicorn the defacto TCP server for python.

Here is an example of using the options programmatically: https://github.com/hansonkd/Tino/blob/master/tino/config.py

and from the command line:

```
kyle@kyle-ThinkPad-X1-Carbon-7th:~/tino/Tino/bench$ uvicorn my_app:app --host "localhost" --port "9999" --workers 1 --server-name "Custom Stuff" --protocol-name "blah"
INFO:     Started server process [12060]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Custom Stuff running on blah://localhost:9999 (Press CTRL+C to quit)
````

Relevant issue:
https://github.com/encode/uvicorn/issues/695

Alternatively I have squashed the commits here:
https://github.com/encode/uvicorn/compare/master...hansonkd:kh/add_server_name?expand=1
