### PR TITLE
Fix issues surrounding X-Forwarded-For header in ProxyHeadersMIddleware

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -28,3 +28,14 @@ def test_proxy_headers_no_port():
     response = client.get("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "Remote: https://1.2.3.4:0"
+
+
+def test_proxy_headers_invalid_x_forwarded_for():
+    client = TestClient(app)
+    headers = {
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-For": "\xf0\xfd\xfd\xfd, 1.2.3.4",
+    }
+    response = client.get("/", headers=headers)
+    assert response.status_code == 200
+    assert response.text == "Remote: https://1.2.3.4:0"

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -30,14 +30,14 @@ class ProxyHeadersMiddleware:
                 if b"x-forwarded-proto" in headers:
                     # Determine if the incoming request was http or https based on
                     # the X-Forwarded-Proto header.
-                    x_forwarded_proto = headers[b"x-forwarded-proto"].decode("ascii")
+                    x_forwarded_proto = headers[b"x-forwarded-proto"].decode("latin1")
                     scope["scheme"] = x_forwarded_proto.strip()
 
                 if b"x-forwarded-for" in headers:
                     # Determine the client address from the last trusted IP in the
                     # X-Forwarded-For header. We've lost the connecting client's port
                     # information by now, so only include the host.
-                    x_forwarded_for = headers[b"x-forwarded-for"].decode("ascii")
+                    x_forwarded_for = headers[b"x-forwarded-for"].decode("latin1")
                     host = x_forwarded_for.split(",")[-1].strip()
                     port = 0
                     scope["client"] = (host, port)


### PR DESCRIPTION
Attempting to fix #700

- Returns `400` if the `X-Forwarded-For` header cannot be `ascii` decoded as (i believe) this is a client error rather than a server one.
- ~~Takes the first value from the list of addresses rather than the last (while there's no actual standard for this header, both [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) and [wikipedia](https://en.wikipedia.org/wiki/X-Forwarded-For) list the client always being the first, followed by any other proxies used)~~ Removed as i think it should be handled in a separate PR.

I'm by no means an expert in how to write sensible asgi code yet, I just took what I could find from other parts of the code to make the 400 response here. If it's completely wrong I'm perfectly comfortable being told how to do it properly (or simply closing this PR in favour of a more appropriate one done by someone else)