### PR TITLE
Fix failures when ASGI app rejects a connection during handshake

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -216,6 +216,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
 
             elif message_type == "websocket.close":
                 code = message.get("code", 1000)
+                self.close_code = code  # for WebSocketServerProtocol
                 await self.close(code)
                 self.closed_event.set()
 
@@ -236,6 +237,14 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             return {"type": "websocket.connect"}
 
         await self.handshake_completed_event.wait()
+
+        if self.closed_event.is_set():
+            # If the client disconnected: WebSocketServerProtocol set self.close_code.
+            # If the handshake failed or the app closed before handshake completion,
+            # use 1006 Abnormal Closure.
+            code = getattr(self, "close_code", 1006)
+            return {"type": "websocket.disconnect", "code": code}
+
         try:
             data = await self.recv()
         except websockets.ConnectionClosed as exc:

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -255,10 +255,8 @@ class WSProtocol(asyncio.Protocol):
                 )
                 self.handshake_complete = True
                 self.close_sent = True
-                msg = h11.Response(status_code=403, headers=[])
+                msg = events.RejectConnection(status_code=403, headers=[])
                 output = self.conn.send(msg)
-                msg = h11.EndOfMessage()
-                output += self.conn.send(msg)
                 self.transport.write(output)
                 self.transport.close()
 


### PR DESCRIPTION
Fixes #244. The unit test already existed, but it logged exceptions that
weren't being noticed.

* websockets_impl: `transfer_data_task` is unset if the handshake fails, so we can't call recv().
* wsproto_impl: `h11.Reject` is invalid during handshake; send `RejectConnection` instead.