### PR TITLE
Release version 0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.11.6
+
+* Remove `iocp` mentions from documentation.
+* Document default backlog settings.
+* Fix overriding the root logger.
+* Remove Python 3.6 specific leftover.
+
 ## 0.11.5
 
 * Revert "Watch all files, not just .py" due to unexpected side effects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## 0.11.6
 
-* Remove `iocp` mentions from documentation.
-* Document default backlog settings.
 * Fix overriding the root logger.
-* Remove Python 3.6 specific leftover.
 
 ## 0.11.5
 

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.11.5"
+__version__ = "0.11.6"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Release version 0.11.6.

I added notes in the changelog for the recent PRs after version 0.11.6:  https://github.com/encode/uvicorn/pull/660

All the changes are docs or bugfixes, so I just bumped the patch version.

---

Note: After/if merging, this would require adding a manual release in GitHub, including the new changelog items.