### PR TITLE
add response headers to scope

### DIFF
--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -443,6 +443,7 @@ class RequestResponseCycle:
 
             status_code = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
+            self.scope["response_headers"] = headers
 
             if self.access_log:
                 self.access_logger.info(


### PR DESCRIPTION
While implementing a custom logger formatter to support gunicorn logging syntax (https://docs.gunicorn.org/en/stable/settings.html#logging), we had some crucial information missing. One of which, we could solve by injecting the response headers to the scope object. This might be a first step towards 
https://github.com/encode/uvicorn/issues/527