### PR TITLE
return 'connection: close' header in response

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,21 @@ async def app(scope, receive, send):
 
 
 @pytest.mark.asyncio
+async def test_return_close_header():
+    config = Config(app=app, host="localhost", loop="asyncio", limit_max_requests=1)
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "http://127.0.0.1:8000", headers={"connection": "close"}
+            )
+
+    assert response.status_code == 204
+    assert (
+        "connection" in response.headers and response.headers["connection"] == "close"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "host, url",
     [

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -25,6 +25,8 @@ STATUS_PHRASES = {
     status_code: _get_status_phrase(status_code) for status_code in range(100, 600)
 }
 
+CLOSE_HEADER = (b"connection", b"close")
+
 HIGH_WATER_LIMIT = 65536
 
 TRACE_LOG_LEVEL = 5
@@ -451,6 +453,9 @@ class RequestResponseCycle:
 
             status_code = message["status"]
             headers = self.default_headers + message.get("headers", [])
+
+            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+                headers = headers + [CLOSE_HEADER]
 
             if self.access_log:
                 self.access_logger.info(

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -30,6 +30,8 @@ STATUS_LINE = {
     status_code: _get_status_line(status_code) for status_code in range(100, 600)
 }
 
+CLOSE_HEADER = (b"connection", b"close")
+
 HIGH_WATER_LIMIT = 65536
 
 TRACE_LOG_LEVEL = 5
@@ -453,6 +455,9 @@ class RequestResponseCycle:
 
             status_code = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
+
+            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+                headers = headers + [CLOSE_HEADER]
 
             if self.access_log:
                 self.access_logger.info(


### PR DESCRIPTION
According to https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html a
server should return the 'connection: close' header in the response when
a request has that header. Resolves #720