### PR TITLE
Get the request.client under case uvicorn is run with a fd or a unix socket

### DIFF
--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -38,10 +38,11 @@ def test_get_local_addr_with_socket():
     )
     assert get_local_addr(transport) == ("123.45.6.7", 123)
 
-    transport = MockTransport(
-        {"socket": MockSocket(family=socket.AF_UNIX, sockname=("127.0.0.1", 8000))}
-    )
-    assert get_local_addr(transport) == ("127.0.0.1", 8000)
+    if hasattr(socket, "AF_UNIX"):
+        transport = MockTransport(
+            {"socket": MockSocket(family=socket.AF_UNIX, sockname=("127.0.0.1", 8000))}
+        )
+        assert get_local_addr(transport) == ("127.0.0.1", 8000)
 
 
 def test_get_remote_addr_with_socket():
@@ -58,10 +59,11 @@ def test_get_remote_addr_with_socket():
     )
     assert get_remote_addr(transport) == ("123.45.6.7", 123)
 
-    transport = MockTransport(
-        {"socket": MockSocket(family=socket.AF_UNIX, peername=("127.0.0.1", 8000))}
-    )
-    assert get_remote_addr(transport) == ("127.0.0.1", 8000)
+    if hasattr(socket, "AF_UNIX"):
+        transport = MockTransport(
+            {"socket": MockSocket(family=socket.AF_UNIX, peername=("127.0.0.1", 8000))}
+        )
+        assert get_remote_addr(transport) == ("127.0.0.1", 8000)
 
 
 def test_get_local_addr():

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -38,6 +38,11 @@ def test_get_local_addr_with_socket():
     )
     assert get_local_addr(transport) == ("123.45.6.7", 123)
 
+    transport = MockTransport(
+        {"socket": MockSocket(family=socket.AF_UNIX, sockname=("127.0.0.1", 8000))}
+    )
+    assert get_local_addr(transport) == ("127.0.0.1", 8000)
+
 
 def test_get_remote_addr_with_socket():
     transport = MockTransport({"socket": MockSocket(family=socket.AF_IPX)})
@@ -52,6 +57,11 @@ def test_get_remote_addr_with_socket():
         {"socket": MockSocket(family=socket.AF_INET, peername=("123.45.6.7", 123))}
     )
     assert get_remote_addr(transport) == ("123.45.6.7", 123)
+
+    transport = MockTransport(
+        {"socket": MockSocket(family=socket.AF_UNIX, peername=("127.0.0.1", 8000))}
+    )
+    assert get_remote_addr(transport) == ("127.0.0.1", 8000)
 
 
 def test_get_local_addr():

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -53,7 +53,9 @@ def test_get_remote_addr_with_socket():
     )
     assert get_remote_addr(transport) == ("123.45.6.7", 123)
 
-    transport = MockTransport({"socket": MockSocket(family=socket.AF_UNIX, peername=("127.0.0.1", 8000))})
+    transport = MockTransport(
+        {"socket": MockSocket(family=socket.AF_UNIX, peername=("127.0.0.1", 8000))}
+    )
     assert get_remote_addr(transport) == ("127.0.0.1", 8000)
 
 

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -53,11 +53,6 @@ def test_get_remote_addr_with_socket():
     )
     assert get_remote_addr(transport) == ("123.45.6.7", 123)
 
-    transport = MockTransport(
-        {"socket": MockSocket(family=socket.AF_UNIX, peername=("127.0.0.1", 8000))}
-    )
-    assert get_remote_addr(transport) == ("127.0.0.1", 8000)
-
 
 def test_get_local_addr():
     transport = MockTransport({"sockname": "path/to/unix-domain-socket"})

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -29,12 +29,12 @@ def test_get_local_addr_with_socket():
     assert get_local_addr(transport) is None
 
     transport = MockTransport(
-        {"socket": MockSocket(family=socket.AF_INET6, sockname=["::1", 123])}
+        {"socket": MockSocket(family=socket.AF_INET6, sockname=("::1", 123))}
     )
     assert get_local_addr(transport) == ("::1", 123)
 
     transport = MockTransport(
-        {"socket": MockSocket(family=socket.AF_INET, sockname=["123.45.6.7", 123])}
+        {"socket": MockSocket(family=socket.AF_INET, sockname=("123.45.6.7", 123))}
     )
     assert get_local_addr(transport) == ("123.45.6.7", 123)
 
@@ -44,21 +44,24 @@ def test_get_remote_addr_with_socket():
     assert get_remote_addr(transport) is None
 
     transport = MockTransport(
-        {"socket": MockSocket(family=socket.AF_INET6, peername=["::1", 123])}
+        {"socket": MockSocket(family=socket.AF_INET6, peername=("::1", 123))}
     )
     assert get_remote_addr(transport) == ("::1", 123)
 
     transport = MockTransport(
-        {"socket": MockSocket(family=socket.AF_INET, peername=["123.45.6.7", 123])}
+        {"socket": MockSocket(family=socket.AF_INET, peername=("123.45.6.7", 123))}
     )
     assert get_remote_addr(transport) == ("123.45.6.7", 123)
+
+    transport = MockTransport({"socket": MockSocket(family=socket.AF_UNIX, peername=("127.0.0.1", 8000))})
+    assert get_remote_addr(transport) == ("127.0.0.1", 8000)
 
 
 def test_get_local_addr():
     transport = MockTransport({"sockname": "path/to/unix-domain-socket"})
     assert get_local_addr(transport) is None
 
-    transport = MockTransport({"sockname": ["123.45.6.7", 123]})
+    transport = MockTransport({"sockname": ("123.45.6.7", 123)})
     assert get_local_addr(transport) == ("123.45.6.7", 123)
 
 
@@ -66,5 +69,5 @@ def test_get_remote_addr():
     transport = MockTransport({"peername": None})
     assert get_remote_addr(transport) is None
 
-    transport = MockTransport({"peername": ["123.45.6.7", 123]})
+    transport = MockTransport({"peername": ("123.45.6.7", 123)})
     assert get_remote_addr(transport) == ("123.45.6.7", 123)

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -3,9 +3,6 @@ import urllib
 
 def get_remote_addr(transport):
     socket_info = transport.get_extra_info("socket")
-    peer_info = transport.get_extra_info("peername")
-    print(socket_info)
-    print(peer_info)
     if socket_info is not None:
         try:
             info = socket_info.getpeername()

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -17,7 +17,7 @@ def get_remote_addr(transport):
 
         if family in (socket.AF_INET, socket.AF_INET6):
             return (str(info[0]), int(info[1]))
-        elif family is socket.AF_UNIX:
+        elif hasattr(socket, "AF_UNIX") and family is socket.AF_UNIX:
             if isinstance(info, tuple):
                 # fd case
                 # <uvloop.PseudoSocket fd=13, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 8000), raddr=('127.0.0.1', 38634)>

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,32 +1,20 @@
-import socket
 import urllib
 
 
 def get_remote_addr(transport):
     socket_info = transport.get_extra_info("socket")
+    peer_info = transport.get_extra_info("peername")
+    print(socket_info)
+    print(peer_info)
     if socket_info is not None:
         try:
             info = socket_info.getpeername()
+            return (str(info[0]), int(info[1])) if isinstance(info, tuple) else None
         except OSError:
             # This case appears to inconsistently occur with uvloop
             # bound to a unix domain socket.
-            family = None
-            info = None
-        else:
-            family = socket_info.family
+            return None
 
-        if family in (socket.AF_INET, socket.AF_INET6):
-            return (str(info[0]), int(info[1]))
-        elif hasattr(socket, "AF_UNIX") and family is socket.AF_UNIX:
-            if isinstance(info, tuple):
-                # fd case
-                # <uvloop.PseudoSocket fd=13, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 8000), raddr=('127.0.0.1', 38634)>
-                return (str(info[0]), int(info[1]))
-            else:
-                # unix socket case
-                # <uvloop.PseudoSocket fd=21, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=/tmp/gunicorn.sock>
-                return None
-        return None
     info = transport.get_extra_info("peername")
     if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:
         return (str(info[0]), int(info[1]))
@@ -37,19 +25,8 @@ def get_local_addr(transport):
     socket_info = transport.get_extra_info("socket")
     if socket_info is not None:
         info = socket_info.getsockname()
-        family = socket_info.family
-        if family in (socket.AF_INET, socket.AF_INET6):
-            return (str(info[0]), int(info[1]))
-        elif hasattr(socket, "AF_UNIX") and family is socket.AF_UNIX:
-            if isinstance(info, tuple):
-                # fd case
-                # <uvloop.PseudoSocket fd=13, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 8000), raddr=('127.0.0.1', 38634)>
-                return (str(info[0]), int(info[1]))
-            else:
-                # unix socket case
-                # <uvloop.PseudoSocket fd=21, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=/tmp/gunicorn.sock>
-                return None
-        return None
+
+        return (str(info[0]), int(info[1])) if isinstance(info, tuple) else None
     info = transport.get_extra_info("sockname")
     if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:
         return (str(info[0]), int(info[1]))

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -17,6 +17,15 @@ def get_remote_addr(transport):
 
         if family in (socket.AF_INET, socket.AF_INET6):
             return (str(info[0]), int(info[1]))
+        elif family is socket.AF_UNIX:
+            if isinstance(info, tuple):
+                # fd case
+                # <uvloop.PseudoSocket fd=13, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 8000), raddr=('127.0.0.1', 38634)>
+                return (str(info[0]), int(info[1]))
+            else:
+                # unix socket case
+                # <uvloop.PseudoSocket fd=21, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=/tmp/gunicorn.sock>
+                return None
         return None
     info = transport.get_extra_info("peername")
     if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -40,6 +40,15 @@ def get_local_addr(transport):
         family = socket_info.family
         if family in (socket.AF_INET, socket.AF_INET6):
             return (str(info[0]), int(info[1]))
+        elif hasattr(socket, "AF_UNIX") and family is socket.AF_UNIX:
+            if isinstance(info, tuple):
+                # fd case
+                # <uvloop.PseudoSocket fd=13, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 8000), raddr=('127.0.0.1', 38634)>
+                return (str(info[0]), int(info[1]))
+            else:
+                # unix socket case
+                # <uvloop.PseudoSocket fd=21, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, laddr=/tmp/gunicorn.sock>
+                return None
         return None
     info = transport.get_extra_info("sockname")
     if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,11 +1,6 @@
 import socket
 import urllib
 
-if hasattr(socket, "AF_UNIX"):
-    SUPPORTED_SOCKET_FAMILIES = (socket.AF_INET, socket.AF_INET6, socket.AF_UNIX)
-else:
-    SUPPORTED_SOCKET_FAMILIES = (socket.AF_INET, socket.AF_INET6)
-
 
 def get_remote_addr(transport):
     socket_info = transport.get_extra_info("socket")
@@ -20,9 +15,8 @@ def get_remote_addr(transport):
         else:
             family = socket_info.family
 
-        if family in SUPPORTED_SOCKET_FAMILIES:
+        if family in (socket.AF_INET, socket.AF_INET6):
             return (str(info[0]), int(info[1]))
-
         return None
     info = transport.get_extra_info("peername")
     if info is not None and isinstance(info, (list, tuple)) and len(info) == 2:
@@ -35,7 +29,7 @@ def get_local_addr(transport):
     if socket_info is not None:
         info = socket_info.getsockname()
         family = socket_info.family
-        if family in SUPPORTED_SOCKET_FAMILIES:
+        if family in (socket.AF_INET, socket.AF_INET6):
             return (str(info[0]), int(info[1]))
         return None
     info = transport.get_extra_info("sockname")


### PR DESCRIPTION
should solve #727 and still give the correct info that https://github.com/encode/uvicorn/issues/634 wanted
