### PR TITLE
Version 0.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.11.8 - 2020-07-30
+
+* Fix a regression that caused Uvicorn to crash when using `--interface=wsgi`. (Pull #730)
+
 ## 0.11.7
 
 * SECURITY FIX: Prevent sending invalid HTTP header names and values.

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.11.7"
+__version__ = "0.11.8"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Went ahead and added release date and references to merged PRs in the changelog entry, as I think those are useful bits of info and we have it in eg HTTPX and HTTPCore.

---

## 0.11.8 - 2020-07-30

* Fix a regression that caused Uvicorn to crash when using `--interface=wsgi`. (Pull #730)
* Fix a regression that caused Uvicorn to crash when using unix domain sockets. (Pull #729)