### PR TITLE
Update 0.11.7 changelog: add missing entry, formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-## 0.11.7
+## 0.11.7 - 2020-28-07
 
-* SECURITY FIX: Prevent sending invalid HTTP header names and values.
-* SECURITY FIX: Ensure path value is escaped before logging to the console.
+* SECURITY FIX: Prevent sending invalid HTTP header names and values. (Pull #725)
+* SECURITY FIX: Ensure path value is escaped before logging to the console. (Pull #724)
+* Fix `--proxy-headers` client IP and host when using a Unix socket. (Pull #636)
 
 ## 0.11.6
 


### PR DESCRIPTION
Refs https://github.com/encode/uvicorn/issues/727#issuecomment-666234023

PR https://github.com/encode/uvicorn/pull/636 was merged and included in 0.11.7 but is not listed in the changelog.