### PR TITLE
Reloader yields PermissionError on windows after a syntax error

### DIFF
--- a/tests/supervisors/test_statreload.py
+++ b/tests/supervisors/test_statreload.py
@@ -45,3 +45,28 @@ def test_should_reload(tmpdir):
         reloader.shutdown()
     finally:
         os.chdir(working_dir)
+
+
+def test_should_reload_after_exception(tmpdir):
+    update_file = Path(os.path.join(str(tmpdir), "example.py"))
+    update_file.touch()
+
+    working_dir = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        config = Config(app=None, reload=True)
+        reloader = StatReload(config, target=run, sockets=[])
+        reloader.signal_handler(sig=signal.SIGINT, frame=None)
+        reloader.startup()
+
+        assert not reloader.should_restart()
+        time.sleep(1)
+        with open(update_file, "w") as f:
+            f.write("this will certainly raise a syntax error!")
+        time.sleep(1)
+        assert reloader.should_restart()
+
+        reloader.restart()
+        reloader.shutdown()
+    finally:
+        os.chdir(working_dir)

--- a/tests/supervisors/test_watchgodreload.py
+++ b/tests/supervisors/test_watchgodreload.py
@@ -64,3 +64,28 @@ def test_should_not_reload_when_dot_file_is_changed(tmpdir):
         reloader.shutdown()
     finally:
         os.chdir(working_dir)
+
+
+def test_should_reload_after_exception(tmpdir):
+    update_file = Path(os.path.join(str(tmpdir), "example.py"))
+    update_file.touch()
+
+    working_dir = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        config = Config(app=None, reload=True)
+        reloader = WatchGodReload(config, target=run, sockets=[])
+        reloader.signal_handler(sig=signal.SIGINT, frame=None)
+        reloader.startup()
+
+        assert not reloader.should_restart()
+        time.sleep(1)
+        with open(update_file, "w") as f:
+            f.write("this will certainly raise a syntax error!")
+        time.sleep(1)
+        assert reloader.should_restart()
+
+        reloader.restart()
+        reloader.shutdown()
+    finally:
+        os.chdir(working_dir)

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import signal
+import sys
 import threading
 
 import click
@@ -62,7 +63,10 @@ class BaseReload:
 
     def restart(self):
         self.mtimes = {}
-        os.kill(self.process.pid, signal.SIGTERM)
+        if sys.platform == 'win32':
+            os.kill(self.process.pid, signal.CTRL_C_EVENT)
+        else:
+            os.kill(self.process.pid, signal.SIGTERM)
         self.process.join()
 
         self.process = get_subprocess(

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -63,7 +63,7 @@ class BaseReload:
 
     def restart(self):
         self.mtimes = {}
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
             os.kill(self.process.pid, signal.CTRL_C_EVENT)
         else:
             os.kill(self.process.pid, signal.SIGTERM)


### PR DESCRIPTION
Attempt at solving #684 
It replaces  #686 which seems weaker
see https://docs.python.org/3/library/os.html#os.kill  