### PR TITLE
fix terminate error in windows

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -62,7 +62,8 @@ class BaseReload:
 
     def restart(self):
         self.mtimes = {}
-        os.kill(self.process.pid, signal.SIGTERM)
+
+        self.process.terminate()
         self.process.join()
 
         self.process = get_subprocess(


### PR DESCRIPTION
fix https://github.com/encode/uvicorn/issues/684

https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.terminate

I have tested it on Windows10.