### PR TITLE
Upgrade wsproto to 0.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ h11
 httptools; sys_platform != 'win32'
 uvloop>=0.14.0; sys_platform != 'win32'
 websockets==8.*
-wsproto>=0.13.*
+wsproto==0.15.*
 watchgod>=0.6,<0.7
 python_dotenv==0.13.*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ h11
 httptools; sys_platform != 'win32'
 uvloop>=0.14.0; sys_platform != 'win32'
 websockets==8.*
-wsproto==0.13.*
+wsproto>=0.13.*
 watchgod>=0.6,<0.7
 python_dotenv==0.13.*
 


### PR DESCRIPTION

1. Might be useful in the future since 0.15.0 offers type hints

2. Avoids the CI script "error" we currently have during the install script `ERROR: wsproto 0.13.0 has requirement h11~=0.8.1, but you'll have h11 0.9.0 which is incompatible.`