### PR TITLE
Add `asgi` field to the lifespan scope

### DIFF
--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -44,7 +44,10 @@ class LifespanOn:
     async def main(self):
         try:
             app = self.config.loaded_app
-            scope = {"type": "lifespan"}
+            scope = {
+                "type": "lifespan",
+                "asgi": {"version": self.config.asgi_version, "spec_version": "2.0"},
+            }
             await app(scope, self.receive, self.send)
         except BaseException as exc:
             self.asgi = None


### PR DESCRIPTION
fix #753 
note that spec version is 2.0 according to https://asgi.readthedocs.io/en/latest/specs/lifespan.html#version-history