### PR TITLE
Deal gently with ConnectionClosedError fron websockets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ isort
 pytest
 pytest-cov
 pytest-mock
+pytest-reraise
 requests
 seed-isort-config
 mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ check_untyped_defs = True
 profile = black
 combine_as_imports = True
 known_first_party = uvicorn,tests
-known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,setuptools,urllib3,uvloop,watchgod,websockets,wsproto
+known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,setuptools,urllib3,uvloop,watchgod,websockets,wsproto,yaml
 
 [tool:pytest]
 addopts = --cov=uvicorn --cov=tests -rxXs

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -466,3 +466,34 @@ def test_subprotocols(protocol_cls, subprotocol):
         accepted_subprotocol = loop.run_until_complete(get_subprotocol(url))
         assert accepted_subprotocol == subprotocol
         loop.close()
+
+
+@pytest.mark.parametrize("protocol_cls", WS_PROTOCOLS)
+def test_server_lost_connection(protocol_cls):
+    class App(WebSocketResponse):
+        async def websocket_connect(self, message):
+            await self.send({"type": "websocket.accept"})
+            await self.receive()
+
+            # Simulate a lost connection
+            # without receiving a close frame
+            self.send.__self__.connection_lost(None)
+
+            with pytest.raises(Exception) as exc:
+                await self.send({"type": "websocket.send", "text": "123"})
+
+            assert exc.value.code == 1006
+
+    async def websocket_session(url):
+        async with websockets.connect(url) as websocket:
+            await websocket.ping()
+            await websocket.send("abc")
+            # Delay exiting context manager
+            # to avoid sending a close frame before server attempts send
+            await asyncio.sleep(1)
+
+    if protocol_cls is WebSocketProtocol:
+        with run_server(App, protocol_cls=protocol_cls) as url:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(websocket_session(url))
+            loop.close()

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -469,7 +469,7 @@ def test_subprotocols(protocol_cls, subprotocol):
 
 
 @pytest.mark.parametrize("protocol_cls", WS_PROTOCOLS)
-def test_server_lost_connection(protocol_cls):
+def test_server_lost_connection(protocol_cls, reraise):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -479,10 +479,8 @@ def test_server_lost_connection(protocol_cls):
             # without receiving a close frame
             self.send.__self__.connection_lost(None)
 
-            with pytest.raises(Exception) as exc:
+            with reraise:
                 await self.send({"type": "websocket.send", "text": "123"})
-
-            assert exc.value.code == 1006
 
     async def websocket_session(url):
         async with websockets.connect(url) as websocket:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -490,8 +490,7 @@ def test_server_lost_connection(protocol_cls, reraise):
             # to avoid sending a close frame before server attempts send
             await asyncio.sleep(1)
 
-    if protocol_cls is WebSocketProtocol:
-        with run_server(App, protocol_cls=protocol_cls) as url:
-            loop = asyncio.new_event_loop()
-            loop.run_until_complete(websocket_session(url))
-            loop.close()
+    with run_server(App, protocol_cls=protocol_cls) as url:
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(websocket_session(url))
+        loop.close()


### PR DESCRIPTION
based on test nicely provided in https://github.com/encode/uvicorn/pull/758 
using pytest-reraise to avoid the bug shown in https://github.com/encode/uvicorn/pull/759
fix #757 

Would really appreciate some feedback on this,  not sure I got this right