### PR TITLE
Enabled permessage-deflate extension in websockets

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -4,6 +4,7 @@ import logging
 from urllib.parse import unquote
 
 import websockets
+from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFactory
 
 from uvicorn.protocols.utils import get_local_addr, get_remote_addr, is_ssl
 
@@ -54,7 +55,11 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
 
         self.ws_server = Server()
 
-        super().__init__(ws_handler=self.ws_handler, ws_server=self.ws_server)
+        super().__init__(
+            ws_handler=self.ws_handler,
+            ws_server=self.ws_server,
+            extensions=[ServerPerMessageDeflateFactory()],
+        )
 
     def connection_made(self, transport):
         self.connections.add(self)


### PR DESCRIPTION
The permessage deflate extension for the websocket protocol
was already enabled when using the wsproto implementation.

This enables it for the websockets implementation and add
tests for both implementations