### PR TITLE
Upgrade maximum h11 dependency version to 0.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
     "click==7.*",
-    "h11>=0.8,<0.10",
+    "h11>=0.8,<0.11",
     "typing-extensions;" + env_marker_below_38,
 ]
 


### PR DESCRIPTION
The h11 Changelog for 0.10 only include those items:
 - Drop support for Python 3.4.
 - Support Python 3.8.
 - Make error messages returned by match failures less ambiguous (https://github.com/python-hyper/h11/issues/98).