### PR TITLE
Make reload delay configurable

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -133,6 +133,7 @@ class Config:
         debug=False,
         reload=False,
         reload_dirs=None,
+        reload_delay=None,
         workers=None,
         proxy_headers=True,
         forwarded_allow_ips=None,
@@ -167,6 +168,7 @@ class Config:
         self.interface = interface
         self.debug = debug
         self.reload = reload
+        self.reload_delay = reload_delay or 0.25
         self.workers = workers or 1
         self.proxy_headers = proxy_headers
         self.root_path = root_path

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -89,6 +89,13 @@ def print_version(ctx, param, value):
     " directory.",
 )
 @click.option(
+    "--reload-delay",
+    type=float,
+    default=0.25,
+    show_default=True,
+    help="Delay between previous and next check if application needs to be. Defaults to 0.25s.",
+)
+@click.option(
     "--workers",
     default=None,
     type=int,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -93,7 +93,8 @@ def print_version(ctx, param, value):
     type=float,
     default=0.25,
     show_default=True,
-    help="Delay between previous and next check if application needs to be. Defaults to 0.25s.",
+    help="Delay between previous and next check if application needs to be."
+    " Defaults to 0.25s.",
 )
 @click.option(
     "--workers",
@@ -290,6 +291,7 @@ def main(
     debug: bool,
     reload: bool,
     reload_dirs: typing.List[str],
+    reload_delay: float,
     workers: int,
     env_file: str,
     log_config: str,
@@ -332,6 +334,7 @@ def main(
         "debug": debug,
         "reload": reload,
         "reload_dirs": reload_dirs if reload_dirs else None,
+        "reload_delay": reload_delay,
         "workers": workers,
         "proxy_headers": proxy_headers,
         "forwarded_allow_ips": forwarded_allow_ips,

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -32,9 +32,10 @@ class BaseReload:
 
     def run(self):
         self.startup()
-        while not self.should_exit.wait(0.25):
+        while not self.should_exit.wait(self.config.reload_delay):
             if self.should_restart():
                 self.restart()
+
         self.shutdown()
 
     def startup(self):


### PR DESCRIPTION
As I've mentioned in #338, hitting filesystem for differences four times a second is too much for larger codebases. I've contemplated bumping this to 1s (which is how often Django's default file watcher checks for changes) but I've decided to make this configurable to let end users decide what makes sense for their projects and setups. Defaults to 0.25s which is original value of the setting.