### PR TITLE
adding parameter --ssl-password to decrypt ssl key file

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,6 +79,7 @@ Options:
                                   5]
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
+  --ssl-password TEXT             SSL key file password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 2]
   --ssl-cert-reqs INTEGER         Whether client certificate is required (see

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,6 +130,7 @@ Options:
                                   5]
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
+  --ssl-password TEXT             SSL key file password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 2]
   --ssl-cert-reqs INTEGER         Whether client certificate is required (see

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -106,7 +106,7 @@ def create_ssl_context(
 ):
     ctx = ssl.SSLContext(ssl_version)
     if password:
-        getpassword = lambda _: password
+        def getpassword() : return password
         ctx.load_cert_chain(certfile, keyfile, getpassword)
     else:
         ctx.load_cert_chain(certfile, keyfile)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -106,7 +106,10 @@ def create_ssl_context(
 ):
     ctx = ssl.SSLContext(ssl_version)
     if password:
-        def getpassword() : return password
+
+        def getpassword():
+            return password
+
         ctx.load_cert_chain(certfile, keyfile, getpassword)
     else:
         ctx.load_cert_chain(certfile, keyfile)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -101,9 +101,15 @@ LOGGING_CONFIG = {
 logger = logging.getLogger("uvicorn.error")
 
 
-def create_ssl_context(certfile, keyfile, password, ssl_version, cert_reqs, ca_certs, ciphers):
+def create_ssl_context(
+    certfile, keyfile, password, ssl_version, cert_reqs, ca_certs, ciphers
+):
     ctx = ssl.SSLContext(ssl_version)
-    ctx.load_cert_chain(certfile, keyfile)
+    if password:
+        getpassword = lambda _: password
+        ctx.load_cert_chain(certfile, keyfile, getpassword)
+    else:
+        ctx.load_cert_chain(certfile, keyfile)
     ctx.verify_mode = cert_reqs
     if ca_certs:
         ctx.load_verify_locations(ca_certs)
@@ -266,6 +272,7 @@ class Config:
             self.ssl = create_ssl_context(
                 keyfile=self.ssl_keyfile,
                 certfile=self.ssl_certfile,
+                password=self.ssl_password,
                 ssl_version=self.ssl_version,
                 cert_reqs=self.ssl_cert_reqs,
                 ca_certs=self.ssl_ca_certs,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -103,11 +103,7 @@ logger = logging.getLogger("uvicorn.error")
 
 def create_ssl_context(certfile, keyfile, password, ssl_version, cert_reqs, ca_certs, ciphers):
     ctx = ssl.SSLContext(ssl_version)
-    if password:
-        getpassword = lambda _: password
-        ctx.load_cert_chain(certfile, keyfile, getpassword)
-    else:
-        ctx.load_cert_chain(certfile, keyfile)
+    ctx.load_cert_chain(certfile, keyfile)
     ctx.verify_mode = cert_reqs
     if ca_certs:
         ctx.load_verify_locations(ca_certs)
@@ -270,7 +266,6 @@ class Config:
             self.ssl = create_ssl_context(
                 keyfile=self.ssl_keyfile,
                 certfile=self.ssl_certfile,
-                password=self.ssl_password,
                 ssl_version=self.ssl_version,
                 cert_reqs=self.ssl_cert_reqs,
                 ca_certs=self.ssl_ca_certs,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -101,9 +101,13 @@ LOGGING_CONFIG = {
 logger = logging.getLogger("uvicorn.error")
 
 
-def create_ssl_context(certfile, keyfile, ssl_version, cert_reqs, ca_certs, ciphers):
+def create_ssl_context(certfile, keyfile, password, ssl_version, cert_reqs, ca_certs, ciphers):
     ctx = ssl.SSLContext(ssl_version)
-    ctx.load_cert_chain(certfile, keyfile)
+    if password:
+        getpassword = lambda _: password
+        ctx.load_cert_chain(certfile, keyfile, getpassword)
+    else:
+        ctx.load_cert_chain(certfile, keyfile)
     ctx.verify_mode = cert_reqs
     if ca_certs:
         ctx.load_verify_locations(ca_certs)
@@ -145,6 +149,7 @@ class Config:
         callback_notify=None,
         ssl_keyfile=None,
         ssl_certfile=None,
+        ssl_password=None,
         ssl_version=SSL_PROTOCOL_VERSION,
         ssl_cert_reqs=ssl.CERT_NONE,
         ssl_ca_certs=None,
@@ -178,6 +183,7 @@ class Config:
         self.callback_notify = callback_notify
         self.ssl_keyfile = ssl_keyfile
         self.ssl_certfile = ssl_certfile
+        self.ssl_password = ssl_password
         self.ssl_version = ssl_version
         self.ssl_cert_reqs = ssl_cert_reqs
         self.ssl_ca_certs = ssl_ca_certs
@@ -264,6 +270,7 @@ class Config:
             self.ssl = create_ssl_context(
                 keyfile=self.ssl_keyfile,
                 certfile=self.ssl_certfile,
+                password=self.ssl_password,
                 ssl_version=self.ssl_version,
                 cert_reqs=self.ssl_cert_reqs,
                 ca_certs=self.ssl_ca_certs,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -220,6 +220,9 @@ def print_version(ctx, param, value):
     show_default=True,
 )
 @click.option(
+    "--ssl-password", type=str, default=None, help="SSL key password", show_default=True
+)
+@click.option(
     "--ssl-version",
     type=int,
     default=SSL_PROTOCOL_VERSION,
@@ -297,6 +300,7 @@ def main(
     timeout_keep_alive: int,
     ssl_keyfile: str,
     ssl_certfile: str,
+    ssl_password: str,
     ssl_version: int,
     ssl_cert_reqs: int,
     ssl_ca_certs: str,
@@ -335,6 +339,7 @@ def main(
         "timeout_keep_alive": timeout_keep_alive,
         "ssl_keyfile": ssl_keyfile,
         "ssl_certfile": ssl_certfile,
+        "ssl_password": ssl_password,
         "ssl_version": ssl_version,
         "ssl_cert_reqs": ssl_cert_reqs,
         "ssl_ca_certs": ssl_ca_certs,

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -42,6 +42,7 @@ class UvicornWorker(Worker):
             ssl_kwargs = {
                 "ssl_keyfile": self.cfg.ssl_options.get("keyfile"),
                 "ssl_certfile": self.cfg.ssl_options.get("certfile"),
+                "ssl_password": self.cfg.ssl_options.get("password"),
                 "ssl_version": self.cfg.ssl_options.get("ssl_version"),
                 "ssl_cert_reqs": self.cfg.ssl_options.get("cert_reqs"),
                 "ssl_ca_certs": self.cfg.ssl_options.get("ca_certs"),


### PR DESCRIPTION
Add parameter `--ssl-password` to be able to decrypt the ssl key
If provided, this parameter will be passed to load_cert_chain as password.

The password argument may be a function to call to get the password for decrypting the private key. It will only be called if the private key is encrypted and a password is necessary. It will be called with no arguments, and it should return a string, bytes, or bytearray. If the return value is a string it will be encoded as UTF-8 before using it to decrypt the key. Alternatively a string, bytes, or bytearray value may be supplied directly as the password argument. It will be ignored if the private key is not encrypted and no password is needed.

https://docs.python.org/3.3/library/ssl.html#ssl.SSLContext.load_cert_chain

This issue required a pull request https://github.com/encode/uvicorn/issues/581

Fixes https://github.com/encode/uvicorn/issues/581