### PR TITLE
Add watchdog to gunicorn worker

### DIFF
--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -61,9 +61,6 @@ class UvicornWorker(Worker):
         self.config.setup_event_loop()
         super(UvicornWorker, self).init_process()
 
-    def init_signals(self):
-        pass
-
     def run(self):
         self.config.app = self.wsgi
         self.server = Server(config=self.config)


### PR DESCRIPTION
It is similar to [watchdog](https://github.com/benoitc/gunicorn/blob/master/gunicorn/workers/gtornado.py#L55) and [heartbeat](https://github.com/benoitc/gunicorn/blob/master/gunicorn/workers/gtornado.py#L63) in tornado worker implemented by gunicorn.

1.  **Exit appropriately when worker should not be alive**

If we set `reload = True` in gunicorn configuration, gunicorn could restart workers automatically when code changes. The reloader set ``self.alive = False`` and the worker should exit then.  It is one of the most useful features when we developing web applications. However, the original UvicornWorker could not set `server.should_exit = True` when  gunicorn reloader set `self.alive = False` . So the worker could not exit appropriately and fail to reboot.

2. **Shutting down when parent changed**

The original UvicornWorker will keep alive when parent changed, e.g. kill -9 the gunicorn master process.

