### PR TITLE
Pinning h11 and python-dotenv to min versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ h11
 # Optional
 httptools; sys_platform != 'win32'
 uvloop>=0.14.0; sys_platform != 'win32'
-websockets==8.*
-wsproto==0.15.*
-watchgod>=0.6,<0.7
-python_dotenv==0.13.*
+websockets>=8.*
+wsproto>=0.15.*
+watchgod>=0.6
+python_dotenv>=0.13.*
 PyYAML>=5.1
 
 # Packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ h11
 # Optional
 httptools; sys_platform != 'win32'
 uvloop>=0.14.0; sys_platform != 'win32'
-websockets>=8.*
-wsproto>=0.15.*
-watchgod>=0.6
+websockets==8.*
+wsproto==0.15.*
+watchgod>=0.6,<0.7
 python_dotenv>=0.13.*
 PyYAML>=5.1
 

--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,11 @@ minimal_requirements = [
 ]
 
 extra_requirements = [
-    "websockets>=8.*",
-    "httptools>=0.1.* ;" + env_marker_cpython,
+    "websockets==8.*",
+    "httptools==0.1.* ;" + env_marker_cpython,
     "uvloop>=0.14.0 ;" + env_marker_cpython,
     "colorama>=0.4.*;" + env_marker_win,
-    "watchgod>=0.6",
+    "watchgod>=0.6,<0.7",
     "python-dotenv>=0.13.*",
     "PyYAML>=5.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -45,17 +45,17 @@ env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
     "click==7.*",
-    "h11>=0.8,<0.11",
+    "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,
 ]
 
 extra_requirements = [
-    "websockets==8.*",
-    "httptools==0.1.* ;" + env_marker_cpython,
+    "websockets>=8.*",
+    "httptools>=0.1.* ;" + env_marker_cpython,
     "uvloop>=0.14.0 ;" + env_marker_cpython,
     "colorama>=0.4.*;" + env_marker_win,
-    "watchgod>=0.6,<0.7",
-    "python-dotenv==0.13.*",
+    "watchgod>=0.6",
+    "python-dotenv>=0.13.*",
     "PyYAML>=5.1",
 ]
 


### PR DESCRIPTION
Following https://gitter.im/encode/community?at=5f71fafdb39cb873c08b5c9a and in light of https://github.com/encode/uvicorn/pull/772#issuecomment-700012365 and https://github.com/encode/uvicorn/issues/788

this removes the max dependencies and just sets the minimum version