### PR TITLE
Move package editable install to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,4 @@
-# Minimal
-click
-h11
-
-# Optional
-httptools; sys_platform != 'win32'
-uvloop>=0.14.0; sys_platform != 'win32'
-websockets==8.*
-wsproto==0.15.*
-watchgod>=0.6,<0.7
-python_dotenv==0.13.*
-PyYAML>=5.1
+-e .[standard]
 
 # Packaging
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 -e .[standard]
 
+# Explicit optionals
+wsproto==0.15.*
+
 # Packaging
 twine
 wheel

--- a/scripts/install
+++ b/scripts/install
@@ -16,4 +16,3 @@ else
 fi
 
 "$PIP" install -r "$REQUIREMENTS"
-"$PIP" install -e .


### PR DESCRIPTION
Hey team!

Quick tweak to the `requirements.txt` so that it's treated as the "all dev dependencies" file. Basically drops the duplicate requirements in favor of using those specified in `setup.py`, by installing `-e .[standard]`.