### PR TITLE
Add a little sleep for Windows shared sockets to catch up ?

### DIFF
--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -2,6 +2,7 @@ import logging
 import os
 import signal
 import threading
+import time
 
 import click
 
@@ -50,6 +51,7 @@ class Multiprocess:
                 config=self.config, target=self.target, sockets=self.sockets
             )
             process.start()
+            time.sleep(1)
             self.processes.append(process)
 
     def shutdown(self):


### PR DESCRIPTION
Fixes #683 
I manually confirmed the bug on a windows machine, manually confirmed the fix also
I dont get the reason why it fixes it, I discovered it having breakpoints and realizing after a wait the workers launched normally.