### PR TITLE
Note the need to configure trusted "ips" when using unix sockets

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -204,6 +204,7 @@ Using Nginx as a proxy in front of your Uvicorn processes may not be neccessary,
 In managed environments such as `Heroku`, you wont typically need to configure Nginx, as your server processes will already be running behind load balancing proxies.
 
 The recommended configuration for proxying from Nginx is to use a UNIX domain socket between Nginx and whatever the process manager that is being used to run Uvicorn.
+Note that when doing this you will need run Uvicorn with `--forwarded-allow-ips='*'` to ensure that the domain socket is trusted as a source from which to proxy headers.
 
 When fronting the application with a proxy server you want to make sure that the proxy sets headers to ensure that application can properly determine the client address of the incoming connection, and if the connection was over `http` or `https`.
 


### PR DESCRIPTION
It is unfortunately non-obvious that when using an unix socket, clients connecting to that socket are not trusted as a source of headers for proxying to the underlying application.

Fixes https://github.com/encode/uvicorn/issues/713