### PR TITLE
Add support for proposed "lifespan.shutdown.notice" ASGI extension

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -18,7 +18,7 @@ def test_lifespan_on():
         startup_complete = True
         await send({"type": "lifespan.startup.complete"})
         message = await receive()
-        assert message["type"] == "lifespan.shutdown.before"
+        assert message["type"] == "lifespan.shutdown.notice"
         message = await receive()
         assert message["type"] == "lifespan.shutdown"
         shutdown_complete = True
@@ -33,7 +33,7 @@ def test_lifespan_on():
         await lifespan.startup()
         assert startup_complete
         assert not shutdown_complete
-        await lifespan.before_shutdown()
+        await lifespan.shutdown_notice()
         await lifespan.shutdown()
         assert startup_complete
         assert shutdown_complete
@@ -51,7 +51,7 @@ def test_lifespan_off():
         lifespan = LifespanOff(config)
 
         await lifespan.startup()
-        await lifespan.before_shutdown()
+        await lifespan.shutdown_notice()
         await lifespan.shutdown()
 
     loop = asyncio.new_event_loop()
@@ -69,7 +69,7 @@ def test_lifespan_auto():
         startup_complete = True
         await send({"type": "lifespan.startup.complete"})
         message = await receive()
-        assert message["type"] == "lifespan.shutdown.before"
+        assert message["type"] == "lifespan.shutdown.notice"
         message = await receive()
         assert message["type"] == "lifespan.shutdown"
         shutdown_complete = True
@@ -84,7 +84,7 @@ def test_lifespan_auto():
         await lifespan.startup()
         assert startup_complete
         assert not shutdown_complete
-        await lifespan.before_shutdown()
+        await lifespan.shutdown_notice()
         await lifespan.shutdown()
         assert startup_complete
         assert shutdown_complete

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -123,11 +123,15 @@ def test_lifespan_on_with_error():
 
 @pytest.mark.parametrize("mode", ("auto", "on"))
 @pytest.mark.parametrize("raise_exception", (True, False))
-def test_lifespan_with_failed_startup(mode, raise_exception):
+@pytest.mark.parametrize("add_message", (True, False))
+def test_lifespan_with_failed_startup(mode, raise_exception, add_message):
     async def app(scope, receive, send):
         message = await receive()
         assert message["type"] == "lifespan.startup"
-        await send({"type": "lifespan.startup.failed"})
+        if add_message:
+            await send({"type": "lifespan.startup.failed", "message": "it failed"})
+        else:
+            await send({"type": "lifespan.startup.failed"})
         if raise_exception:
             # App should be able to re-raise an exception if startup failed.
             raise RuntimeError()

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -18,6 +18,8 @@ def test_lifespan_on():
         startup_complete = True
         await send({"type": "lifespan.startup.complete"})
         message = await receive()
+        assert message["type"] == "lifespan.shutdown.before"
+        message = await receive()
         assert message["type"] == "lifespan.shutdown"
         shutdown_complete = True
         await send({"type": "lifespan.shutdown.complete"})
@@ -31,6 +33,7 @@ def test_lifespan_on():
         await lifespan.startup()
         assert startup_complete
         assert not shutdown_complete
+        await lifespan.before_shutdown()
         await lifespan.shutdown()
         assert startup_complete
         assert shutdown_complete
@@ -48,6 +51,7 @@ def test_lifespan_off():
         lifespan = LifespanOff(config)
 
         await lifespan.startup()
+        await lifespan.before_shutdown()
         await lifespan.shutdown()
 
     loop = asyncio.new_event_loop()
@@ -65,6 +69,8 @@ def test_lifespan_auto():
         startup_complete = True
         await send({"type": "lifespan.startup.complete"})
         message = await receive()
+        assert message["type"] == "lifespan.shutdown.before"
+        message = await receive()
         assert message["type"] == "lifespan.shutdown"
         shutdown_complete = True
         await send({"type": "lifespan.shutdown.complete"})
@@ -78,6 +84,7 @@ def test_lifespan_auto():
         await lifespan.startup()
         assert startup_complete
         assert not shutdown_complete
+        await lifespan.before_shutdown()
         await lifespan.shutdown()
         assert startup_complete
         assert shutdown_complete

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -18,7 +18,7 @@ class LifespanScope(TypedDict):
 
 
 class LifespanReceiveMessage(TypedDict):
-    type: Literal["lifespan.startup", "lifespan.shutdown.before", "lifespan.shutdown"]
+    type: Literal["lifespan.startup", "lifespan.shutdown.notice", "lifespan.shutdown"]
 
 
 class LifespanSendMessage(TypedDict):

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -18,7 +18,7 @@ class LifespanScope(TypedDict):
 
 
 class LifespanReceiveMessage(TypedDict):
-    type: Literal["lifespan.startup", "lifespan.shutdown"]
+    type: Literal["lifespan.startup", "lifespan.shutdown.before", "lifespan.shutdown"]
 
 
 class LifespanSendMessage(TypedDict):

--- a/uvicorn/lifespan/off.py
+++ b/uvicorn/lifespan/off.py
@@ -8,7 +8,7 @@ class LifespanOff:
     async def startup(self) -> None:
         pass
 
-    async def before_shutdown(self) -> None:
+    async def shutdown_notice(self) -> None:
         pass
 
     async def shutdown(self) -> None:

--- a/uvicorn/lifespan/off.py
+++ b/uvicorn/lifespan/off.py
@@ -8,5 +8,8 @@ class LifespanOff:
     async def startup(self) -> None:
         pass
 
+    async def before_shutdown(self) -> None:
+        pass
+
     async def shutdown(self) -> None:
         pass

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -37,11 +37,11 @@ class LifespanOn:
         else:
             self.logger.info("Application startup complete.")
 
-    async def before_shutdown(self) -> None:
+    async def shutdown_notice(self) -> None:
         if self.error_occured:
             return
         self.logger.info("Beginning application shutdown.")
-        await self.receive_queue.put({"type": "lifespan.shutdown.before"})
+        await self.receive_queue.put({"type": "lifespan.shutdown.notice"})
 
     async def shutdown(self) -> None:
         if self.error_occured:

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -37,6 +37,12 @@ class LifespanOn:
         else:
             self.logger.info("Application startup complete.")
 
+    async def before_shutdown(self) -> None:
+        if self.error_occured:
+            return
+        self.logger.info("Beginning application shutdown.")
+        await self.receive_queue.put({"type": "lifespan.shutdown.before"})
+
     async def shutdown(self) -> None:
         if self.error_occured:
             return

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -549,9 +549,6 @@ class Server:
         return False
 
     async def shutdown(self, sockets=None):
-        # Send the lifespan shutdown before event, allowing looping requests to exit
-        await self.lifespan.shutdown_notice()
-
         logger.info("Shutting down")
 
         # Stop accepting new connections.
@@ -561,6 +558,9 @@ class Server:
             sock.close()
         for server in self.servers:
             await server.wait_closed()
+
+        # Send the lifespan shutdown before event, allowing looping requests to exit
+        await self.lifespan.shutdown_notice()
 
         # Request shutdown on all existing connections.
         for connection in list(self.server_state.connections):

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -559,6 +559,9 @@ class Server:
         for server in self.servers:
             await server.wait_closed()
 
+        # Send the lifespan shutdown before event, allowing looping requests to exit
+        await self.lifespan.before_shutdown()
+
         # Request shutdown on all existing connections.
         for connection in list(self.server_state.connections):
             connection.shutdown()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -549,6 +549,9 @@ class Server:
         return False
 
     async def shutdown(self, sockets=None):
+        # Send the lifespan shutdown before event, allowing looping requests to exit
+        await self.lifespan.shutdown_notice()
+
         logger.info("Shutting down")
 
         # Stop accepting new connections.
@@ -558,9 +561,6 @@ class Server:
             sock.close()
         for server in self.servers:
             await server.wait_closed()
-
-        # Send the lifespan shutdown before event, allowing looping requests to exit
-        await self.lifespan.shutdown_notice()
 
         # Request shutdown on all existing connections.
         for connection in list(self.server_state.connections):

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -559,7 +559,7 @@ class Server:
         for server in self.servers:
             await server.wait_closed()
 
-        # Send the lifespan shutdown before event, allowing looping requests to exit
+        # Send the lifespan shutdown notice event.
         await self.lifespan.shutdown_notice()
 
         # Request shutdown on all existing connections.

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -560,7 +560,7 @@ class Server:
             await server.wait_closed()
 
         # Send the lifespan shutdown before event, allowing looping requests to exit
-        await self.lifespan.before_shutdown()
+        await self.lifespan.shutdown_notice()
 
         # Request shutdown on all existing connections.
         for connection in list(self.server_state.connections):


### PR DESCRIPTION
I'm working with Uvicorn and an indefinitely looping endpoint using [Server-Sent Events](https://www.w3.org/TR/eventsource/) to push unidirectional data to browser clients without client polling or WebSockets.

When Uvicorn shuts down, my response is unable to break out of its loop because the spec does not fire "shutdown" signals until after all connections have been closed. 

I opened a proposed change to the ASGI spec here: https://github.com/django/asgiref/pull/199

This PR is code to support the proposed spec changes, and could be used to fix #451, but has to remain a draft until (if) the changes are adopted.