### PR TITLE
Update .gitignore to ignore .coverage.*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cache
 .coverage
+.coverage.*
 .mypy_cache/
 __pycache__/
 uvicorn.egg-info/


### PR DESCRIPTION
This is a scoped PR to update the `.gitignore` file with the extra files generated by `pytest`. This was discussed within https://github.com/encode/uvicorn/pull/799 with @euri10. Not sure why `pytest` generates both the `.coverage` and `.coverage.<hostname>.<some float number>` files.