### PR TITLE
Drop pytest-cov and uses vanilla coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ codecov
 flake8
 isort
 pytest
-pytest-cov
 pytest-mock
 requests
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,13 @@ wheel
 # Testing
 autoflake
 black
-codecov
 flake8
 isort
 pytest
 pytest-mock
 requests
 mypy
+coverage
 
 # Documentation
 mkdocs

--- a/scripts/test
+++ b/scripts/test
@@ -4,7 +4,6 @@ export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
-export SOURCE_FILES="uvicorn tests"
 
 set -ex
 

--- a/scripts/test
+++ b/scripts/test
@@ -4,6 +4,7 @@ export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
+export SOURCE_FILES="uvicorn tests"
 
 set -ex
 
@@ -11,7 +12,7 @@ if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
 
-${PREFIX}pytest $@
+${PREFIX}coverage run --debug config -m pytest
 
 if [ -z $GITHUB_ACTIONS ]; then
     scripts/coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,4 +19,4 @@ known_first_party = uvicorn,tests
 known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,setuptools,urllib3,uvloop,watchgod,websockets,wsproto,yaml
 
 [tool:pytest]
-addopts = --cov=uvicorn --cov=tests -rxXs
+addopts = -rxXs

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,7 @@ known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,
 
 [tool:pytest]
 addopts = -rxXs
+
+[coverage:run]
+omit=venv/*
+source=uvicorn,tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,5 @@ known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,
 addopts = -rxXs
 
 [coverage:run]
-omit=venv/*
-source=uvicorn,tests
+omit = venv/*
+include = uvicorn/*, tests/*


### PR DESCRIPTION
Prompted by https://github.com/encode/uvicorn/pull/805

I personally dont see the advantage of using pytest-cov, this PR drops it and uses vanilla coverage.

It solves the creation of those coverage.hostname.xxxx left by pytest-cov that the aforementioned PR wanted to ignore.

Any preferences ?