### PR TITLE
Added cli suport for headers containing colon

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,30 @@
+import importlib
+from unittest import mock
+
+from click.testing import CliRunner
+
+from uvicorn.main import main as cli
+
+HEADERS = "Content-Security-Policy:default-src 'self'; script-src https://example.com"
+main = importlib.import_module("uvicorn.main")
+
+
+def test_cli_headers():
+    runner = CliRunner()
+
+    with mock.patch.object(main, "run") as mock_run:
+        result = runner.invoke(cli, ["tests.test_cli:App", "--header", HEADERS])
+
+    assert result.output == ""
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+    assert mock_run.call_args[1]["headers"] == [
+        [
+            "Content-Security-Policy",
+            "default-src 'self'; script-src https://example.com",
+        ]
+    ]
+
+
+class App:
+    pass

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -349,7 +349,7 @@ def main(
         "ssl_cert_reqs": ssl_cert_reqs,
         "ssl_ca_certs": ssl_ca_certs,
         "ssl_ciphers": ssl_ciphers,
-        "headers": list([header.split(":") for header in headers]),
+        "headers": list([header.split(":", 1) for header in headers]),
         "use_colors": use_colors,
     }
     run(**kwargs)


### PR DESCRIPTION
Some http headers need to have colon in its values, such as:
```
Content-Security-Policy: default-src 'self'; script-src https://example.com;
```
Passing this value though the client used to raise an error, because this
header would be parsed as:
```
["Content-Security-Policy", "default-src 'self'; script-src https", "//example.com;"]
```
And could no be unpached as key, value pair.

This commit limits the spliting on colon to its first occuence in the string,
enabling us to pass a value containing semicolon in the cli:

```
$ uvicorn main:app --header Content-Security-Policy:default-src *:8000
```