### PR TITLE
Fixes watchgod with common prefixes

### DIFF
--- a/tests/supervisors/test_watchgodreload.py
+++ b/tests/supervisors/test_watchgodreload.py
@@ -22,7 +22,7 @@ def test_watchgodreload(
 
 def test_should_reload_when_python_file_is_changed(tmpdir):
     file = "example.py"
-    update_file = Path(os.path.join(str(tmpdir), file))
+    update_file = Path(tmpdir).joinpath(file)
     update_file.touch()
 
     working_dir = os.getcwd()
@@ -46,7 +46,7 @@ def test_should_reload_when_python_file_is_changed(tmpdir):
 
 def test_should_not_reload_when_dot_file_is_changed(tmpdir):
     file = ".dotted"
-    update_file = Path(os.path.join(str(tmpdir), file))
+    update_file = Path(tmpdir).joinpath(file)
     update_file.touch()
 
     working_dir = os.getcwd()
@@ -63,6 +63,45 @@ def test_should_not_reload_when_dot_file_is_changed(tmpdir):
         assert not reloader.should_restart()
 
         reloader.restart()
+        reloader.shutdown()
+    finally:
+        os.chdir(working_dir)
+
+
+def test_should_reload_when_directories_have_same_prefix(tmpdir):
+    file = "example.py"
+    tmpdir_path = Path(tmpdir)
+    app_dir = tmpdir_path.joinpath("app")
+    app_ext_dir = tmpdir_path.joinpath("app_extension")
+    app_file = app_dir.joinpath(file)
+    app_ext_file = app_ext_dir.joinpath(file)
+    app_dir.mkdir()
+    app_ext_dir.mkdir()
+    app_file.touch()
+    app_ext_file.touch()
+
+    working_dir = os.getcwd()
+    os.chdir(str(tmpdir))
+    try:
+        config = Config(
+            app=None, reload=True, reload_dirs=[str(app_dir), str(app_ext_dir)]
+        )
+        reloader = WatchGodReload(config, target=run, sockets=[])
+        reloader.signal_handler(sig=signal.SIGINT, frame=None)
+        reloader.startup()
+
+        assert not reloader.should_restart()
+        time.sleep(0.1)
+        app_file.touch()
+        assert reloader.should_restart()
+
+        reloader.restart()
+
+        assert not reloader.should_restart()
+        time.sleep(0.1)
+        app_ext_file.touch()
+        assert reloader.should_restart()
+
         reloader.shutdown()
     finally:
         os.chdir(working_dir)

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from os import path
+from pathlib import Path
 
 from watchgod import DefaultWatcher
 
@@ -30,9 +30,9 @@ class WatchGodReload(BaseReload):
         self.reloader_name = "watchgod"
         self.watchers = []
         watch_dirs = {
-            path.realpath(watch_dir)
+            Path(watch_dir).resolve()
             for watch_dir in self.config.reload_dirs
-            if path.isdir(watch_dir)
+            if Path(watch_dir).is_dir()
         }
         watch_dirs_set = set(watch_dirs)
 
@@ -43,10 +43,9 @@ class WatchGodReload(BaseReload):
                 if compare_dir is watch_dir:
                     continue
 
-                if watch_dir.startswith(compare_dir) and len(watch_dir) > len(
-                    compare_dir
-                ):
+                if compare_dir in watch_dir.parents:
                     watch_dirs_set.remove(watch_dir)
+
         self.watch_dir_set = watch_dirs_set
         for w in watch_dirs_set:
             self.watchers.append(CustomWatcher(w))


### PR DESCRIPTION
In the current watchgod implementations directories with similar names and same prefix will remove all except the shortest one.

Example:
``` bash
uvicorn --reload --reload-dir "app" --reload-dir "app_extension" --proxy-headers --host 0.0.0.0 limes.asgi:application
```
With this command line the app_extension directory will be removed form the watch_dirs_set

With this pull request the logic is changed so it uses pathlib (python 3.4+) to recognize common ancestry instead of string compare.