### PR TITLE
Support disabling default Server and Date headers

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,6 +68,8 @@ Options:
                                   populate remote address info.
   --server-header / --no-server-header
                                   Enable/Disable default Server header.
+  --date-header / --no-date-header
+                                  Enable/Disable default Date header.
   --forwarded-allow-ips TEXT      Comma seperated list of IPs to trust with
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,6 +66,8 @@ Options:
                                   Enable/Disable X-Forwarded-Proto,
                                   X-Forwarded-For, X-Forwarded-Port to
                                   populate remote address info.
+  --server-header / --no-server-header
+                                  Enable/Disable default Server header.
   --forwarded-allow-ips TEXT      Comma seperated list of IPs to trust with
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,6 +136,8 @@ Options:
                                   Enable/Disable X-Forwarded-Proto,
                                   X-Forwarded-For, X-Forwarded-Port to
                                   populate remote address info.
+  --server-header / --no-server-header
+                                  Enable/Disable default Server header.
   --forwarded-allow-ips TEXT      Comma seperated list of IPs to trust with
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,6 +138,8 @@ Options:
                                   populate remote address info.
   --server-header / --no-server-header
                                   Enable/Disable default Server header.
+  --date-header / --no-date-header
+                                  Enable/Disable default Date header.
   --forwarded-allow-ips TEXT      Comma seperated list of IPs to trust with
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -83,3 +83,17 @@ async def test_add_additional_header():
                 and response.headers["server"] == "uvicorn"
                 and response.headers["date"]
             )
+
+
+@pytest.mark.asyncio
+async def test_disable_default_date_header():
+    config = Config(
+        app=app,
+        loop="asyncio",
+        limit_max_requests=1,
+        date_header=False,
+    )
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            response = await client.get("http://127.0.0.1:8000")
+            assert "date" not in response.headers

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -37,6 +37,20 @@ async def test_override_server_header():
 
 
 @pytest.mark.asyncio
+async def test_disable_default_server_header():
+    config = Config(
+        app=app,
+        loop="asyncio",
+        limit_max_requests=1,
+        server_header=False,
+    )
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            response = await client.get("http://127.0.0.1:8000")
+            assert "server" not in response.headers
+
+
+@pytest.mark.asyncio
 async def test_override_server_header_multiple_times():
     config = Config(
         app=app,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -145,6 +145,7 @@ class Config:
         reload_delay=None,
         workers=None,
         proxy_headers=True,
+        server_header=True,
         forwarded_allow_ips=None,
         root_path="",
         limit_concurrency=None,
@@ -183,6 +184,7 @@ class Config:
         self.reload_delay = reload_delay or 0.25
         self.workers = workers or 1
         self.proxy_headers = proxy_headers
+        self.server_header = server_header
         self.root_path = root_path
         self.limit_concurrency = limit_concurrency
         self.limit_max_requests = limit_max_requests
@@ -297,9 +299,9 @@ class Config:
             for key, value in self.headers
         ]
         self.encoded_headers = (
-            encoded_headers
-            if b"server" in dict(encoded_headers)
-            else [(b"server", b"uvicorn")] + encoded_headers
+            [(b"server", b"uvicorn")] + encoded_headers
+            if b"server" not in dict(encoded_headers) and self.server_header
+            else encoded_headers
         )  # type: List[Tuple[bytes, bytes]]
 
         if isinstance(self.http, str):

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -146,6 +146,7 @@ class Config:
         workers=None,
         proxy_headers=True,
         server_header=True,
+        date_header=True,
         forwarded_allow_ips=None,
         root_path="",
         limit_concurrency=None,
@@ -185,6 +186,7 @@ class Config:
         self.workers = workers or 1
         self.proxy_headers = proxy_headers
         self.server_header = server_header
+        self.date_header = date_header
         self.root_path = root_path
         self.limit_concurrency = limit_concurrency
         self.limit_max_requests = limit_max_requests

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -182,6 +182,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     help="Enable/Disable default Server header.",
 )
 @click.option(
+    "--date-header/--no-date-header",
+    is_flag=True,
+    default=True,
+    help="Enable/Disable default Date header.",
+)
+@click.option(
     "--forwarded-allow-ips",
     type=str,
     default=None,
@@ -317,6 +323,7 @@ def main(
     access_log: bool,
     proxy_headers: bool,
     server_header: bool,
+    date_header: bool,
     forwarded_allow_ips: str,
     root_path: str,
     limit_concurrency: int,
@@ -359,6 +366,7 @@ def main(
         "workers": workers,
         "proxy_headers": proxy_headers,
         "server_header": server_header,
+        "date_header": date_header,
         "forwarded_allow_ips": forwarded_allow_ips,
         "root_path": root_path,
         "limit_concurrency": limit_concurrency,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -176,6 +176,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "populate remote address info.",
 )
 @click.option(
+    "--server-header/--no-server-header",
+    is_flag=True,
+    default=True,
+    help="Enable/Disable default Server header.",
+)
+@click.option(
     "--forwarded-allow-ips",
     type=str,
     default=None,
@@ -310,6 +316,7 @@ def main(
     log_level: str,
     access_log: bool,
     proxy_headers: bool,
+    server_header: bool,
     forwarded_allow_ips: str,
     root_path: str,
     limit_concurrency: int,
@@ -351,6 +358,7 @@ def main(
         "reload_delay": reload_delay,
         "workers": workers,
         "proxy_headers": proxy_headers,
+        "server_header": server_header,
         "forwarded_allow_ips": forwarded_allow_ips,
         "root_path": root_path,
         "limit_concurrency": limit_concurrency,

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -221,9 +221,15 @@ class Server:
         if counter % 10 == 0:
             current_time = time.time()
             current_date = formatdate(current_time, usegmt=True).encode()
-            self.server_state.default_headers = [
-                (b"date", current_date)
-            ] + self.config.encoded_headers
+
+            if self.config.date_header:
+                date_header = [(b"date", current_date)]
+            else:
+                date_header = []
+
+            self.server_state.default_headers = (
+                date_header + self.config.encoded_headers
+            )
 
             # Callback to `callback_notify` once every `timeout_notify` seconds.
             if self.config.callback_notify is not None:


### PR DESCRIPTION
As described in the individual commit messages, this pull request adds configuration flags to control the default Server and Date headers. With these flags, the Server header can be entirely removed rather than overwritten, and the Date header can be suppressed in (the extremely rare) case that HTTP/1.1 requires an origin server to do so.

Fixes #688