### PR TITLE
Feature: Change reload to be configurable with glob patterns

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,7 +40,7 @@ Options:
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
-  --reload-include TEXT           Set glob patterns to exclude files in
+  --reload-include TEXT           Set glob patterns to include files in
                                   reload watch.
   --reload-exclude TEXT           Set glob patterns to exclude files from
                                   reload watch.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,39 +31,50 @@ Usage: uvicorn [OPTIONS] APP
 Options:
   --host TEXT                     Bind socket to this host.  [default:
                                   127.0.0.1]
+
   --port INTEGER                  Bind socket to this port.  [default: 8000]
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
   --reload                        Enable auto-reload.
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
+
+  --reload-include TEXT           Set glob patterns to include while watching
+                                  for files.
+
+  --reload-exclude TEXT           Set glob patterns to exclude while watching
+                                  for files.
+
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
-  --reload-include TEXT           Set glob patterns to include files in
-                                  reload watch.
-  --reload-exclude TEXT           Set glob patterns to exclude files from
-                                  reload watch.
+
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
+
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
+
   --ws [auto|none|websockets|wsproto]
                                   WebSocket protocol implementation.
                                   [default: auto]
+
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
-  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
+
+  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20]
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --interface [auto|asgi3|asgi2|wsgi]
                                   Select ASGI3, ASGI2, or WSGI as the
                                   application interface.  [default: auto]
+
   --env-file PATH                 Environment configuration file.
   --log-config PATH               Logging configuration file. Supported
                                   formats: .ini, .json, .yaml.
+
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
@@ -72,6 +83,7 @@ Options:
                                   Enable/Disable X-Forwarded-Proto,
                                   X-Forwarded-For, X-Forwarded-Port to
                                   populate remote address info.
+
   --server-header / --no-server-header
                                   Enable/Disable default Server header.
   --date-header / --no-date-header
@@ -80,36 +92,48 @@ Options:
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if
                                   available, or '127.0.0.1'.
+
   --root-path TEXT                Set the ASGI 'root_path' for applications
                                   submounted below a given URL path.
+
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
+
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
+
   --limit-max-requests INTEGER    Maximum number of requests to service before
                                   terminating the process.
+
   --timeout-keep-alive INTEGER    Close Keep-Alive connections if no new data
                                   is received within this timeout.  [default:
                                   5]
+
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 17]
+
   --ssl-cert-reqs INTEGER         Whether client certificate is required (see
                                   stdlib ssl module's)  [default: 0]
+
   --ssl-ca-certs TEXT             CA certificates file
   --ssl-ciphers TEXT              Ciphers to use (see stdlib ssl module's)
                                   [default: TLSv1]
+
   --header TEXT                   Specify custom default HTTP response headers
                                   as a Name:Value pair
+
   --version                       Display the uvicorn version and exit.
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
+
   --factory                       Treat APP as an application factory, i.e. a
                                   () -> <ASGI app> callable.  [default: False]
+
   --help                          Show this message and exit.
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,9 +38,12 @@ Options:
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
   --reload-include TEXT           Set glob patterns to include while watching
-                                  for files.
+                                  for files. Includes '*.py' by default, which
+                                  can be overridden in reload-excludes.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
-                                  for files.
+                                  for files. Includes '.*, .py[cod], .sw.*,
+                                  ~*' by default, which can be overridden in
+                                  reload-excludes.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,6 +40,10 @@ Options:
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
+  --reload-include TEXT           Set glob patterns to exclude files in
+                                  reload watch.
+  --reload-exclude TEXT           Set glob patterns to exclude files from
+                                  reload watch.
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,50 +31,39 @@ Usage: uvicorn [OPTIONS] APP
 Options:
   --host TEXT                     Bind socket to this host.  [default:
                                   127.0.0.1]
-
   --port INTEGER                  Bind socket to this port.  [default: 8000]
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
   --reload                        Enable auto-reload.
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
-
   --reload-include TEXT           Set glob patterns to include while watching
                                   for files.
-
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files.
-
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
-
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
-
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
-
   --ws [auto|none|websockets|wsproto]
                                   WebSocket protocol implementation.
                                   [default: auto]
-
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
-
-  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20]
+  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --interface [auto|asgi3|asgi2|wsgi]
                                   Select ASGI3, ASGI2, or WSGI as the
                                   application interface.  [default: auto]
-
   --env-file PATH                 Environment configuration file.
   --log-config PATH               Logging configuration file. Supported
                                   formats: .ini, .json, .yaml.
-
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
@@ -83,7 +72,6 @@ Options:
                                   Enable/Disable X-Forwarded-Proto,
                                   X-Forwarded-For, X-Forwarded-Port to
                                   populate remote address info.
-
   --server-header / --no-server-header
                                   Enable/Disable default Server header.
   --date-header / --no-date-header
@@ -92,48 +80,36 @@ Options:
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if
                                   available, or '127.0.0.1'.
-
   --root-path TEXT                Set the ASGI 'root_path' for applications
                                   submounted below a given URL path.
-
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
-
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
-
   --limit-max-requests INTEGER    Maximum number of requests to service before
                                   terminating the process.
-
   --timeout-keep-alive INTEGER    Close Keep-Alive connections if no new data
                                   is received within this timeout.  [default:
                                   5]
-
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 17]
-
   --ssl-cert-reqs INTEGER         Whether client certificate is required (see
                                   stdlib ssl module's)  [default: 0]
-
   --ssl-ca-certs TEXT             CA certificates file
   --ssl-ciphers TEXT              Ciphers to use (see stdlib ssl module's)
                                   [default: TLSv1]
-
   --header TEXT                   Specify custom default HTTP response headers
                                   as a Name:Value pair
-
   --version                       Display the uvicorn version and exit.
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
-
   --factory                       Treat APP as an application factory, i.e. a
                                   () -> <ASGI app> callable.  [default: False]
-
   --help                          Show this message and exit.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,50 +104,39 @@ Usage: uvicorn [OPTIONS] APP
 Options:
   --host TEXT                     Bind socket to this host.  [default:
                                   127.0.0.1]
-
   --port INTEGER                  Bind socket to this port.  [default: 8000]
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
   --reload                        Enable auto-reload.
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
-
   --reload-include TEXT           Set glob patterns to include while watching
                                   for files.
-
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files.
-
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
-
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
-
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
-
   --ws [auto|none|websockets|wsproto]
                                   WebSocket protocol implementation.
                                   [default: auto]
-
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
-
-  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20]
+  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --interface [auto|asgi3|asgi2|wsgi]
                                   Select ASGI3, ASGI2, or WSGI as the
                                   application interface.  [default: auto]
-
   --env-file PATH                 Environment configuration file.
   --log-config PATH               Logging configuration file. Supported
                                   formats: .ini, .json, .yaml.
-
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
@@ -156,7 +145,6 @@ Options:
                                   Enable/Disable X-Forwarded-Proto,
                                   X-Forwarded-For, X-Forwarded-Port to
                                   populate remote address info.
-
   --server-header / --no-server-header
                                   Enable/Disable default Server header.
   --date-header / --no-date-header
@@ -165,48 +153,36 @@ Options:
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if
                                   available, or '127.0.0.1'.
-
   --root-path TEXT                Set the ASGI 'root_path' for applications
                                   submounted below a given URL path.
-
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
-
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
-
   --limit-max-requests INTEGER    Maximum number of requests to service before
                                   terminating the process.
-
   --timeout-keep-alive INTEGER    Close Keep-Alive connections if no new data
                                   is received within this timeout.  [default:
                                   5]
-
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 17]
-
   --ssl-cert-reqs INTEGER         Whether client certificate is required (see
                                   stdlib ssl module's)  [default: 0]
-
   --ssl-ca-certs TEXT             CA certificates file
   --ssl-ciphers TEXT              Ciphers to use (see stdlib ssl module's)
                                   [default: TLSv1]
-
   --header TEXT                   Specify custom default HTTP response headers
                                   as a Name:Value pair
-
   --version                       Display the uvicorn version and exit.
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
-
   --factory                       Treat APP as an application factory, i.e. a
                                   () -> <ASGI app> callable.  [default: False]
-
   --help                          Show this message and exit.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,9 +111,12 @@ Options:
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
   --reload-include TEXT           Set glob patterns to include while watching
-                                  for files.
+                                  for files. Includes '*.py' by default, which
+                                  can be overridden in reload-excludes.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
-                                  for files.
+                                  for files. Includes '.*, .py[cod], .sw.*,
+                                  ~*' by default, which can be overridden in
+                                  reload-excludes.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,39 +104,50 @@ Usage: uvicorn [OPTIONS] APP
 Options:
   --host TEXT                     Bind socket to this host.  [default:
                                   127.0.0.1]
+
   --port INTEGER                  Bind socket to this port.  [default: 8000]
   --uds TEXT                      Bind to a UNIX domain socket.
   --fd INTEGER                    Bind to socket from this file descriptor.
   --reload                        Enable auto-reload.
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
+
+  --reload-include TEXT           Set glob patterns to include while watching
+                                  for files.
+
+  --reload-exclude TEXT           Set glob patterns to exclude while watching
+                                  for files.
+
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
-  --reload-include TEXT           Set glob patterns to include files in
-                                  reload watch.
-  --reload-exclude TEXT           Set glob patterns to exclude files from
-                                  reload watch.
+
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
+
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
+
   --ws [auto|none|websockets|wsproto]
                                   WebSocket protocol implementation.
                                   [default: auto]
+
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
-  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
+
+  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20]
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --interface [auto|asgi3|asgi2|wsgi]
                                   Select ASGI3, ASGI2, or WSGI as the
                                   application interface.  [default: auto]
+
   --env-file PATH                 Environment configuration file.
   --log-config PATH               Logging configuration file. Supported
                                   formats: .ini, .json, .yaml.
+
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
@@ -145,6 +156,7 @@ Options:
                                   Enable/Disable X-Forwarded-Proto,
                                   X-Forwarded-For, X-Forwarded-Port to
                                   populate remote address info.
+
   --server-header / --no-server-header
                                   Enable/Disable default Server header.
   --date-header / --no-date-header
@@ -153,36 +165,48 @@ Options:
                                   proxy headers. Defaults to the
                                   $FORWARDED_ALLOW_IPS environment variable if
                                   available, or '127.0.0.1'.
+
   --root-path TEXT                Set the ASGI 'root_path' for applications
                                   submounted below a given URL path.
+
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
+
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
+
   --limit-max-requests INTEGER    Maximum number of requests to service before
                                   terminating the process.
+
   --timeout-keep-alive INTEGER    Close Keep-Alive connections if no new data
                                   is received within this timeout.  [default:
                                   5]
+
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 17]
+
   --ssl-cert-reqs INTEGER         Whether client certificate is required (see
                                   stdlib ssl module's)  [default: 0]
+
   --ssl-ca-certs TEXT             CA certificates file
   --ssl-ciphers TEXT              Ciphers to use (see stdlib ssl module's)
                                   [default: TLSv1]
+
   --header TEXT                   Specify custom default HTTP response headers
                                   as a Name:Value pair
+
   --version                       Display the uvicorn version and exit.
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
+
   --factory                       Treat APP as an application factory, i.e. a
                                   () -> <ASGI app> callable.  [default: False]
+
   --help                          Show this message and exit.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,10 @@ Options:
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
+  --reload-include TEXT           Set glob patterns to exclude files in
+                                  reload watch.
+  --reload-exclude TEXT           Set glob patterns to exclude files from
+                                  reload watch.
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,7 +113,7 @@ Options:
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
-  --reload-include TEXT           Set glob patterns to exclude files in
+  --reload-include TEXT           Set glob patterns to include files in
                                   reload watch.
   --reload-exclude TEXT           Set glob patterns to exclude files from
                                   reload watch.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -22,7 +22,15 @@ you should put `uvicorn.run` into `if __name__ == '__main__'` clause in the main
 ## Development
 
 * `--reload` - Enable auto-reload.
-* `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default all directories in current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.
+* `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default the whole current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.
+* `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `.py`. These can be overwritten by explicitly excluding them.
+* `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These can be overwritten by explicitly including them.
+
+By default Uvicorn uses simple changes detection strategy that compares python files modification times few times a second. If this approach doesn't work for your project (eg. because of its complexity), or you need watching of non python files, you can install Uvicorn with optional `watchgod` dependency to use filesystem events instead:
+
+```
+$ pip install uvicorn[watchgodreload]
+```
 
 ## Production
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -29,7 +29,6 @@ you should put `uvicorn.run` into `if __name__ == '__main__'` clause in the main
 By default Uvicorn uses simple changes detection strategy that compares python files modification times few times a second. If this approach doesn't work for your project (eg. because of its complexity), or you need watching of non python files you can install [watchgod](https://pypi.org/project/watchgod/) or install uvicorn with `uvicorn[standard]`, which will include watchgod.
 
 ```
-$ pip install uvicorn[watchgodreload]
 ```
 
 ## Production

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -23,7 +23,7 @@ you should put `uvicorn.run` into `if __name__ == '__main__'` clause in the main
 
 * `--reload` - Enable auto-reload.
 * `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default the whole current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.
-* `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `.py`. These can be overwritten by explicitly excluding them.
+* `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These can be overwritten by explicitly excluding them.
 * `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These can be overwritten by explicitly including them.
 
 By default Uvicorn uses simple changes detection strategy that compares python files modification times few times a second. If this approach doesn't work for your project (eg. because of its complexity), or you need watching of non python files, you can install Uvicorn with optional `watchgod` dependency to use filesystem events instead:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -26,7 +26,7 @@ you should put `uvicorn.run` into `if __name__ == '__main__'` clause in the main
 * `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These can be overwritten by explicitly excluding them.
 * `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These can be overwritten by explicitly including them.
 
-By default Uvicorn uses simple changes detection strategy that compares python files modification times few times a second. If this approach doesn't work for your project (eg. because of its complexity), or you need watching of non python files, you can install Uvicorn with optional `watchgod` dependency to use filesystem events instead:
+By default Uvicorn uses simple changes detection strategy that compares python files modification times few times a second. If this approach doesn't work for your project (eg. because of its complexity), or you need watching of non python files you can install [watchgod](https://pypi.org/project/watchgod/) or install uvicorn with `uvicorn[standard]`, which will include watchgod.
 
 ```
 $ pip install uvicorn[watchgodreload]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,3 +71,43 @@ def tls_ca_ssl_context(tls_certificate_authority: trustme.CA) -> ssl.SSLContext:
     ssl_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
     tls_certificate_authority.configure_trust(ssl_ctx)
     return ssl_ctx
+
+
+@pytest.fixture(scope="package")
+def reload_directory_structure(tmp_path_factory: pytest.TempPathFactory):
+    """This fixture creates a directory structure to enable reload parameter tests"""
+    root = tmp_path_factory.mktemp("reload_directory")
+    apps = ["app", "app_first", "app_second", "app_third"]
+
+    root_file = root / "main.py"
+    root_file.touch()
+
+    dotted_file = root / ".dotted"
+    dotted_file.touch()
+
+    dotted_dir = root / ".dotted_dir"
+    dotted_dir.mkdir()
+    dotted_dir_file = dotted_dir / "file.txt"
+    dotted_dir_file.touch()
+
+    for app in apps:
+        app_path = root / app
+        app_path.mkdir()
+        dir_files = [
+            ("src", ["main.py"]),
+            ("js", ["main.js"]),
+            ("css", ["main.css"]),
+            ("sub", ["sub.py"]),
+        ]
+        for directory, files in dir_files:
+            directory_path = app_path / directory
+            directory_path.mkdir()
+            for file in files:
+                file_path = directory_path / file
+                file_path.touch()
+    ext_dir = root / "ext"
+    ext_dir.mkdir()
+    ext_file = ext_dir / "ext.jpg"
+    ext_file.touch()
+
+    yield root

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,24 @@ def tls_ca_ssl_context(tls_certificate_authority: trustme.CA) -> ssl.SSLContext:
 
 @pytest.fixture(scope="package")
 def reload_directory_structure(tmp_path_factory: pytest.TempPathFactory):
-    """This fixture creates a directory structure to enable reload parameter tests"""
+    """
+    This fixture creates a directory structure to enable reload parameter tests
+
+    The fixture has the following structure:
+    root
+    ├── [app, app_first, app_second, app_third]
+    │   ├── css
+    │   │   └── main.css
+    │   ├── js
+    │   │   └── main.js
+    │   ├── src
+    │   │   └── main.py
+    │   └── sub
+    │       └── sub.py
+    ├── ext
+    │   └── ext.jpg
+    └── main.py
+    """
     root = tmp_path_factory.mktemp("reload_directory")
     apps = ["app", "app_first", "app_second", "app_third"]
 

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -203,20 +203,6 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload])
-    def test_should_not_parse_filetype_from_includes(self) -> None:
-        file = self.reload_path / "app" / "js" / "main.js"
-
-        with as_cwd(self.reload_path):
-            config = Config(
-                app="tests.test_config:asgi_app", reload=True, reload_includes=["*.js"]
-            )
-            reloader = self._setup_reloader(config)
-
-            assert not self._reload_tester(reloader, file)
-
-            reloader.shutdown()
-
     @pytest.mark.parametrize("reloader_class", [WatchGodReload])
     def test_override_defaults(self) -> None:
         dotted_file = self.reload_path / ".dotted"

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -23,10 +23,10 @@ class TestBaseReload:
         pass  # pragma: no cover
     
     @contextmanager
-    def as_cwd(self):
+    def as_cwd(self, path: Path):
         """Changes working directory and returns to previous on exit."""
         prev_cwd = Path.cwd()
-        os.chdir(self.tmp_path)
+        os.chdir(path)
         try:
             yield
         finally:
@@ -65,7 +65,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(app=None, reload=True)
             reloader = self._setup_reloader(config)
 
@@ -81,7 +81,7 @@ class TestBaseReload:
         sub_dir.mkdir(parents=True)
         update_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(app=None, reload=True)
             reloader = self._setup_reloader(config)
 
@@ -97,7 +97,7 @@ class TestBaseReload:
         sub_dir.mkdir(parents=True)
         update_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(
                 app=None,
                 reload=True,
@@ -117,7 +117,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(app=None, reload=True, reload_includes=["*.js"])
             reloader = self._setup_reloader(config)
 
@@ -134,7 +134,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(
                 app=None, reload=True, reload_includes=["*"], reload_excludes=["*.js"]
             )
@@ -151,7 +151,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(app=None, reload=True)
             reloader = self._setup_reloader(config)
 
@@ -172,7 +172,7 @@ class TestBaseReload:
         app_file.touch()
         app_ext_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(
                 app=None, reload=True, reload_dirs=[str(app_dir), str(app_ext_dir)]
             )
@@ -196,7 +196,7 @@ class TestBaseReload:
         app_file.touch()
         app_ext_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(app=None, reload=True, reload_includes=[str(app_dir)])
             reloader = self._setup_reloader(config)
 
@@ -213,7 +213,7 @@ class TestBaseReload:
         app_dir.mkdir()
         app_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(app=None, reload=True, reload_includes=["*.js"])
             reloader = self._setup_reloader(config)
 
@@ -231,7 +231,7 @@ class TestBaseReload:
         dotted_file.touch()
         python_file.touch()
 
-        with self.as_cwd():
+        with self.as_cwd(self.tmp_path):
             config = Config(
                 app=None, reload=True, reload_includes=[".*"], reload_excludes=["*.py"]
             )
@@ -255,7 +255,7 @@ class TestBaseReload:
         ext_dir.mkdir()
         ext_file.touch()
 
-        with app_dir.cwd():
+        with self.as_cwd(app_dir):
             config = Config(app=None, reload=True, reload_dirs=[str(ext_dir)])
             reloader = self._setup_reloader(config)
 

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -256,14 +256,17 @@ class TestBaseReload:
             assert self._reload_tester(reloader, app_file)
             assert (
                 caplog.records[-1].message
-                == f"WatchGodReload detected file change in '['{str(app_file)}']'."
+                == f"WatchGodReload detected file change in '{[str(app_file)]}'."
                 " Reloading..."
             )
+            assert caplog.records[-1].levelno == WARNING
             assert self._reload_tester(reloader, app_first_file)
+            assert "WatchGodReload detected file change" in caplog.records[-1].message
             assert (
                 caplog.records[-1].message == "WatchGodReload detected file change in "
-                f"'['{str(app_first_file)}']'. Reloading..."
+                f"'{[str(app_first_file)]}'. Reloading..."
             )
+            assert caplog.records[-1].levelno == WARNING
 
             reloader.shutdown()
 
@@ -292,15 +295,14 @@ class TestBaseReload:
             assert self._reload_tester(reloader, app_file)
             assert caplog.records[-1].levelno == WARNING
             assert (
-                caplog.records[-1].message
-                == f"WatchGodReload detected file change in '['{str(app_file)}']'."
-                " Reloading..."
+                caplog.records[-1].message == "WatchGodReload detected file change in "
+                f"'{[str(app_file)]}'. Reloading..."
             )
             assert self._reload_tester(reloader, app_first_file)
             assert caplog.records[-1].levelno == WARNING
             assert (
                 caplog.records[-1].message == "WatchGodReload detected file change in "
-                f"'['{str(app_first_file)}']'. Reloading..."
+                f"'{[str(app_first_file)]}'. Reloading..."
             )
 
             reloader.shutdown()

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -47,9 +47,10 @@ class TestBaseReload:
         Simply run the reloader against a no-op server, and signal for it to
         quit immediately.
         """
-        config = Config(app="tests.test_config:asgi_app", reload=True)
-        reloader = self._setup_reloader(config)
-        reloader.shutdown()
+        with as_cwd(self.reload_path):
+            config = Config(app="tests.test_config:asgi_app", reload=True)
+            reloader = self._setup_reloader(config)
+            reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
     def test_reload_when_python_file_is_changed(self) -> None:

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -22,6 +22,7 @@ class TestBaseReload:
 
     def _setup_reloader(self, config: Config) -> BaseReload:
         reloader = self.reloader_class(config, target=self.run, sockets=[])
+        assert config.should_reload
         reloader.signal_handler(sig=signal.SIGINT, frame=None)
         reloader.startup()
         return reloader
@@ -41,7 +42,7 @@ class TestBaseReload:
         Simply run the reloader against a no-op server, and signal for it to
         quit immediately.
         """
-        config = Config(app=None, reload=True)
+        config = Config(app="tests.test_config:asgi_app", reload=True)
         reloader = self._setup_reloader(config)
         reloader.shutdown()
 
@@ -54,7 +55,7 @@ class TestBaseReload:
         update_file.touch()
 
         with as_cwd(self.tmp_path):
-            config = Config(app=None, reload=True)
+            config = Config(app="tests.test_config:asgi_app", reload=True)
             reloader = self._setup_reloader(config)
 
             assert self._reload_tester(reloader, update_file) == result
@@ -70,7 +71,7 @@ class TestBaseReload:
         update_file.touch()
 
         with as_cwd(self.tmp_path):
-            config = Config(app=None, reload=True)
+            config = Config(app="tests.test_config:asgi_app", reload=True)
             reloader = self._setup_reloader(config)
 
             assert self._reload_tester(reloader, update_file)
@@ -87,7 +88,7 @@ class TestBaseReload:
 
         with as_cwd(self.tmp_path):
             config = Config(
-                app=None,
+                app="tests.test_config:asgi_app",
                 reload=True,
                 reload_excludes=[str(sub_dir)],
             )
@@ -106,7 +107,9 @@ class TestBaseReload:
         update_file.touch()
 
         with as_cwd(self.tmp_path):
-            config = Config(app=None, reload=True, reload_includes=["*.js"])
+            config = Config(
+                app="tests.test_config:asgi_app", reload=True, reload_includes=["*.js"]
+            )
             reloader = self._setup_reloader(config)
 
             assert self._reload_tester(reloader, update_file) == result
@@ -124,7 +127,10 @@ class TestBaseReload:
 
         with as_cwd(self.tmp_path):
             config = Config(
-                app=None, reload=True, reload_includes=["*"], reload_excludes=["*.js"]
+                app="tests.test_config:asgi_app",
+                reload=True,
+                reload_includes=["*"],
+                reload_excludes=["*.js"],
             )
             reloader = self._setup_reloader(config)
 
@@ -140,7 +146,7 @@ class TestBaseReload:
         update_file.touch()
 
         with as_cwd(self.tmp_path):
-            config = Config(app=None, reload=True)
+            config = Config(app="tests.test_config:asgi_app", reload=True)
             reloader = self._setup_reloader(config)
 
             assert not self._reload_tester(reloader, update_file)
@@ -162,7 +168,9 @@ class TestBaseReload:
 
         with as_cwd(self.tmp_path):
             config = Config(
-                app=None, reload=True, reload_dirs=[str(app_dir), str(app_ext_dir)]
+                app="tests.test_config:asgi_app",
+                reload=True,
+                reload_dirs=[str(app_dir), str(app_ext_dir)],
             )
             reloader = self._setup_reloader(config)
 
@@ -185,7 +193,11 @@ class TestBaseReload:
         app_ext_file.touch()
 
         with as_cwd(self.tmp_path):
-            config = Config(app=None, reload=True, reload_includes=[str(app_dir)])
+            config = Config(
+                app="tests.test_config:asgi_app",
+                reload=True,
+                reload_includes=[str(app_dir)],
+            )
             reloader = self._setup_reloader(config)
 
             assert self._reload_tester(reloader, app_file)
@@ -202,7 +214,9 @@ class TestBaseReload:
         app_file.touch()
 
         with as_cwd(self.tmp_path):
-            config = Config(app=None, reload=True, reload_includes=["*.js"])
+            config = Config(
+                app="tests.test_config:asgi_app", reload=True, reload_includes=["*.js"]
+            )
             reloader = self._setup_reloader(config)
 
             assert not self._reload_tester(reloader, app_file)
@@ -221,7 +235,10 @@ class TestBaseReload:
 
         with as_cwd(self.tmp_path):
             config = Config(
-                app=None, reload=True, reload_includes=[".*"], reload_excludes=["*.py"]
+                app="tests.test_config:asgi_app",
+                reload=True,
+                reload_includes=[".*"],
+                reload_excludes=["*.py"],
             )
             reloader = self._setup_reloader(config)
 
@@ -244,7 +261,11 @@ class TestBaseReload:
         ext_file.touch()
 
         with as_cwd(app_dir):
-            config = Config(app=None, reload=True, reload_dirs=[str(ext_dir)])
+            config = Config(
+                app="tests.test_config:asgi_app",
+                reload=True,
+                reload_dirs=[str(ext_dir)],
+            )
             reloader = self._setup_reloader(config)
 
             assert self._reload_tester(reloader, ext_file)

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -77,7 +77,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [WatchGodReload])
-    def test_should_not_reload_when_python_file_in_subdir_is_changed(self) -> None:
+    def test_should_not_reload_when_python_file_in_excluded_subdir_is_changed(self) -> None:
         sub_dir = self.reload_path / "app" / "sub"
         sub_file = sub_dir / "sub.py"
 

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -77,7 +77,9 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [WatchGodReload])
-    def test_should_not_reload_when_python_file_in_excluded_subdir_is_changed(self) -> None:
+    def test_should_not_reload_when_python_file_in_excluded_subdir_is_changed(
+        self,
+    ) -> None:
         sub_dir = self.reload_path / "app" / "sub"
         sub_file = sub_dir / "sub.py"
 

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -14,7 +14,7 @@ class TestBaseReload:
     tmp_path: Path
 
     @pytest.fixture(autouse=True)
-    def setup(self, tmpdir, reloader_class):
+    def setup(self, tmpdir, reloader_class: BaseReload):
         self.tmpdir = tmpdir
         self.tmp_path = Path(tmpdir)
         self.reloader_class = reloader_class
@@ -36,7 +36,7 @@ class TestBaseReload:
         return reloader.should_restart()
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
-    def test_reloader_should_initialize(self):
+    def test_reloader_should_initialize(self) -> None:
         """
         A basic sanity check.
 
@@ -50,7 +50,7 @@ class TestBaseReload:
     @pytest.mark.parametrize(
         "reloader_class, result", [(StatReload, True), (WatchGodReload, True)]
     )
-    def test_reload_when_python_file_is_changed(self, result):
+    def test_reload_when_python_file_is_changed(self, result: bool) -> None:
         file = "example.py"
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
@@ -64,7 +64,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
-    def test_should_reload_when_python_file_in_subdir_is_changed(self):
+    def test_should_reload_when_python_file_in_subdir_is_changed(self) -> None:
         file = "example.py"
         sub_dir = self.tmp_path.joinpath("app", "subdir")
         update_file = sub_dir.joinpath(file)
@@ -80,7 +80,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [WatchGodReload])
-    def test_should_not_reload_when_python_file_in_subdir_is_changed(self):
+    def test_should_not_reload_when_python_file_in_subdir_is_changed(self) -> None:
         file = "example.py"
         sub_dir = self.tmp_path.joinpath("app", "subdir")
         update_file = sub_dir.joinpath(file)
@@ -102,7 +102,7 @@ class TestBaseReload:
     @pytest.mark.parametrize(
         "reloader_class, result", [(StatReload, False), (WatchGodReload, True)]
     )
-    def test_reload_when_javascript_file_is_changed(self, result):
+    def test_reload_when_javascript_file_is_changed(self, result: bool) -> None:
         file = "example.js"
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
@@ -116,7 +116,9 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class, result", [(WatchGodReload, False)])
-    def test_should_not_reload_when_javascript_file_is_changed(self, result):
+    def test_should_not_reload_when_javascript_file_is_changed(
+        self, result: bool
+    ) -> None:
         file = "example.js"
 
         update_file = self.tmp_path.joinpath(file)
@@ -133,7 +135,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
-    def test_should_not_reload_when_dot_file_is_changed(self):
+    def test_should_not_reload_when_dot_file_is_changed(self) -> None:
         file = ".dotted"
 
         update_file = self.tmp_path.joinpath(file)
@@ -148,7 +150,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
-    def test_should_reload_when_directories_have_same_prefix(self):
+    def test_should_reload_when_directories_have_same_prefix(self) -> None:
         file = "example.py"
 
         app_dir = self.tmp_path.joinpath("app")
@@ -172,7 +174,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
-    def test_should_parse_dir_from_includes(self):
+    def test_should_parse_dir_from_includes(self) -> None:
         file = "example.py"
 
         app_dir = self.tmp_path.joinpath("app")
@@ -194,7 +196,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [StatReload])
-    def test_should_not_parse_filetype_from_includes(self):
+    def test_should_not_parse_filetype_from_includes(self) -> None:
         file = "example.js"
         app_dir = self.tmp_path.joinpath("app")
         app_file = app_dir.joinpath(file)
@@ -210,7 +212,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [WatchGodReload])
-    def test_override_defaults(self):
+    def test_override_defaults(self) -> None:
         dotted = ".dotted"
         python = "example.py"
 
@@ -231,7 +233,9 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [StatReload])
-    def test_should_print_full_path_for_non_relative(self, caplog):
+    def test_should_print_full_path_for_non_relative(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         file = "example.py"
         app_dir = self.tmpdir.join("app")
         ext_dir = self.tmp_path.joinpath("ext")

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -1,11 +1,10 @@
-import os
 import signal
-from contextlib import contextmanager
 from pathlib import Path
 from time import sleep
 
 import pytest
 
+from tests.utils import as_cwd
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
 from uvicorn.supervisors.statreload import StatReload
@@ -13,7 +12,6 @@ from uvicorn.supervisors.watchgodreload import WatchGodReload
 
 
 class TestBaseReload:
-
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path, reloader_class: BaseReload):
         self.tmp_path = tmp_path
@@ -21,16 +19,6 @@ class TestBaseReload:
 
     def run(self, sockets):
         pass  # pragma: no cover
-    
-    @contextmanager
-    def as_cwd(self, path: Path):
-        """Changes working directory and returns to previous on exit."""
-        prev_cwd = Path.cwd()
-        os.chdir(path)
-        try:
-            yield
-        finally:
-            os.chdir(prev_cwd)
 
     def _setup_reloader(self, config: Config) -> BaseReload:
         reloader = self.reloader_class(config, target=self.run, sockets=[])
@@ -65,7 +53,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(app=None, reload=True)
             reloader = self._setup_reloader(config)
 
@@ -81,7 +69,7 @@ class TestBaseReload:
         sub_dir.mkdir(parents=True)
         update_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(app=None, reload=True)
             reloader = self._setup_reloader(config)
 
@@ -97,7 +85,7 @@ class TestBaseReload:
         sub_dir.mkdir(parents=True)
         update_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(
                 app=None,
                 reload=True,
@@ -117,7 +105,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(app=None, reload=True, reload_includes=["*.js"])
             reloader = self._setup_reloader(config)
 
@@ -134,7 +122,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(
                 app=None, reload=True, reload_includes=["*"], reload_excludes=["*.js"]
             )
@@ -151,7 +139,7 @@ class TestBaseReload:
         update_file = self.tmp_path.joinpath(file)
         update_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(app=None, reload=True)
             reloader = self._setup_reloader(config)
 
@@ -172,7 +160,7 @@ class TestBaseReload:
         app_file.touch()
         app_ext_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(
                 app=None, reload=True, reload_dirs=[str(app_dir), str(app_ext_dir)]
             )
@@ -196,7 +184,7 @@ class TestBaseReload:
         app_file.touch()
         app_ext_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(app=None, reload=True, reload_includes=[str(app_dir)])
             reloader = self._setup_reloader(config)
 
@@ -213,7 +201,7 @@ class TestBaseReload:
         app_dir.mkdir()
         app_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(app=None, reload=True, reload_includes=["*.js"])
             reloader = self._setup_reloader(config)
 
@@ -231,7 +219,7 @@ class TestBaseReload:
         dotted_file.touch()
         python_file.touch()
 
-        with self.as_cwd(self.tmp_path):
+        with as_cwd(self.tmp_path):
             config = Config(
                 app=None, reload=True, reload_includes=[".*"], reload_excludes=["*.py"]
             )
@@ -255,7 +243,7 @@ class TestBaseReload:
         ext_dir.mkdir()
         ext_file.touch()
 
-        with self.as_cwd(app_dir):
+        with as_cwd(app_dir):
             config = Config(app=None, reload=True, reload_dirs=[str(ext_dir)])
             reloader = self._setup_reloader(config)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,7 +108,6 @@ def test_reload_subdir_removal(tmp_path: Path) -> None:
 
     with as_cwd(tmp_path):
         config = Config(app=asgi_app, reload=True, reload_dirs=reload_dirs)
-        print(config.reload_dirs, Path.cwd())
         assert config.reload_dirs == [tmp_path]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,7 +116,7 @@ def test_reload_dir_is_set(
         assert len(caplog.records) == 1
         assert (
             caplog.records[-1].message
-            == f"Will watch for changes in these directories: ['{app_dir}']"
+            == f"Will watch for changes in these directories: {[app_dir]}"
         )
         assert config.reload_dirs == [app_dir]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,7 +135,8 @@ def test_reload_dir_subdirectories_are_removed(tmp_path: Path) -> None:
     ext_dir = tmp_path / "ext"
     ext_sub_dir = ext_dir / "sub"
 
-    [x.mkdir() for x in [app_dir, app_sub_dir, ext_dir, ext_sub_dir]]
+    for dir in [app_dir, app_sub_dir, ext_dir, ext_sub_dir]:
+        dir.mkdir()
 
     with as_cwd(tmp_path):
         config = Config(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,8 +81,32 @@ def test_config_should_reload_is_set(
     assert config_reload.should_reload is expected_should_reload
 
 
+def test_should_warn_on_invalid_reload_configuration(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    config_class = Config(app=asgi_app, reload_dirs=[str(tmp_path)])
+    assert not config_class.should_reload
+    assert len(caplog.records) == 1
+    assert (
+        caplog.records[-1].message
+        == "Current configuration will not reload as not all conditions are met,"
+        "please refer to documentation."
+    )
+
+    config_no_reload = Config(
+        app="tests.test_config:asgi_app", reload_dirs=[str(tmp_path)]
+    )
+    assert not config_no_reload.should_reload
+    assert len(caplog.records) == 2
+    assert (
+        caplog.records[-1].message
+        == "Current configuration will not reload as not all conditions are met,"
+        "please refer to documentation."
+    )
+
+
 def test_reload_dir_is_set(tmp_path: Path) -> None:
-    config = Config(app=asgi_app, reload=True, reload_dirs=[str(tmp_path)])
+    config = Config(app="tests.test_config:asgi_app", reload=True, reload_dirs=[str(tmp_path)])
     assert config.reload_dirs == [tmp_path]
 
 
@@ -90,7 +114,9 @@ def test_non_existant_reload_dir_is_not_set(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     with as_cwd(tmp_path):
-        config = Config(app=asgi_app, reload=True, reload_dirs=["reload"])
+        config = Config(
+            app="tests.test_config:asgi_app", reload=True, reload_dirs=["reload"]
+        )
         assert config.reload_dirs == [tmp_path]
         assert (
             caplog.records[-1].message
@@ -107,7 +133,9 @@ def test_reload_subdir_removal(tmp_path: Path) -> None:
     reload_dirs = [str(tmp_path), "app", str(app_dir)]
 
     with as_cwd(tmp_path):
-        config = Config(app=asgi_app, reload=True, reload_dirs=reload_dirs)
+        config = Config(
+            app="tests.test_config:asgi_app", reload=True, reload_dirs=reload_dirs
+        )
         assert config.reload_dirs == [tmp_path]
 
 
@@ -120,7 +148,7 @@ def test_reload_included_dir_is_added_to_reload_dirs(tmp_path: Path) -> None:
 
     with as_cwd(tmp_path):
         config = Config(
-            app=asgi_app,
+            app="tests.test_config:asgi_app",
             reload=True,
             reload_dirs=[str(app_dir)],
             reload_includes=["*.js", str(ext_dir)],
@@ -140,7 +168,7 @@ def test_reload_dir_subdirectories_are_removed(tmp_path: Path) -> None:
 
     with as_cwd(tmp_path):
         config = Config(
-            app=asgi_app,
+            app="tests.test_config:asgi_app",
             reload=True,
             reload_dirs=[
                 str(app_dir),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,15 +105,23 @@ def test_should_warn_on_invalid_reload_configuration(
     )
 
 
-def test_reload_dir_is_set(tmp_path: Path) -> None:
-    config = Config(app="tests.test_config:asgi_app", reload=True, reload_dirs=[str(tmp_path)])
-    assert config.reload_dirs == [tmp_path]
+def test_reload_dir_is_set(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO):
+        config = Config(
+            app="tests.test_config:asgi_app", reload=True, reload_dirs=[str(tmp_path)]
+        )
+        assert len(caplog.records) == 1
+        assert (
+            caplog.records[-1].message
+            == f"Will watch for changes in these directories: ['{tmp_path}']"
+        )
+        assert config.reload_dirs == [tmp_path]
 
 
 def test_non_existant_reload_dir_is_not_set(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    with as_cwd(tmp_path):
+    with as_cwd(tmp_path), caplog.at_level(logging.WARNING):
         config = Config(
             app="tests.test_config:asgi_app", reload=True, reload_dirs=["reload"]
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -222,11 +222,10 @@ def test_reload_includes_exclude_dir_patterns_are_matched(
             )
             assert len(caplog.records) == 1
             assert (
-                "Will watch for changes in these directories: "
-                in caplog.records[-1].message
+                caplog.records[-1].message
+                == "Will watch for changes in these directories: "
+                f"{sorted([str(first_app_dir), str(second_app_dir)])}"
             )
-            assert str(first_app_dir) in caplog.records[-1].message
-            assert str(second_app_dir) in caplog.records[-1].message
             assert frozenset(config.reload_dirs) == frozenset(
                 [first_app_dir, second_app_dir]
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,7 +85,9 @@ def test_reload_dir_is_set(tmp_path) -> None:
     assert config.reload_dirs == [tmp_path]
 
 
-def test_non_existant_reload_dir_is_not_set(tmpdir, caplog) -> None:
+def test_non_existant_reload_dir_is_not_set(
+    tmpdir, caplog: pytest.LogCaptureFixture
+) -> None:
     with tmpdir.as_cwd():
         print(Path.cwd())
         config = Config(app=asgi_app, reload=True, reload_dirs=["reload"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,7 +116,7 @@ def test_reload_dir_is_set(
         assert len(caplog.records) == 1
         assert (
             caplog.records[-1].message
-            == f"Will watch for changes in these directories: {[app_dir]}"
+            == f"Will watch for changes in these directories: {[str(app_dir)]}"
         )
         assert config.reload_dirs == [app_dir]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,7 @@
 import asyncio
+import os
+from contextlib import contextmanager
+from pathlib import Path
 
 try:
     from contextlib import asynccontextmanager
@@ -18,3 +21,14 @@ async def run_server(config: Config, sockets=None):
     finally:
         await server.shutdown()
         cancel_handle.cancel()
+
+
+@contextmanager
+def as_cwd(path: Path):
+    """Changes working directory and returns to previous on exit."""
+    prev_cwd = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -133,6 +133,15 @@ def create_ssl_context(
     return ctx
 
 
+def is_dir(path: Path) -> bool:
+    try:
+        if not path.is_absolute():
+            path = path.resolve()
+        return path.is_dir()
+    except OSError:
+        return False
+
+
 def resolve_reload_patterns(
     patterns_list: List[str], directories_list: List[str]
 ) -> Tuple[List[str], List[Path]]:
@@ -147,21 +156,19 @@ def resolve_reload_patterns(
         if pattern == ".*":
             continue
         patterns.append(pattern)
-        try:
-            if Path(pattern).resolve().is_dir():
-                directories.append(Path(pattern))
-            else:
-                for match in current_working_directory.glob(pattern):
-                    if match.is_dir():
-                        directories.append(match)
-        except OSError:
-            pass
+        if is_dir(Path(pattern)):
+            directories.append(Path(pattern))
+        else:
+            print("here")
+            for match in current_working_directory.glob(pattern):
+                if is_dir(match):
+                    directories.append(match)
 
     directories = list(set(directories))
     directories = list(map(Path, directories))
     directories = list(map(lambda x: x.resolve(), directories))
     directories = list(
-        set([reload_path for reload_path in directories if reload_path.is_dir()])
+        set([reload_path for reload_path in directories if is_dir(reload_path)])
     )
 
     children = []

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -238,7 +238,6 @@ class Config:
             try:
                 if Path(pattern).is_dir():
                     reload_dirs_list.append(pattern)
-                    reload_includes.remove(pattern)
                 else:
                     self.reload_includes.append(pattern)
             except OSError:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -331,7 +331,7 @@ class Config:
 
             logger.info(
                 "Will watch for changes in these directories: %s",
-                list(map(str, self.reload_dirs)),
+                sorted(list(map(str, self.reload_dirs))),
             )
 
         if env_file is not None:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -295,6 +295,11 @@ class Config:
 
             self.reload_dirs = list(set(reload_paths).difference(set(children)))
 
+            logger.info(
+                "Will watch for changes in these directories: %s",
+                list(map(str, self.reload_dirs)),
+            )
+
         if env_file is not None:
             from dotenv import load_dotenv
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -159,7 +159,6 @@ def resolve_reload_patterns(
         if is_dir(Path(pattern)):
             directories.append(Path(pattern))
         else:
-            print("here")
             for match in current_working_directory.glob(pattern):
                 if is_dir(match):
                     directories.append(match)

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -84,13 +84,15 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--reload-include",
     "reload_includes",
     multiple=True,
-    help="Set glob patterns to include while watching for files.",
+    help="Set glob patterns to include while watching for files. Includes '*.py' "
+    "by default, which can be overridden in reload-excludes.",
 )
 @click.option(
     "--reload-exclude",
     "reload_excludes",
     multiple=True,
-    help="Set glob patterns to exclude while watching for files.",
+    help="Set glob patterns to exclude while watching for files. Includes "
+    "'.*, .py[cod], .sw.*, ~*' by default, which can be overridden in reload-excludes.",
 )
 @click.option(
     "--reload-delay",

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -81,6 +81,18 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     type=click.Path(exists=True),
 )
 @click.option(
+    "--reload-include",
+    "reload_includes",
+    multiple=True,
+    help="Set glob patterns to include while watching for files.",
+)
+@click.option(
+    "--reload-exclude",
+    "reload_excludes",
+    multiple=True,
+    help="Set glob patterns to exclude while watching for files.",
+)
+@click.option(
     "--reload-delay",
     type=float,
     default=0.25,
@@ -333,6 +345,8 @@ def main(
     debug: bool,
     reload: bool,
     reload_dirs: typing.List[str],
+    reload_includes: typing.List[str],
+    reload_excludes: typing.List[str],
     reload_delay: float,
     workers: int,
     env_file: str,
@@ -382,6 +396,8 @@ def main(
         "debug": debug,
         "reload": reload,
         "reload_dirs": reload_dirs if reload_dirs else None,
+        "reload_includes": reload_includes if reload_includes else None,
+        "reload_excludes": reload_excludes if reload_excludes else None,
         "reload_delay": reload_delay,
         "workers": workers,
         "proxy_headers": proxy_headers,

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -2,6 +2,7 @@ import logging
 import os
 import signal
 import threading
+from pathlib import Path
 from socket import socket
 from types import FrameType
 from typing import Callable, Dict, List, Optional
@@ -64,7 +65,7 @@ class BaseReload:
         self.process.start()
 
     def restart(self) -> None:
-        self.mtimes: Dict[str, float] = {}
+        self.mtimes: Dict[Path, float] = {}
 
         self.process.terminate()
         self.process.join()

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -2,10 +2,9 @@ import logging
 import os
 import signal
 import threading
-from pathlib import Path
 from socket import socket
 from types import FrameType
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 import click
 
@@ -65,7 +64,6 @@ class BaseReload:
         self.process.start()
 
     def restart(self) -> None:
-        self.mtimes: Dict[Path, float] = {}
 
         self.process.terminate()
         self.process.join()

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 from socket import socket
-from typing import Callable, Iterator, List, Optional
+from typing import Callable, Dict, Iterator, List, Optional
 
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
@@ -18,6 +18,7 @@ class StatReload(BaseReload):
     ) -> None:
         super().__init__(config, target, sockets)
         self.reloader_name = "statreload"
+        self.mtimes: Dict[Path, float] = {}
 
     def should_restart(self) -> bool:
         for file in self.iter_py_files():
@@ -40,6 +41,10 @@ class StatReload(BaseReload):
                 logger.warning(message, display_path)
                 return True
         return False
+
+    def restart(self) -> None:
+        self.mtimes = {}
+        return super().restart()
 
     def iter_py_files(self) -> Iterator[Path]:
         for reload_dir in self.config.reload_dirs:

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 from socket import socket
 from typing import Callable, Iterator, List, Optional
@@ -19,31 +18,30 @@ class StatReload(BaseReload):
     ) -> None:
         super().__init__(config, target, sockets)
         self.reloader_name = "statreload"
-        self.mtimes = {}
 
     def should_restart(self) -> bool:
-        for filename in self.iter_py_files():
+        for file in self.iter_py_files():
             try:
-                mtime = os.path.getmtime(filename)
+                mtime = file.stat().st_mtime
             except OSError:  # pragma: nocover
                 continue
 
-            old_time = self.mtimes.get(filename)
+            old_time = self.mtimes.get(file)
             if old_time is None:
-                self.mtimes[filename] = mtime
+                self.mtimes[file] = mtime
                 continue
             elif mtime > old_time:
-                display_path = os.path.normpath(filename)
-                if Path.cwd() in Path(filename).parents:
-                    display_path = os.path.normpath(os.path.relpath(filename))
+                display_path = str(file)
+                try:
+                    display_path = str(file.relative_to(Path.cwd()))
+                except ValueError:
+                    pass
                 message = "StatReload detected file change in '%s'. Reloading..."
                 logger.warning(message, display_path)
                 return True
         return False
 
-    def iter_py_files(self) -> Iterator[str]:
+    def iter_py_files(self) -> Iterator[Path]:
         for reload_dir in self.config.reload_dirs:
-            for subdir, dirs, files in os.walk(reload_dir):
-                for file in files:
-                    if file.endswith(".py"):
-                        yield subdir + os.sep + file
+            for path in list(reload_dir.rglob("*.py")):
+                yield path.resolve()

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import re
 from pathlib import Path
 from socket import socket
 from typing import TYPE_CHECKING, Callable, List, Optional
@@ -13,22 +11,58 @@ from uvicorn.supervisors.basereload import BaseReload
 logger = logging.getLogger("uvicorn.error")
 
 if TYPE_CHECKING:
+    import os
+
     DirEntry = os.DirEntry[str]
 
 
 class CustomWatcher(DefaultWatcher):
-    ignore_dotted_file_regex = r"^\/?(?:\w+\/)*(\.\w+)"
-    ignored: List[str] = []
+    def __init__(self, root_path: Path, config: Config):
+        default_includes = ["*.py"]
+        self.includes = [
+            default
+            for default in default_includes
+            if default not in config.reload_excludes
+        ]
+        self.includes.extend(config.reload_includes)
+        self.includes = list(set(self.includes))
 
-    def __init__(self, root_path: str) -> None:
-        for t in self.ignored_file_regexes:
-            self.ignored.append(t)
-        self.ignored.append(self.ignore_dotted_file_regex)
-        self._ignored = tuple(re.compile(r) for r in self.ignored)
-        super().__init__(root_path)
+        default_excludes = [".*", ".py[cod]", ".sw.*", "~*"]
+        self.excludes = [
+            default
+            for default in default_excludes
+            if default not in config.reload_includes
+        ]
+        self.excludes.extend(config.reload_excludes)
+        self.excludes = list(set(self.excludes))
+
+        self.dirs = config.reload_dirs
+        self.dirs_excludes = config.reload_dirs_excludes
+        super().__init__(str(root_path))
 
     def should_watch_file(self, entry: "DirEntry") -> bool:
-        return not any(r.search(entry.name) for r in self._ignored)
+        entry_path = Path(entry)
+        for include_pattern in self.includes:
+            if entry_path.match(include_pattern):
+                for exclude_pattern in self.excludes:
+                    if entry_path.match(exclude_pattern):
+                        return False
+                return True
+
+        return False
+
+    def should_watch_dir(self, entry: "DirEntry") -> bool:
+        entry_path = Path(entry)
+        for directory in self.dirs:
+            if entry_path == directory or directory in entry_path.parents:
+                for excl_directory in self.dirs_excludes:
+                    if (
+                        entry_path == excl_directory
+                        or excl_directory in entry_path.parents
+                    ):
+                        return False
+                return True
+        return False
 
 
 class WatchGodReload(BaseReload):
@@ -41,26 +75,8 @@ class WatchGodReload(BaseReload):
         super().__init__(config, target, sockets)
         self.reloader_name = "watchgod"
         self.watchers = []
-        watch_dirs = {
-            Path(watch_dir).resolve()
-            for watch_dir in self.config.reload_dirs
-            if Path(watch_dir).is_dir()
-        }
-        watch_dirs_set = set(watch_dirs)
-
-        # remove directories that already have a parent watched, so that we don't have
-        # duplicated change events
-        for watch_dir in watch_dirs:
-            for compare_dir in watch_dirs:
-                if compare_dir is watch_dir:
-                    continue
-
-                if compare_dir in watch_dir.parents:
-                    watch_dirs_set.remove(watch_dir)
-
-        self.watch_dir_set = watch_dirs_set
-        for w in watch_dirs_set:
-            self.watchers.append(CustomWatcher(str(w)))
+        for w in config.reload_dirs:
+            self.watchers.append(CustomWatcher(w.resolve(), self.config))
 
     def should_restart(self) -> bool:
         for watcher in self.watchers:

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -78,12 +78,21 @@ class CustomWatcher(DefaultWatcher):
 
         for exclude_pattern in self.excludes:
             if entry_path.match(exclude_pattern):
-                logger.debug(
-                    "WatchGodReload detected a new excluded dir '%s' in '%s'; "
-                    "Adding to exclude list.",
-                    entry_path.relative_to(self.resolved_root),
-                    str(self.resolved_root),
-                )
+                is_watched = False
+                if entry_path in self.dirs_includes:
+                    is_watched = True
+
+                for directory in self.dirs_includes:
+                    if directory in entry_path.parents:
+                        is_watched = True
+
+                if is_watched:
+                    logger.debug(
+                        "WatchGodReload detected a new excluded dir '%s' in '%s'; "
+                        "Adding to exclude list.",
+                        entry_path.relative_to(self.resolved_root),
+                        str(self.resolved_root),
+                    )
                 self.watched_dirs[entry.path] = False
                 self.dirs_excludes.add(entry_path)
                 return False

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -10,7 +10,7 @@ from uvicorn.supervisors.basereload import BaseReload
 
 logger = logging.getLogger("uvicorn.error")
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import os
 
     DirEntry = os.DirEntry[str]


### PR DESCRIPTION
With this change it is possible to control which files will trigger a reload of uvicorn.

Features:

- New Option `reload-include` is a repeatable list of unix style glob patterns [pathlib.Path.glob](https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob) that will be included in reload watch.
- New Option `reload-exclude` is a repeatable list of unix style glob patterns [pathlib.Path.glob](https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob) that will be excluded in reload watch.
- Common Watchgod and Startreload configuration:
  - Both reloaders get their directories from the new configurations
- Improved Watchgod implementation:
  - Use `should_watch_dir` to reduce setup overhead
  - Use `should_watch_file` with `pathlib` to verify included paths
  - Only watch .py files by default
- Improved Startreload implementation:
  - Use pathlib glob to search for .py files
- Updated documentation
- Updated tests


Edit by @Kludex:
- Closes #984 
- Closes #966  