### PR TITLE
Changed test_config fixture scope, which fixes some config tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,7 @@ def mocked_logging_config_module(mocker):
     return mocker.patch("logging.config")
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def logging_config():
     return deepcopy(LOGGING_CONFIG)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,9 +125,9 @@ def test_asgi_version(app, expected_interface):
     "use_colors, expected",
     [
         pytest.param(None, None, id="use_colors_not_provided"),
+        pytest.param("invalid", None, id="use_colors_invalid_value"),
         pytest.param(True, True, id="use_colors_enabled"),
         pytest.param(False, False, id="use_colors_disabled"),
-        pytest.param("invalid", False, id="use_colors_invalid_value"),
     ],
 )
 def test_log_config_default(mocked_logging_config_module, use_colors, expected):


### PR DESCRIPTION
In https://github.com/encode/uvicorn/pull/814#issuecomment-709948830 I found that changing the `test_log_config_default` parameters order, we break test suite.

It happens because in the test we change `LOGGING_CONFIG` copy from `logging_config` fixture.

I changed `logging_config` scope to `"function"` I fixed this problem