### PR TITLE
Support module:create_app() style factory pattern imports

### DIFF
--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -24,6 +24,13 @@ def test_invalid_attr():
     assert expected in str(exc_info.value)
 
 
+def test_invalid_factory_attr():
+    with pytest.raises(ImportFromStringError) as exc_info:
+        import_from_string("tempfile:tempdir()")
+    expected = 'Attribute "tempdir()" is not callable in module "tempfile".'
+    assert expected in str(exc_info.value)
+
+
 def test_internal_import_error():
     with pytest.raises(ImportError):
         import_from_string("tests.importer.raise_import_error:myattr")
@@ -34,6 +41,13 @@ def test_valid_import():
     from tempfile import TemporaryFile
 
     assert instance == TemporaryFile
+
+
+def test_valid_factory_import():
+    instance = import_from_string("tempfile:TemporaryFile()")
+
+    assert instance is not None
+    assert hasattr(instance, "read") and callable(instance.read)
 
 
 def test_no_import_needed():

--- a/uvicorn/importer.py
+++ b/uvicorn/importer.py
@@ -27,11 +27,19 @@ def import_from_string(import_str):
     instance = module
     try:
         for attr_str in attrs_str.split("."):
-            instance = getattr(instance, attr_str)
+            if attr_str.endswith("()"):
+                callable_ = getattr(instance, attr_str[:-2])
+                instance = callable_()
+            else:
+                instance = getattr(instance, attr_str)
     except AttributeError:
         message = 'Attribute "{attrs_str}" not found in module "{module_str}".'
         raise ImportFromStringError(
             message.format(attrs_str=attrs_str, module_str=module_str)
         )
-
+    except TypeError:
+        message = 'Attribute "{attrs_str}" is not callable in module "{module_str}".'
+        raise ImportFromStringError(
+            message.format(attrs_str=attrs_str, module_str=module_str)
+        )
     return instance


### PR DESCRIPTION
I think holding state in module level objects (created at import time) is a double-edged sword. It's a great python feature, but comes with a cost: makes things harder to test.

My PR allows the users to define a clear intent to use a callable.
I've implemented the same behavior gunicorn has with the explicit  `()` at the end of the import string.

I saw the previous discussion: #492 

**Edit (florimondmanca)**: Closes  #492