### PR TITLE
[Docs] Fix mkdocs warning + Added Permalinks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ repo_name: encode/uvicorn
 repo_url: https://github.com/encode/uvicorn
 edit_uri: ""
 
-pages:
+nav:
     - Introduction: 'index.md'
     - Settings: 'settings.md'
     - Deployment: 'deployment.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,8 @@ pages:
 markdown_extensions:
   - markdown.extensions.codehilite:
       guess_lang: false
+  - toc:
+      permalink: true
 
 extra_javascript:
   - 'js/chat.js'


### PR DESCRIPTION
**Fix MkDocs Warning**
`WARNING -  Config value: 'pages'. Warning: The 'pages' configuration option has been deprecated and will be removed in a future release of MkDocs. Use 'nav' instead.`

**Added Permalink**
From [python-markdown](https://python-markdown.github.io/extensions/toc/#usage):
_**permalink**: Set to `True` or a string to generate permanent links at the end of each header._
_When set to `True` the paragraph symbol (¶ or “`&para;`”) is used as the link text._