### PR TITLE
Cancel old keep-alive trigger before setting new one

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -153,10 +153,13 @@ class H11Protocol(asyncio.Protocol):
     def eof_received(self):
         pass
 
-    def data_received(self, data):
+    def _unset_keepalive_if_required(self):
         if self.timeout_keep_alive_task is not None:
             self.timeout_keep_alive_task.cancel()
             self.timeout_keep_alive_task = None
+
+    def data_received(self, data):
+        self._unset_keepalive_if_required()
 
         self.conn.receive_data(data)
         self.handle_events()
@@ -299,6 +302,8 @@ class H11Protocol(asyncio.Protocol):
             return
 
         # Set a short Keep-Alive timeout.
+        self._unset_keepalive_if_required()
+
         self.timeout_keep_alive_task = self.loop.call_later(
             self.timeout_keep_alive, self.timeout_keep_alive_handler
         )

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -153,10 +153,13 @@ class HttpToolsProtocol(asyncio.Protocol):
     def eof_received(self):
         pass
 
-    def data_received(self, data):
+    def _unset_keepalive_if_required(self):
         if self.timeout_keep_alive_task is not None:
             self.timeout_keep_alive_task.cancel()
             self.timeout_keep_alive_task = None
+
+    def data_received(self, data):
+        self._unset_keepalive_if_required()
 
         try:
             self.parser.feed_data(data)
@@ -301,6 +304,8 @@ class HttpToolsProtocol(asyncio.Protocol):
             return
 
         # Set a short Keep-Alive timeout.
+        self._unset_keepalive_if_required()
+
         self.timeout_keep_alive_task = self.loop.call_later(
             self.timeout_keep_alive, self.timeout_keep_alive_handler
         )


### PR DESCRIPTION
This PR should fix #824. The second PR with tests https://github.com/encode/uvicorn/pull/831 should be merged after this PR (as you can see its build fails https://github.com/encode/uvicorn/pull/831/checks?check_run_id=1298976600)

I found that we do not cancel old keep-alive timeout, creating new one. So that sometimes we have the race-condition, where there are 2 keep-alive sweepers existing at the same time.