### PR TITLE
Ensure non-zero exit code when startup fails

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -388,6 +388,11 @@ def run(app, **kwargs):
         supervisor.run()
     else:
         server.run()
+        # If the server exited and it is not started,
+        # we can assume that something went wrong during startup.
+        # Thus we need to exit with non-zero exit code.
+        if not server.started:
+            sys.exit(1)
 
 
 class ServerState:


### PR DESCRIPTION
Fixes #780 

I think this is a pretty straightforward and minimal fix. I tested it in my app and it works.

I'm using `uvicorn` like this:
```
uvicorn \
  --host "0.0.0.0" \
  --port "${SERVER_PORT}" \
  --access-log \
  --log-level debug \
  --limit-concurrency "${UVICORN_LIMIT_CONCURRENCY:-30}" \
  --backlog "${UVICORN_BACKLOG:-2048}" \
  myapp.main:app
```
In other words, I don't use a supervisor or something like that, so I'm not sure if those use cases are covered.

Let me know what you think.