### PR TITLE
Rework IPv6 support

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,7 +11,7 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 
 ## Socket Binding
 
-* `--host <str>` - Bind socket to this host. Use `--host 0.0.0.0` to make the application available on your local network. **Default:** *'127.0.0.1'*.
+* `--host <str>` - Bind socket to this host. Use `--host 0.0.0.0` to make the application available on your local network. IPv6 addresses are supported, for example: `--host '::'`. **Default:** *'127.0.0.1'*.
 * `--port <int>` - Bind to a socket with this port. **Default:** *8000*.
 * `--uds <str>` - Bind to a UNIX domain socket. Useful if you want to run Uvicorn behind a reverse proxy.
 * `--fd <int>` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,7 @@ from uvicorn.main import Server
     [
         pytest.param(None, "http://127.0.0.1:8000", id="default"),
         pytest.param("localhost", "http://127.0.0.1:8000", id="hostname"),
-        pytest.param("::", "http://[::]:8000", id="ipv6"),
+        pytest.param("::1", "http://[::1]:8000", id="ipv6"),
     ],
 )
 def test_run(host, url):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -33,31 +33,6 @@ def test_run():
     thread.join()
 
 
-def test_run_hostname():
-    class App:
-        def __init__(self, scope):
-            if scope["type"] != "http":
-                raise Exception()
-
-        async def __call__(self, receive, send):
-            await send({"type": "http.response.start", "status": 204, "headers": []})
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
-    config = Config(app=App, host="localhost", loop="asyncio", limit_max_requests=1)
-    server = CustomServer(config=config)
-    thread = threading.Thread(target=server.run)
-    thread.start()
-    while not server.started:
-        time.sleep(0.01)
-    response = requests.get("http://localhost:8000")
-    assert response.status_code == 204
-    thread.join()
-
-
 def test_run_multiprocess():
     class App:
         def __init__(self, scope):

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -7,6 +7,7 @@ import os
 import socket
 import ssl
 import sys
+from enum import Enum
 from typing import List, Tuple
 
 import click
@@ -115,8 +116,15 @@ def create_ssl_context(
     return ctx
 
 
-def _get_server_start_message(is_ipv6_message: bool = False) -> Tuple[str, str]:
-    if is_ipv6_message:
+class _IPKind(Enum):
+    IPv4 = "IPv4"
+    IPv6 = "IPv6"
+
+
+def _get_server_start_message(
+    host_ip_version: _IPKind = _IPKind.IPv4,
+) -> Tuple[str, str]:
+    if host_ip_version is _IPKind.IPv6:
         ip_repr = "%s://[%s]:%d"
     else:
         ip_repr = "%s://%s:%d"
@@ -368,9 +376,9 @@ class Config:
         sock.set_inheritable(True)
 
         if family == socket.AddressFamily.AF_INET6:
-            message, color_message = _get_server_start_message(is_ipv6_message=True)
+            message, color_message = _get_server_start_message(_IPKind.IPv6)
         else:
-            message, color_message = _get_server_start_message()
+            message, color_message = _get_server_start_message(_IPKind.IPv4)
         protocol_name = "https" if self.is_ssl else "http"
         logger.info(
             message,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -341,13 +341,10 @@ class Config:
             loop_setup()
 
     def bind_socket(self):
-        host = self.host
-        port = self.port
-
         family = socket.AF_INET
         addr_format = "%s://%s:%d"
 
-        if host and ":" in host:
+        if self.host and ":" in self.host:
             # It's an IPv6 address.
             family = socket.AF_INET6
             addr_format = "%s://[%s]:%d"
@@ -355,7 +352,7 @@ class Config:
         sock = socket.socket(family=family)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            sock.bind((host, port))
+            sock.bind((self.host, self.port))
         except OSError as exc:
             logger.error(exc)
             sys.exit(1)
@@ -371,8 +368,8 @@ class Config:
         logger.info(
             message,
             protocol_name,
-            host,
-            port,
+            self.host,
+            self.port,
             extra={"color_message": color_message},
         )
         return sock

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -7,7 +7,6 @@ import os
 import socket
 import ssl
 import sys
-from enum import Enum
 from typing import List, Tuple
 
 import click
@@ -114,27 +113,6 @@ def create_ssl_context(
     if ciphers:
         ctx.set_ciphers(ciphers)
     return ctx
-
-
-class _IPKind(Enum):
-    IPv4 = "IPv4"
-    IPv6 = "IPv6"
-
-
-def _get_server_start_message(
-    host_ip_version: _IPKind = _IPKind.IPv4,
-) -> Tuple[str, str]:
-    if host_ip_version is _IPKind.IPv6:
-        ip_repr = "%s://[%s]:%d"
-    else:
-        ip_repr = "%s://%s:%d"
-    message = f"Uvicorn running on {ip_repr} (Press CTRL+C to quit)"
-    color_message = (
-        "Uvicorn running on "
-        + click.style(ip_repr, bold=True)
-        + " (Press CTRL+C to quit)"
-    )
-    return message, color_message
 
 
 class Config:
@@ -363,10 +341,7 @@ class Config:
             loop_setup()
 
     def bind_socket(self):
-        family, sockettype, proto, canonname, sockaddr = socket.getaddrinfo(
-            self.host, self.port, type=socket.SOCK_STREAM
-        )[0]
-        sock = socket.socket(family=family, type=sockettype)
+        sock = socket.socket()
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((self.host, self.port))
@@ -375,10 +350,12 @@ class Config:
             sys.exit(1)
         sock.set_inheritable(True)
 
-        if family == socket.AddressFamily.AF_INET6:
-            message, color_message = _get_server_start_message(_IPKind.IPv6)
-        else:
-            message, color_message = _get_server_start_message(_IPKind.IPv4)
+        message = "Uvicorn running on %s://%s:%d (Press CTRL+C to quit)"
+        color_message = (
+            "Uvicorn running on "
+            + click.style("%s://%s:%d", bold=True)
+            + " (Press CTRL+C to quit)"
+        )
         protocol_name = "https" if self.is_ssl else "http"
         logger.info(
             message,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -10,7 +10,7 @@ import sys
 import time
 import typing
 from email.utils import formatdate
-from ipaddress import IPv4Address, IPv6Address, ip_address
+from ipaddress import IPv6Address, ip_address
 
 import click
 
@@ -26,6 +26,7 @@ from uvicorn.config import (
     WS_PROTOCOLS,
     Config,
     _get_server_start_message,
+    _IPKind,
 )
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
@@ -522,16 +523,10 @@ class Server:
             if port == 0:
                 port = server.sockets[0].getsockname()[1]
             protocol_name = "https" if config.ssl else "http"
-            try:
-                addr = ip_address(config.host)
-                if isinstance(addr, IPv6Address):
-                    message, color_message = _get_server_start_message(
-                        is_ipv6_message=True
-                    )
-                elif isinstance(addr, IPv4Address):
-                    message, color_message = _get_server_start_message()
-            except ValueError:
-                message, color_message = _get_server_start_message()
+            if isinstance(ip_address(config.host), IPv6Address):
+                message, color_message = _get_server_start_message(_IPKind.IPv6)
+            else:
+                message, color_message = _get_server_start_message(_IPKind.IPv4)
 
             logger.info(
                 message,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -505,7 +505,7 @@ class Server:
         else:
             # Standard case. Create a socket from a host/port pair.
             addr_format = "%s://%s:%d"
-            if self.host and ":" in self.host:
+            if config.host and ":" in config.host:
                 # It's an IPv6 address.
                 addr_format = "%s://[%s]:%d"
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -10,7 +10,6 @@ import sys
 import time
 import typing
 from email.utils import formatdate
-from ipaddress import IPv6Address, ip_address
 
 import click
 
@@ -25,8 +24,6 @@ from uvicorn.config import (
     SSL_PROTOCOL_VERSION,
     WS_PROTOCOLS,
     Config,
-    _get_server_start_message,
-    _IPKind,
 )
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
@@ -523,11 +520,12 @@ class Server:
             if port == 0:
                 port = server.sockets[0].getsockname()[1]
             protocol_name = "https" if config.ssl else "http"
-            if isinstance(ip_address(config.host), IPv6Address):
-                message, color_message = _get_server_start_message(_IPKind.IPv6)
-            else:
-                message, color_message = _get_server_start_message(_IPKind.IPv4)
-
+            message = "Uvicorn running on %s://%s:%d (Press CTRL+C to quit)"
+            color_message = (
+                "Uvicorn running on "
+                + click.style("%s://%s:%d", bold=True)
+                + " (Press CTRL+C to quit)"
+            )
             logger.info(
                 message,
                 protocol_name,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -504,20 +504,16 @@ class Server:
 
         else:
             # Standard case. Create a socket from a host/port pair.
-
-            host = config.host
-            port = config.port
             addr_format = "%s://%s:%d"
-
-            if host and ":" in host:
+            if self.host and ":" in self.host:
                 # It's an IPv6 address.
                 addr_format = "%s://[%s]:%d"
 
             try:
                 server = await loop.create_server(
                     create_protocol,
-                    host=host,
-                    port=port,
+                    host=config.host,
+                    port=config.port,
                     ssl=config.ssl,
                     backlog=config.backlog,
                 )
@@ -525,7 +521,7 @@ class Server:
                 logger.error(exc)
                 await self.lifespan.shutdown()
                 sys.exit(1)
-
+            port = config.port
             if port == 0:
                 port = server.sockets[0].getsockname()[1]
             protocol_name = "https" if config.ssl else "http"
@@ -538,7 +534,7 @@ class Server:
             logger.info(
                 message,
                 protocol_name,
-                host,
+                config.host,
                 port,
                 extra={"color_message": color_message},
             )


### PR DESCRIPTION
Prompted by https://github.com/encode/uvicorn/issues/836#issuecomment-715975954

It looks like IPv6 support as added (or most likely _fixed_? I found #383 dating back from June 2019) into `0.12.2` to resolve #553. This was done via #803, which glossed over a small edge case leading to `host="localhost"` not working anymore, leading to issue #825, and then a fix via #827.

But @euri10 mentioned in #827 that the fix wasn't the prettiest, so I went ahead and started this whole thing all over — here's what I did in this PR…

1. Revert #827 
1. Revert #803 
1. Re-implement them in a simpler way. Also expanded the `test_run()` test so that it tests all three cases: default case (`127.0.0.1`), DNS hostname (`localhost`), and IPv6 (`[::]`).
1. Update docs to mention that `--host` now supports IPv6 addresses, with an example.

It might be easy to review commit-by-commit, since the overall diff conflates reverts and the actual re-implementation. :-)

**Note**: for the changelog, we'll probably want to _not_ mention #827, and mention this PR instead (if we decide to merge it).