### PR TITLE
Make lifespan implementation agnostic to async library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ env_marker_below_38 = "python_version < '3.8'"
 minimal_requirements = [
     "click==7.*",
     "h11>=0.8",
+    "sniffio==1.*",
     "typing-extensions;" + env_marker_below_38,
 ]
 

--- a/uvicorn/_backends/asyncio.py
+++ b/uvicorn/_backends/asyncio.py
@@ -36,6 +36,6 @@ class AsyncioBackend(AsyncBackend):
     def create_queue(self) -> AsyncQueue:
         return Queue()
 
-    async def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
+    def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
         loop = asyncio.get_event_loop()
         loop.create_task(async_fn())

--- a/uvicorn/_backends/asyncio.py
+++ b/uvicorn/_backends/asyncio.py
@@ -1,0 +1,41 @@
+import asyncio
+from typing import Awaitable, Callable
+
+from .base import AsyncBackend, AsyncEvent, AsyncQueue, T
+
+
+class Event(AsyncEvent):
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def set(self) -> None:
+        self._event.set()
+
+    async def wait(self) -> None:
+        await self._event.wait()
+
+
+class Queue(AsyncQueue[T]):
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[T]" = asyncio.Queue()
+
+    async def get(self) -> T:
+        return await self._queue.get()
+
+    async def put(self, item: T) -> None:
+        await self._queue.put(item)
+
+
+class AsyncioBackend(AsyncBackend):
+    def create_event(self) -> AsyncEvent:
+        return Event()
+
+    def create_queue(self) -> AsyncQueue:
+        return Queue()
+
+    async def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
+        loop = asyncio.get_event_loop()
+        loop.create_task(async_fn())

--- a/uvicorn/_backends/auto.py
+++ b/uvicorn/_backends/auto.py
@@ -25,5 +25,5 @@ class AutoBackend(AsyncBackend):
     def create_queue(self) -> AsyncQueue:
         return self._backend.create_queue()
 
-    async def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
-        await self._backend.unsafe_spawn_task(async_fn)
+    def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
+        self._backend.unsafe_spawn_task(async_fn)

--- a/uvicorn/_backends/auto.py
+++ b/uvicorn/_backends/auto.py
@@ -1,0 +1,29 @@
+from typing import Awaitable, Callable
+
+import sniffio
+
+from .base import AsyncBackend, AsyncEvent, AsyncQueue
+
+
+class AutoBackend(AsyncBackend):
+    @property
+    def _backend(self) -> AsyncBackend:
+        if not hasattr(self, "_backend_impl"):
+            library = sniffio.current_async_library()
+            if library == "asyncio":
+                from .asyncio import AsyncioBackend
+
+                self._backend_impl = AsyncioBackend()
+            else:
+                raise RuntimeError("Unknown async environment: {library}")
+
+        return self._backend_impl
+
+    def create_event(self) -> AsyncEvent:
+        return self._backend.create_event()
+
+    def create_queue(self) -> AsyncQueue:
+        return self._backend.create_queue()
+
+    async def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
+        await self._backend.unsafe_spawn_task(async_fn)

--- a/uvicorn/_backends/base.py
+++ b/uvicorn/_backends/base.py
@@ -43,5 +43,5 @@ class AsyncBackend:
     def create_queue(self) -> AsyncQueue:
         raise NotImplementedError  # pragma: no cover
 
-    async def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
+    def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
         raise NotImplementedError  # pragma: no cover

--- a/uvicorn/_backends/base.py
+++ b/uvicorn/_backends/base.py
@@ -1,0 +1,47 @@
+from typing import Awaitable, Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class AsyncEvent:
+    """
+    Base interface for events.
+    """
+
+    def is_set(self) -> bool:
+        raise NotImplementedError  # pragma: no cover
+
+    def set(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    async def wait(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class AsyncQueue(Generic[T]):
+    """
+    Base interface for FIFO queues.
+    """
+
+    async def get(self) -> T:
+        raise NotImplementedError  # pragma: no cover
+
+    async def put(self, item: T) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+
+class AsyncBackend:
+    """
+    Base interface for async concurrency backends.
+
+    Aims at abstracting away any asyncio-specific APIs.
+    """
+
+    def create_event(self) -> AsyncEvent:
+        raise NotImplementedError  # pragma: no cover
+
+    def create_queue(self) -> AsyncQueue:
+        raise NotImplementedError  # pragma: no cover
+
+    async def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
+        raise NotImplementedError  # pragma: no cover

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -28,7 +28,7 @@ class LifespanOn:
     async def startup(self) -> None:
         self.logger.info("Waiting for application startup.")
 
-        await self._backend.unsafe_spawn_task(self.main)
+        self._backend.unsafe_spawn_task(self.main)
 
         await self.receive_queue.put({"type": "lifespan.startup"})
         await self.startup_event.wait()


### PR DESCRIPTION
Builds on #843 

Third step of https://github.com/encode/uvicorn/issues/169#issuecomment-723556384: update `LifespanOn` implementation so that it's using an asyncio-agnostic API. This is done by introducing an `AsyncBackend` interface (much like we're doing in HTTPCore).

Note: Not using `anyio` here (yet) so that we have full control over the interface and we can move forward more easily. (But as in HTTPCore, we can consider switching later.)