### PR TITLE
Make WSGI implementation agnostic to async library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ minimal_requirements = [
     "h11>=0.8",
     "sniffio==1.*",
     "typing-extensions;" + env_marker_below_38,
+    "async_generator; python_version < 3.7",
+    "async_exit_stack; python_version < 3.7",
 ]
 
 extra_requirements = [

--- a/uvicorn/_backends/auto.py
+++ b/uvicorn/_backends/auto.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable
+from typing import Any, AsyncContextManager, Callable
 
 import sniffio
 
@@ -25,5 +25,16 @@ class AutoBackend(AsyncBackend):
     def create_queue(self) -> AsyncQueue:
         return self._backend.create_queue()
 
-    def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
-        self._backend.unsafe_spawn_task(async_fn)
+    def call_soon(self, fn: Callable, *args: Any) -> None:
+        self._backend.call_soon(fn, *args)
+
+    def unsafe_spawn_task(self, async_fn: Callable, *args: Any) -> None:
+        await self._backend.unsafe_spawn_task(async_fn)
+
+    def run_in_background(
+        self, async_fn: Callable, *args: Any
+    ) -> AsyncContextManager[None]:
+        return self._backend.run_in_background(async_fn, *args)
+
+    async def run_sync_in_thread(self, fn: Callable, *args: Any) -> None:
+        await self._backend.run_sync_in_thread(fn, *args)

--- a/uvicorn/_backends/base.py
+++ b/uvicorn/_backends/base.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable, Generic, TypeVar
+from typing import Any, AsyncContextManager, Callable, Generic, TypeVar
 
 T = TypeVar("T")
 
@@ -15,6 +15,9 @@ class AsyncEvent:
         raise NotImplementedError  # pragma: no cover
 
     async def wait(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    def clear(self) -> None:
         raise NotImplementedError  # pragma: no cover
 
 
@@ -43,5 +46,16 @@ class AsyncBackend:
     def create_queue(self) -> AsyncQueue:
         raise NotImplementedError  # pragma: no cover
 
-    def unsafe_spawn_task(self, async_fn: Callable[[], Awaitable[None]]) -> None:
+    def call_soon(self, fn: Callable, *args: Any) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    def unsafe_spawn_task(self, async_fn: Callable, *args: Any) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    def run_in_background(
+        self, async_fn: Callable, *args: Any
+    ) -> AsyncContextManager[None]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def run_sync_in_thread(self, fn: Callable, *args: Any) -> None:
         raise NotImplementedError  # pragma: no cover

--- a/uvicorn/_compat.py
+++ b/uvicorn/_compat.py
@@ -1,0 +1,17 @@
+try:
+    from contextlib import AsyncExitStack
+except ImportError:  # pragma: no cover
+    # Python < 3.7
+    from async_exit_stack import AsyncExitStack  # type: ignore
+
+try:
+    from contextlib import asynccontextmanager
+except ImportError:  # pragma: no cover
+    # Python < 3.7
+    from async_generator import asynccontextmanager  # type: ignore
+
+
+__all__ = [
+    "AsyncExitStack",
+    "asynccontextmanager",
+]


### PR DESCRIPTION
Builds on #844 

Last part of stage 1 of https://github.com/encode/uvicorn/issues/169#issuecomment-723556384: rework `WSGIMiddleware` so that it calls into `AsyncBackend` rather than `asyncio` directly.

This is the gnarliest of refactor PRs, since this component does some close concurrency. I know the `backend.call_soon()` method won't stay here when `trio` is added (trio doesn't have such a "schedule a callback from outside the event loop" API), and we'll need to refactor this, but for now the goal is to have some abstraction without changing too much the implementation logic. Tests pass locally, so I'm happy (but let's see what CI says).