### PR TITLE
make sure tests don't fail if a running uvicorn app is present

### DIFF
--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -72,13 +72,14 @@ def test_trace_logging(capsys):
         limit_max_requests=1,
         log_config=test_logging_config,
         log_level="trace",
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
     assert response.status_code == 204
     thread.join()
     captured = capsys.readouterr()
@@ -111,13 +112,14 @@ def test_access_logging(capsys, http_protocol):
         http=http_protocol,
         limit_max_requests=1,
         log_config=test_logging_config,
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
     assert response.status_code == 204
     thread.join()
     captured = capsys.readouterr()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,7 +78,7 @@ def test_concrete_http_class():
 
 
 def test_socket_bind():
-    config = Config(app=asgi_app)
+    config = Config(app=asgi_app, port=8917)
     config.load()
 
     assert isinstance(config.bind_socket(), socket.socket)

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -22,13 +22,13 @@ class CustomServer(Server):
 
 
 def test_default_default_headers():
-    config = Config(app=App, loop="asyncio", limit_max_requests=1)
+    config = Config(app=App, loop="asyncio", limit_max_requests=1, port=8917)
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
 
     assert response.headers["server"] == "uvicorn" and response.headers["date"]
 
@@ -41,13 +41,14 @@ def test_override_server_header():
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden")],
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
 
     assert response.headers["server"] == "over-ridden" and response.headers["date"]
 
@@ -60,13 +61,14 @@ def test_override_server_header_multiple_times():
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden"), ("Server", "another-value")],
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
 
     assert (
         response.headers["server"] == "over-ridden, another-value"
@@ -82,13 +84,14 @@ def test_add_additional_header():
         loop="asyncio",
         limit_max_requests=1,
         headers=[("X-Additional", "new-value")],
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
 
     assert (
         response.headers["x-additional"] == "new-value"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,9 +12,9 @@ from uvicorn.main import Server
 @pytest.mark.parametrize(
     "host, url",
     [
-        pytest.param(None, "http://127.0.0.1:8000", id="default"),
-        pytest.param("localhost", "http://127.0.0.1:8000", id="hostname"),
-        pytest.param("::1", "http://[::1]:8000", id="ipv6"),
+        pytest.param(None, "http://127.0.0.1:8917", id="default"),
+        pytest.param("localhost", "http://127.0.0.1:8917", id="hostname"),
+        pytest.param("::1", "http://[::1]:8917", id="ipv6"),
     ],
 )
 def test_run(host, url):
@@ -31,7 +31,7 @@ def test_run(host, url):
         def install_signal_handlers(self):
             pass
 
-    config = Config(app=App, host=host, loop="asyncio", limit_max_requests=1)
+    config = Config(app=App, host=host, loop="asyncio", limit_max_requests=1, port=8917)
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
@@ -56,13 +56,13 @@ def test_run_multiprocess():
         def install_signal_handlers(self):
             pass
 
-    config = Config(app=App, loop="asyncio", workers=2, limit_max_requests=1)
+    config = Config(app=App, loop="asyncio", workers=2, limit_max_requests=1, port=8917)
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
     assert response.status_code == 204
     thread.join()
 
@@ -81,13 +81,15 @@ def test_run_reload():
         def install_signal_handlers(self):
             pass
 
-    config = Config(app=App, loop="asyncio", reload=True, limit_max_requests=1)
+    config = Config(
+        app=App, loop="asyncio", reload=True, limit_max_requests=1, port=8917
+    )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
         time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+    response = requests.get("http://127.0.0.1:8917")
     assert response.status_code == 204
     thread.join()
 
@@ -106,7 +108,7 @@ def test_run_with_shutdown():
         def install_signal_handlers(self):
             pass
 
-    config = Config(app=App, loop="asyncio", workers=2, limit_max_requests=1)
+    config = Config(app=App, loop="asyncio", workers=2, limit_max_requests=1, port=8917)
     server = CustomServer(config=config)
     sock = config.bind_socket()
     exc = True

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -48,6 +48,7 @@ def test_run(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
         limit_max_requests=1,
         ssl_keyfile=tls_ca_certificate_private_key_path,
         ssl_certfile=tls_ca_certificate_pem_path,
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
@@ -55,7 +56,7 @@ def test_run(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
     while not server.started:
         time.sleep(0.01)
     with no_ssl_verification():
-        response = requests.get("https://127.0.0.1:8000")
+        response = requests.get("https://127.0.0.1:8917")
     assert response.status_code == 204
     thread.join()
 
@@ -82,6 +83,7 @@ def test_run_chain(tls_certificate_pem_path):
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_pem_path,
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
@@ -89,7 +91,7 @@ def test_run_chain(tls_certificate_pem_path):
     while not server.started:
         time.sleep(0.01)
     with no_ssl_verification():
-        response = requests.get("https://127.0.0.1:8000")
+        response = requests.get("https://127.0.0.1:8917")
     assert response.status_code == 204
     thread.join()
 
@@ -120,6 +122,7 @@ def test_run_password(
         ssl_keyfile=tls_ca_certificate_private_key_encrypted_path,
         ssl_certfile=tls_ca_certificate_pem_path,
         ssl_keyfile_password="uvicorn password for the win",
+        port=8917,
     )
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
@@ -127,6 +130,6 @@ def test_run_password(
     while not server.started:
         time.sleep(0.01)
     with no_ssl_verification():
-        response = requests.get("https://127.0.0.1:8000")
+        response = requests.get("https://127.0.0.1:8917")
     assert response.status_code == 204
     thread.join()


### PR DESCRIPTION
Twice I've tried running the uvicorn tests only to have them freeze half-way through execution because I have a Uvicorn app running on my system that is already bound to port 8000 😅 

This PR updates the test suite to use a non-standard port so that the tests pass even if there's already an app running on port 8000.