### PR TITLE
Modernize test ASGI applications

### DIFF
--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -48,26 +48,23 @@ test_logging_config = {
 }
 
 
+async def app(scope, receive, send):
+    assert scope["type"] == "http"
+    await send({"type": "http.response.start", "status": 204, "headers": []})
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("win") or platform.python_implementation() == "PyPy",
     reason="Skipping test on Windows and PyPy",
 )
 def test_trace_logging(capsys):
-    class App:
-        def __init__(self, scope):
-            if scope["type"] != "http":
-                raise Exception()
-
-        async def __call__(self, receive, send):
-            await send({"type": "http.response.start", "status": 204, "headers": []})
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-
     class CustomServer(Server):
         def install_signal_handlers(self):
             pass
 
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         limit_max_requests=1,
         log_config=test_logging_config,
@@ -92,21 +89,12 @@ def test_trace_logging(capsys):
 )
 @pytest.mark.parametrize("http_protocol", [("h11"), ("httptools")])
 def test_access_logging(capsys, http_protocol):
-    class App:
-        def __init__(self, scope):
-            if scope["type"] != "http":
-                raise Exception()
-
-        async def __call__(self, receive, send):
-            await send({"type": "http.response.start", "status": 204, "headers": []})
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-
     class CustomServer(Server):
         def install_signal_handlers(self):
             pass
 
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         http=http_protocol,
         limit_max_requests=1,

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -6,14 +6,10 @@ import requests
 from uvicorn import Config, Server
 
 
-class App:
-    def __init__(self, scope):
-        if scope["type"] != "http":
-            raise Exception()
-
-    async def __call__(self, receive, send):
-        await send({"type": "http.response.start", "status": 200, "headers": []})
-        await send({"type": "http.response.body", "body": b"", "more_body": False})
+async def app(scope, receive, send):
+    assert scope["type"] == "http"
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
 class CustomServer(Server):
@@ -22,7 +18,7 @@ class CustomServer(Server):
 
 
 def test_default_default_headers():
-    config = Config(app=App, loop="asyncio", limit_max_requests=1)
+    config = Config(app=app, loop="asyncio", limit_max_requests=1)
     server = CustomServer(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
@@ -37,7 +33,7 @@ def test_default_default_headers():
 
 def test_override_server_header():
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden")],
@@ -56,7 +52,7 @@ def test_override_server_header():
 
 def test_override_server_header_multiple_times():
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden"), ("Server", "another-value")],
@@ -78,7 +74,7 @@ def test_override_server_header_multiple_times():
 
 def test_add_additional_header():
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("X-Additional", "new-value")],

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -25,25 +25,22 @@ def no_ssl_verification(session=requests.Session):
     session.request = old_request
 
 
+async def app(scope, receive, send):
+    assert scope["type"] == "http"
+    await send({"type": "http.response.start", "status": 204, "headers": []})
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Skipping SSL test on Windows"
 )
 def test_run(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
-    class App:
-        def __init__(self, scope):
-            if scope["type"] != "http":
-                raise Exception()
-
-        async def __call__(self, receive, send):
-            await send({"type": "http.response.start", "status": 204, "headers": []})
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-
     class CustomServer(Server):
         def install_signal_handlers(self):
             pass
 
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         limit_max_requests=1,
         ssl_keyfile=tls_ca_certificate_private_key_path,
@@ -64,21 +61,12 @@ def test_run(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
     sys.platform.startswith("win"), reason="Skipping SSL test on Windows"
 )
 def test_run_chain(tls_certificate_pem_path):
-    class App:
-        def __init__(self, scope):
-            if scope["type"] != "http":
-                raise Exception()
-
-        async def __call__(self, receive, send):
-            await send({"type": "http.response.start", "status": 204, "headers": []})
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-
     class CustomServer(Server):
         def install_signal_handlers(self):
             pass
 
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_pem_path,
@@ -100,21 +88,12 @@ def test_run_chain(tls_certificate_pem_path):
 def test_run_password(
     tls_ca_certificate_pem_path, tls_ca_certificate_private_key_encrypted_path
 ):
-    class App:
-        def __init__(self, scope):
-            if scope["type"] != "http":
-                raise Exception()
-
-        async def __call__(self, receive, send):
-            await send({"type": "http.response.start", "status": 204, "headers": []})
-            await send({"type": "http.response.body", "body": b"", "more_body": False})
-
     class CustomServer(Server):
         def install_signal_handlers(self):
             pass
 
     config = Config(
-        app=App,
+        app=app,
         loop="asyncio",
         limit_max_requests=1,
         ssl_keyfile=tls_ca_certificate_private_key_encrypted_path,


### PR DESCRIPTION
Small refactoring PR that cleans up a bunch of test code, replacing the older ASGI 2.0 style:

```python
class App:
    def __init__(self, scope):
        ...

    async def __call__(self, receive, send):
        ...
```

With an up-to-date ASGI 3.0 style:

```python
async def app(scope, receive, send):
    ...
```

Also reduce code duplication in tests that were just using a sample "empty response" app.