### PR TITLE
Remove scope from access log when using json logging formatter

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -460,7 +460,6 @@ class RequestResponseCycle:
                     get_path_with_query_string(self.scope),
                     self.scope["http_version"],
                     status_code,
-                    extra={"status_code": status_code, "scope": self.scope},
                 )
 
             # Write response status line and headers

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -462,7 +462,6 @@ class RequestResponseCycle:
                     get_path_with_query_string(self.scope),
                     self.scope["http_version"],
                     status_code,
-                    extra={"status_code": status_code, "scope": self.scope},
                 )
 
             # Write response status line and headers


### PR DESCRIPTION
Fixes https://github.com/encode/uvicorn/issues/858 as a 1st step that ensures no sensitive headers are leaked through scope in access logs in case people are using a json formatter

Will work on an implementation that let you access those headers / scope later when there is consensus / discussion about how it should be done.

Gunicorn let you print it with a [custom format](https://docs.gunicorn.org/en/stable/settings.html#access-log-format)