### PR TITLE
v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,9 @@
 
 ## 0.12.3 - 2020-11-21
 
-### Added
-Documentation: HTTPS settings add missing --ssl-keyfile-password (#839) 11/2/20 6468b70c
-
-### Changed
-Use latin1 when decoding X-Forwarded-* headers (#701) 11/12/20 45e6e831
-Isolate server code into an asyncio-specific module (#842) 11/8/20 634aec95
-
 ### Fixed
 Fix race condition that leads Quart to hang with uvicorn (#848) 11/18/20 de213614
+Use latin1 when decoding X-Forwarded-* headers (#701) 11/12/20 45e6e831
 Rework IPv6 support (#837) 11/8/20 bdab488e
 Cancel old keepalive-trigger before setting new one. (#832) 10/26/20 d5dcf80c
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.12.3 - 2020-11-21
+
+### Added
+Documentation: HTTPS settings add missing --ssl-keyfile-password (#839) 11/2/20 6468b70c
+
+### Changed
+Use latin1 when decoding X-Forwarded-* headers (#701) 11/12/20 45e6e831
+Isolate server code into an asyncio-specific module (#842) 11/8/20 634aec95
+
+### Fixed
+Fix race condition that leads Quart to hang with uvicorn (#848) 11/18/20 de213614
+Rework IPv6 support (#837) 11/8/20 bdab488e
+Cancel old keepalive-trigger before setting new one. (#832) 10/26/20 d5dcf80c
+
 ## 0.12.2 - 2020-10-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## 0.12.3 - 2020-11-21
 
 ### Fixed
-Fix race condition that leads Quart to hang with uvicorn (#848) 11/18/20 de213614
-Use latin1 when decoding X-Forwarded-* headers (#701) 11/12/20 45e6e831
-Rework IPv6 support (#837) 11/8/20 bdab488e
-Cancel old keepalive-trigger before setting new one. (#832) 10/26/20 d5dcf80c
+- Fix race condition that leads Quart to hang with uvicorn (#848) 11/18/20 de213614
+- Use latin1 when decoding X-Forwarded-* headers (#701) 11/12/20 45e6e831
+- Rework IPv6 support (#837) 11/8/20 bdab488e
+- Cancel old keepalive-trigger before setting new one. (#832) 10/26/20 d5dcf80c
 
 ## 0.12.2 - 2020-10-19
 

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
See below the PRs that didn't make entries in the change, most are tooling stuff for test, the exception being  #827 as suggested by @florimondmanca because the fix is in #837 for ipv6.

Just not sure if `Isolate server code into an asyncio-specific module (#842) 11/8/20 634aec95` is considered tooling or not

~~Modernize test ASGI applications (#854) 11/18/20, 10:07 PM 79a72e3d~~
Fix race condition that leads Quart to hang with uvicorn (#848) 11/18/20, 8:56 PM de213614
Use latin1 when decoding X-Forwarded-* headers (#701) 11/12/20, 9:59 AM 45e6e831
~~Fix protocol not imported directly (#838) 11/9/20, 7:29 PM 45322cc4~~
~~Isolate server code into an asyncio-specific module (#842) 11/8/20, 9:24 PM 634aec95~~
Rework IPv6 support (#837) 11/8/20, 11:20 AM bdab488e
~~Documentation: HTTPS settings add missing --ssl-keyfile-password (#839) 11/2/20, 12:40 PM 6468b70c~~
Cancel old keepalive-trigger before setting new one. (#832) 10/26/20, 7:44 PM d5dcf80c
~~Add reload test base class (#833) 10/26/20, 12:56 PM ef806259~~
~~Fix server not running with explicit hostname (#827) 10/22/20, 9:25 AM d78394e3~~
~~[Docs] Fix mkdocs warning + Added Permalinks (#826) 10/21/20, 12:35 PM d5614f62~~

Fixes https://github.com/encode/uvicorn/issues/861