### PR TITLE
Move server implementation to server.py

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -7,7 +7,6 @@ import typing
 import click
 
 import uvicorn
-from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.config import (
     HTTP_PROTOCOLS,
     INTERFACES,
@@ -19,6 +18,7 @@ from uvicorn.config import (
     WS_PROTOCOLS,
     Config,
 )
+from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
 LEVEL_CHOICES = click.Choice(LOG_LEVELS.keys())

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -7,7 +7,7 @@ import typing
 import click
 
 import uvicorn
-from uvicorn._impl.asyncio import AsyncioServer, AsyncioServerState
+from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.config import (
     HTTP_PROTOCOLS,
     INTERFACES,
@@ -29,10 +29,6 @@ LOOP_CHOICES = click.Choice([key for key in LOOP_SETUPS.keys() if key != "none"]
 INTERFACE_CHOICES = click.Choice(INTERFACES)
 
 logger = logging.getLogger("uvicorn.error")
-
-# Aliases for backwards compatibility. These used to be defined here.
-Server = AsyncioServer
-ServerState = AsyncioServerState
 
 
 def print_version(ctx, param, value):

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -19,7 +19,7 @@ HANDLED_SIGNALS = (
 logger = logging.getLogger("uvicorn.error")
 
 
-class AsyncioServerState:
+class ServerState:
     """
     Shared servers state that is available between all protocol instances.
     """
@@ -31,10 +31,10 @@ class AsyncioServerState:
         self.default_headers = []
 
 
-class AsyncioServer:
+class Server:
     def __init__(self, config):
         self.config = config
-        self.server_state = AsyncioServerState()
+        self.server_state = ServerState()
 
         self.started = False
         self.should_exit = False


### PR DESCRIPTION
Follow-up to #842 

#842 moved the `Server` code to an `_impl/asyncio.py` module anticipating support for multiple async environments, but this was obviously premature. I've now learnt through #863 that this just won't be as easy as "one server implementation per async library" (well it could be, but that would be at a huge code duplication cost).

This PR reverts back to a more stable and simple state: a `server.py` module. The sole purpose is that we have this isolated in a module, and not cluggering up the `main.py` module — `main.py` should be focused on the CLI.