### PR TITLE
Skip installation of signal handlers when not in main thread

### DIFF
--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -59,10 +59,6 @@ async def app(scope, receive, send):
     reason="Skipping test on Windows and PyPy",
 )
 def test_trace_logging(capsys):
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(
         app=app,
         loop="asyncio",
@@ -70,7 +66,7 @@ def test_trace_logging(capsys):
         log_config=test_logging_config,
         log_level="trace",
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -89,10 +85,6 @@ def test_trace_logging(capsys):
 )
 @pytest.mark.parametrize("http_protocol", [("h11"), ("httptools")])
 def test_access_logging(capsys, http_protocol):
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(
         app=app,
         loop="asyncio",
@@ -100,7 +92,7 @@ def test_access_logging(capsys, http_protocol):
         limit_max_requests=1,
         log_config=test_logging_config,
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -12,14 +12,9 @@ async def app(scope, receive, send):
     await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
-class CustomServer(Server):
-    def install_signal_handlers(self):
-        pass
-
-
 def test_default_default_headers():
     config = Config(app=app, loop="asyncio", limit_max_requests=1)
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -38,7 +33,7 @@ def test_override_server_header():
         limit_max_requests=1,
         headers=[("Server", "over-ridden")],
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -57,7 +52,7 @@ def test_override_server_header_multiple_times():
         limit_max_requests=1,
         headers=[("Server", "over-ridden"), ("Server", "another-value")],
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -79,7 +74,7 @@ def test_add_additional_header():
         limit_max_requests=1,
         headers=[("X-Additional", "new-value")],
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,12 +24,8 @@ async def app(scope, receive, send):
     ],
 )
 def test_run(host, url):
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(app=app, host=host, loop="asyncio", limit_max_requests=1)
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -40,12 +36,8 @@ def test_run(host, url):
 
 
 def test_run_multiprocess():
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(app=app, loop="asyncio", workers=2, limit_max_requests=1)
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -56,12 +48,8 @@ def test_run_multiprocess():
 
 
 def test_run_reload():
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(app=app, loop="asyncio", reload=True, limit_max_requests=1)
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -77,12 +65,8 @@ def test_run_with_shutdown():
         while True:
             time.sleep(1)
 
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(app=app, loop="asyncio", workers=2, limit_max_requests=1)
-    server = CustomServer(config=config)
+    server = Server(config=config)
     sock = config.bind_socket()
     exc = True
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -35,10 +35,6 @@ async def app(scope, receive, send):
     sys.platform.startswith("win"), reason="Skipping SSL test on Windows"
 )
 def test_run(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(
         app=app,
         loop="asyncio",
@@ -46,7 +42,7 @@ def test_run(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
         ssl_keyfile=tls_ca_certificate_private_key_path,
         ssl_certfile=tls_ca_certificate_pem_path,
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -61,17 +57,13 @@ def test_run(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
     sys.platform.startswith("win"), reason="Skipping SSL test on Windows"
 )
 def test_run_chain(tls_certificate_pem_path):
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_pem_path,
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:
@@ -88,10 +80,6 @@ def test_run_chain(tls_certificate_pem_path):
 def test_run_password(
     tls_ca_certificate_pem_path, tls_ca_certificate_private_key_encrypted_path
 ):
-    class CustomServer(Server):
-        def install_signal_handlers(self):
-            pass
-
     config = Config(
         app=app,
         loop="asyncio",
@@ -100,7 +88,7 @@ def test_run_password(
         ssl_certfile=tls_ca_certificate_pem_path,
         ssl_keyfile_password="uvicorn password for the win",
     )
-    server = CustomServer(config=config)
+    server = Server(config=config)
     thread = threading.Thread(target=server.run)
     thread.start()
     while not server.started:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -240,7 +240,7 @@ class Server:
             await self.lifespan.shutdown()
 
     def install_signal_handlers(self) -> None:
-        if threading.current_thread() is threading.main_thread():
+        if threading.current_thread() is not threading.main_thread():
             # Signals can only be listened to from the main thread.
             return
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -6,6 +6,7 @@ import platform
 import signal
 import socket
 import sys
+import threading
 import time
 from email.utils import formatdate
 
@@ -238,7 +239,11 @@ class Server:
         if not self.force_exit:
             await self.lifespan.shutdown()
 
-    def install_signal_handlers(self):
+    def install_signal_handlers(self) -> None:
+        if threading.current_thread() is threading.main_thread():
+            # Signals can only be listened to from the main thread.
+            return
+
         loop = asyncio.get_event_loop()
 
         try:


### PR DESCRIPTION
This one has been bogging me for a while, so here's a tentative pull request for it:

Since signals can only be listened to from the main thread, this PR modifies `.install_signal_handlers()` to skip installation of signal handlers when not in the main thread:

https://docs.python.org/3/library/signal.html#signals-and-threads

> […] **Only the main thread of the main interpreter is allowed to set a new signal handler**.

This way, we can also get rid of a bunch of boilerplate overrides of `.install_signal_handlers()` in tests — and many other people will be able to as well (eg we do it in HTTPX, HTTPCore, many of my personal packages, and essentially anywhere one needs to run Uvicorn in a Python thread right now).

Surprisingly enough I haven't found an issue open for this yet. :-) But this is somewhat related to #526 (although I don't think it's _exactly_ fixing it).