### PR TITLE
Add --factory flag to support factory-style application imports

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -158,7 +158,7 @@ Options:
                                   [default: TLSv1]
   --header TEXT                   Specify custom default HTTP response headers
                                   as a Name:Value pair
-  --factory                       Teat APP as an application factory, i.e. a
+  --factory                       Treat APP as an application factory, i.e. a
                                   () -> <ASGI app> function.  [default: False]
   --help                          Show this message and exit.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -204,18 +204,18 @@ For more information, see the [deployment documentation](deployment.md).
 
 ### Application factories
 
-If your project is structured so that it exposes a "factory function", then you can have Uvicorn run an application from that factory by passing the `--factory` flag.
+The `--factory` flag allows loading the application from a factory function, rather than an application instance directly. The factory will be called with no arguments and should return an ASGI application.
+
+**example.py**:
 
 ```python
-# app.py
-
-def create_app() -> Callable:
+def create_app():
     app = ...
     return app
 ```
 
 ```shell
-$ uvicorn --factory app:create_app
+$ uvicorn --factory example:create_app
 ```
 
 ## The ASGI interface

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,6 +158,8 @@ Options:
                                   [default: TLSv1]
   --header TEXT                   Specify custom default HTTP response headers
                                   as a Name:Value pair
+  --factory                       Teat APP as an application factory, i.e. a
+                                  () -> <ASGI app> function.  [default: False]
   --help                          Show this message and exit.
 ```
 
@@ -199,6 +201,22 @@ gunicorn example:app -w 4 -k uvicorn.workers.UvicornWorker
 For a [PyPy][pypy] compatible configuration use `uvicorn.workers.UvicornH11Worker`.
 
 For more information, see the [deployment documentation](deployment.md).
+
+### Application factories
+
+If your project is structured so that it exposes a "factory function", then you can have Uvicorn run an application from that factory by passing the `--factory` flag.
+
+```python
+# app.py
+
+def create_app() -> Callable:
+    app = ...
+    return app
+```
+
+```shell
+$ uvicorn --factory app:create_app
+```
 
 ## The ASGI interface
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -8,6 +8,7 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 ## Application
 
 * `APP` - The ASGI application to run, in the format `"<module>:<attribute>"`.
+* `--factory` - Treat `APP` as an application factory, i.e. a `() -> <ASGI app>` callable.
 
 ## Socket Binding
 

--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -23,6 +23,10 @@ except ImportError:  # pragma: no cover
     websockets = None
 
 
+async def app(scope, receive, send):
+    pass  # pragma: no cover
+
+
 # TODO: Add pypy to our testing matrix, and assert we get the correct classes
 #       dependent on the platform we're running the tests under.
 
@@ -36,7 +40,7 @@ def test_loop_auto():
 
 
 def test_http_auto():
-    config = Config(app=None)
+    config = Config(app=app)
     server_state = ServerState()
     protocol = AutoHTTPProtocol(config=config, server_state=server_state)
     expected_http = "H11Protocol" if httptools is None else "HttpToolsProtocol"
@@ -44,7 +48,7 @@ def test_http_auto():
 
 
 def test_websocket_auto():
-    config = Config(app=None)
+    config = Config(app=app)
     server_state = ServerState()
     protocol = AutoWebSocketsProtocol(config=config, server_state=server_state)
     expected_websockets = "WSProtocol" if websockets is None else "WebSocketProtocol"

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -318,7 +318,8 @@ class Config:
                 sys.exit(1)
         elif not inspect.signature(self.loaded_app).parameters:
             logger.error(
-                "APP seems to be an application factory. Pass the --factory flag."
+                "APP seems to be an application factory. "
+                "Run uvicorn with the --factory flag."
             )
             sys.exit(1)
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -273,6 +273,13 @@ def print_version(ctx, param, value):
     help="Look for APP in the specified directory, by adding this to the PYTHONPATH."
     " Defaults to the current working directory.",
 )
+@click.option(
+    "--factory",
+    is_flag=True,
+    default=False,
+    help="Treat APP as an application factory, i.e. a () -> <ASGI app> callable.",
+    show_default=True,
+)
 def main(
     app,
     host: str,
@@ -310,6 +317,7 @@ def main(
     headers: typing.List[str],
     use_colors: bool,
     app_dir: str,
+    factory: bool,
 ):
     sys.path.insert(0, app_dir)
 
@@ -349,6 +357,7 @@ def main(
         "ssl_ciphers": ssl_ciphers,
         "headers": list([header.split(":", 1) for header in headers]),
         "use_colors": use_colors,
+        "factory": factory,
     }
     run(**kwargs)
 


### PR DESCRIPTION
Closes #492

This PR adds support for projects that don't expose an `app` instance directly, but rather an application factory.

As per discussions in #822, this style is most typically preferred by some users to avoid side-effects at import time, which may be important for larger-size projects, and — but that's more of a taste preference — global state.

Alternative implementation to #822 that also handles edge cases, and updates the `Settings` documentation.