### PR TITLE
Version 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change Log
 
-## 0.13.1 - 2020-12-10
+## 0.13.1 - 2020-12-12
 
 ### Fixed
 
-- Prevent exceptions when the ASGI application rejects a connection during the WebSocket handshake, when running on both `--ws wsproto` or `--ws websockets`. (Pull #704)
-- Ensure connection `scope` doesn't leak in logs when using JSON log formatters. (Pull #859)
+- Prevent exceptions when the ASGI application rejects a connection during the WebSocket handshake, when running on both `--ws wsproto` or `--ws websockets`. (Pull #704 and #881)
+- Ensure connection `scope` doesn't leak in logs when using JSON log formatters. (Pull #859 and #884)
 
 ## 0.13.0 - 2020-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Prevent exceptions when the ASGI application rejects a connection during the WebSocket handshake, when running on both `--ws wsproto` or `--ws websockets`. (Pull #704)
+- Ensure connection `scope` doesn't leak in logs when using JSON log formatters. (Pull #859)
 
 ## 0.13.0 - 2020-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.13.1 - 2020-12-10
+
+### Fixed
+
+- Prevent exceptions when the ASGI application rejects a connection during the WebSocket handshake, when running on both `--ws wsproto` or `--ws websockets`. (Pull #704)
+
 ## 0.13.0 - 2020-12-08
 
 ### Added

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## 0.13.1 - 2020-12-12

### Fixed

- Prevent exceptions when the ASGI application rejects a connection during the WebSocket handshake, when running on both `--ws wsproto` or `--ws websockets`. (Pull #704 and #881)
- Ensure connection `scope` doesn't leak in logs when using JSON log formatters. (Pull #859 and #884)