### PR TITLE
Ensure that ws connection is open before receiving data 

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -237,6 +237,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
 
         await self.handshake_completed_event.wait()
         try:
+            await self.ensure_open()
             data = await self.recv()
         except websockets.ConnectionClosed as exc:
             return {"type": "websocket.disconnect", "code": exc.code}

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -216,7 +216,6 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
 
             elif message_type == "websocket.close":
                 code = message.get("code", 1000)
-                self.close_code = code  # for WebSocketServerProtocol
                 await self.close(code)
                 self.closed_event.set()
 
@@ -237,14 +236,6 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             return {"type": "websocket.connect"}
 
         await self.handshake_completed_event.wait()
-
-        if self.closed_event.is_set():
-            # If the client disconnected: WebSocketServerProtocol set self.close_code.
-            # If the handshake failed or the app closed before handshake completion,
-            # use 1006 Abnormal Closure.
-            code = getattr(self, "close_code", 1006)
-            return {"type": "websocket.disconnect", "code": code}
-
         try:
             data = await self.recv()
         except websockets.ConnectionClosed as exc:


### PR DESCRIPTION
I think that this is a cleaner way to fix #244 in the websocket protocol implementation
See https://github.com/aaugustin/websockets/pull/670#issuecomment-530368604

This PR reverts only the websocket part of #704 (the wsproto is left intact)