### PR TITLE
Fix Bad file descriptor error when using reload or workers flag and multiprocessing

### DIFF
--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -44,7 +44,7 @@ def subprocess_started(config, target, sockets):
     # Re-open stdin.
     # This is required for some debugging environments.
     try:
-        sys.stdin = open('/dev/stdin')
+        sys.stdin=open("/dev/stdin")
     except:
         print("WARNING: Failed to open '/dev/stdin', debugging might not work.")
 

--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -3,7 +3,6 @@ Some light wrappers around Python's multiprocessing, to deal with cleanly
 starting child processes.
 """
 import multiprocessing
-import os
 import sys
 
 multiprocessing.allow_connection_pickling()
@@ -45,7 +44,7 @@ def subprocess_started(config, target, sockets):
     # This is required for some debugging environments.
     try:
         sys.stdin = open("/dev/stdin")
-    except:
+    except OSError:
         print("WARNING: Failed to open '/dev/stdin', debugging might not work.")
 
     # Logging needs to be setup again for each child.

--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -3,6 +3,7 @@ Some light wrappers around Python's multiprocessing, to deal with cleanly
 starting child processes.
 """
 import multiprocessing
+import os
 import sys
 
 multiprocessing.allow_connection_pickling()
@@ -43,9 +44,9 @@ def subprocess_started(config, target, sockets):
     # Re-open stdin.
     # This is required for some debugging environments.
     try:
-        sys.stdin = open("/dev/stdin")
+        sys.stdin = os.fdopen(0)
     except OSError:
-        print("WARNING: Failed to open '/dev/stdin', debugging might not work.")
+        print("WARNING: Failed to open stdin, debugging might not work.")
 
     # Logging needs to be setup again for each child.
     config.configure_logging()

--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -9,50 +9,40 @@ import sys
 multiprocessing.allow_connection_pickling()
 spawn = multiprocessing.get_context("spawn")
 
-
 def get_subprocess(config, target, sockets):
     """
     Called in the parent process, to instantiate a new child process instance.
     The child is not yet started at this point.
-
     * config - The Uvicorn configuration instance.
     * target - A callable that accepts a list of sockets. In practice this will
                be the `Server.run()` method.
     * sockets - A list of sockets to pass to the server. Sockets are bound once
                 by the parent process, and then passed to the child processes.
     """
-    # We pass across the stdin fileno, and reopen it in the child process.
-    # This is required for some debugging environments.
-    try:
-        stdin_fileno = sys.stdin.fileno()
-    except OSError:
-        stdin_fileno = None
 
     kwargs = {
         "config": config,
         "target": target,
         "sockets": sockets,
-        "stdin_fileno": stdin_fileno,
     }
 
     return spawn.Process(target=subprocess_started, kwargs=kwargs)
 
-
-def subprocess_started(config, target, sockets, stdin_fileno):
+def subprocess_started(config, target, sockets):
     """
     Called when the child process starts.
-
     * config - The Uvicorn configuration instance.
     * target - A callable that accepts a list of sockets. In practice this will
                be the `Server.run()` method.
     * sockets - A list of sockets to pass to the server. Sockets are bound once
                 by the parent process, and then passed to the child processes.
-    * stdin_fileno - The file number of sys.stdin, so that it can be reattached
-                     to the child process.
     """
     # Re-open stdin.
-    if stdin_fileno is not None:
-        sys.stdin = os.fdopen(stdin_fileno)
+    # This is required for some debugging environments.
+    try:
+        sys.stdin = open('/dev/stdin')
+    except:
+        print("WARNING: Failed to open '/dev/stdin', debugging might not work.")
 
     # Logging needs to be setup again for each child.
     config.configure_logging()

--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -9,10 +9,12 @@ import sys
 multiprocessing.allow_connection_pickling()
 spawn = multiprocessing.get_context("spawn")
 
+
 def get_subprocess(config, target, sockets):
     """
     Called in the parent process, to instantiate a new child process instance.
     The child is not yet started at this point.
+
     * config - The Uvicorn configuration instance.
     * target - A callable that accepts a list of sockets. In practice this will
                be the `Server.run()` method.
@@ -28,9 +30,11 @@ def get_subprocess(config, target, sockets):
 
     return spawn.Process(target=subprocess_started, kwargs=kwargs)
 
+
 def subprocess_started(config, target, sockets):
     """
     Called when the child process starts.
+
     * config - The Uvicorn configuration instance.
     * target - A callable that accepts a list of sockets. In practice this will
                be the `Server.run()` method.

--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -44,7 +44,7 @@ def subprocess_started(config, target, sockets):
     # Re-open stdin.
     # This is required for some debugging environments.
     try:
-        sys.stdin=open("/dev/stdin")
+        sys.stdin = open("/dev/stdin")
     except:
         print("WARNING: Failed to open '/dev/stdin', debugging might not work.")
 


### PR DESCRIPTION
Fix for #877. 

Note: Reopening `sys.stdin` in the child process might not even be necessary, but at any rate it works if we use `open('/dev/stdin')`. A warning is produced if for some reason `/dev/stdin` cannot be opened.