### PR TITLE
Test default logging

### DIFF
--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -84,7 +84,8 @@ def test_trace_logging(capsys, log_config, expected_204, expected_logger):
     assert response.status_code == 204
     thread.join()
     captured = capsys.readouterr()
-    assert '"GET / HTTP/1.1" 204' in captured.out
+    assert expected_204 in captured.out
+    assert expected_logger in captured.out
     assert "[TEST_ACCESS] TRACE" not in captured.out
 
 

--- a/tests/middleware/test_trace_logging.py
+++ b/tests/middleware/test_trace_logging.py
@@ -63,7 +63,7 @@ async def app(scope, receive, send):
     "log_config, expected_204, expected_logger",
     [
         (trace_logging_config, '"GET / HTTP/1.1" 204', "uvicorn.access"),
-        (LOGGING_CONFIG,'"GET / HTTP/1.1" 204 No Content', "INFO:" ),
+        (LOGGING_CONFIG, '"GET / HTTP/1.1" 204 No Content', "INFO:"),
     ],
     ids=["trace_log_config", "default_log_config"],
 )
@@ -98,7 +98,7 @@ def test_trace_logging(capsys, log_config, expected_204, expected_logger):
     "log_config, expected_204, expected_logger",
     [
         (trace_logging_config, '"GET / HTTP/1.1" 204', "uvicorn.access"),
-        (LOGGING_CONFIG,'"GET / HTTP/1.1" 204 No Content', "INFO:" ),
+        (LOGGING_CONFIG, '"GET / HTTP/1.1" 204 No Content', "INFO:"),
     ],
     ids=["trace_log_config", "default_log_config"],
 )


### PR DESCRIPTION
While #859 bug went unoticed this test would have revealed it, nowhere we seem to test what the output of our default logging should be,
this is a small addition to do it