### PR TITLE
Log exception traceback in case of invalid HTTP request when using httptools

### DIFF
--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -163,9 +163,9 @@ class HttpToolsProtocol(asyncio.Protocol):
 
         try:
             self.parser.feed_data(data)
-        except httptools.HttpParserError:
+        except httptools.HttpParserError as exc:
             msg = "Invalid HTTP request received."
-            self.logger.warning(msg)
+            self.logger.warning(msg, exc_info=exc)
             self.transport.close()
         except httptools.HttpParserUpgrade:
             self.handle_upgrade()


### PR DESCRIPTION
Refs #344 

To help with moving #344 forward, let's have Uvicorn log the full exception traceback in case an invalid HTTP request is detected by HttpTools.

Here's what we can now expect:

App:

```python
async def app(scope, receive, send):
    await send(
        {
            "type": "http.response.start",
            "status": 200,
            "headers": [(b"content-type", b"text/plain")]
        }
    )
    await send({"type": "http.response.body", "body": b"Hello, world!"})
```

Server:

```
uvicorn app:app
```

Nasty client:

```python
import socket

sock = socket.create_connection(("localhost", 8000))

# Send a broken HTTP request
sock.send(b"did you expect an HTTP method?")
```

Before:

```console
WARNING:  Invalid HTTP request received.
```

After:

```console
WARNING:  Invalid HTTP request received.
Traceback (most recent call last):
  File "/Users/florimond/Developer/python-projects/uvicorn/uvicorn/protocols/http/httptools_impl.py", line 165, in data_received
    self.parser.feed_data(data)
  File "httptools/parser/parser.pyx", line 193, in httptools.parser.parser.HttpParser.feed_data
httptools.parser.errors.HttpParserInvalidMethodError: invalid HTTP method
```