### PR TITLE
Log exception traceback in case of invalid HTTP request when using h11

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -168,9 +168,9 @@ class H11Protocol(asyncio.Protocol):
         while True:
             try:
                 event = self.conn.next_event()
-            except h11.RemoteProtocolError:
+            except h11.RemoteProtocolError as exc:
                 msg = "Invalid HTTP request received."
-                self.logger.warning(msg)
+                self.logger.warning(msg, exc_info=exc)
                 self.transport.close()
                 return
             event_type = type(event)


### PR DESCRIPTION
Follow-up to #886, adding the same behavior for `h11`. Figured this could also be helpful someday!