### PR TITLE
Release 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.13.2 - 2020-12-12
+
+### Fixed
+
+- Log full exception traceback in case of invalid HTTP request. (Pull #886 and #888)
+
 ## 0.13.1 - 2020-12-12
 
 ### Fixed


### PR DESCRIPTION
Preparing a new release with the "invalid HTTP request" exception tracebacks, so we can move forward on #344. I think we're okay having those stable in Uvicorn — no need for a temporary beta release, right?

Prerequisites:

* [x] Merge #888

## 0.13.2 - 2020-12-12

### Fixed

- Log full exception traceback in case of invalid HTTP request. (Pull #886 and #888)
