### PR TITLE
adds BlackSheep to the list of ASGI web frameworks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -481,6 +481,12 @@ with application code still running in a standard threaded context.
 
 You write your API function parameters with Python 3.6+ type declarations and get automatic data conversion, data validation, OpenAPI schemas (with JSON Schemas) and interactive API documentation UIs.
 
+### BlackSheep
+
+[BlackSheep](https://www.neoteroi.dev/blacksheep/) is a web framework based on ASGI, inspired by Flask and ASP.NET Core.
+
+Its most distinctive features are built-in support for dependency injection, automatic binding of parameters by request handler's type annotations, and automatic generation of OpenAPI documentation and Swagger UI.
+
 
 [uvloop]: https://github.com/MagicStack/uvloop
 [httptools]: https://github.com/MagicStack/httptools


### PR DESCRIPTION
Hi,
Please consider this PR to add [BlackSheep](https://github.com/RobertoPrevato/BlackSheep) to the list of ASGI web frameworks. This framework is based on ASGI since a long time, and now it is well documented in a [dedicated site](https://www.neoteroi.dev/blacksheep/).

Its code base is good quality as you can verify in GitHub:
* it is 100% code covered, including integration tests that run the framework on top of `uvicorn`
* CI/CD pipelines validate that the framework works on Python 3.7, 3.8, 3.9, Ubuntu and Windows