### PR TITLE
Up wsproto to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .[standard]
 
 # Explicit optionals
-wsproto==0.15.*
+wsproto==1.0.*
 
 # Packaging
 twine

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from asyncio import StreamReader
 
 import pytest
 
@@ -91,6 +92,7 @@ class MockTransport:
         self.closed = False
         self.buffer = b""
         self.read_paused = False
+        self.reader = StreamReader()
 
     def get_extra_info(self, key):
         return {
@@ -120,6 +122,9 @@ class MockTransport:
         self.buffer = b""
 
     def set_protocol(self, protocol):
+        pass
+    
+    def set_write_buffer_limits(self, limit):
         pass
 
 
@@ -677,13 +682,11 @@ def test_unsupported_upgrade_request_no_protocol_set(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-@pytest.mark.parametrize("ws_protocol", [("wsproto"), ("websockets")])
-def test_supported_upgrade_request_but_wrong_ws_version(protocol_cls, ws_protocol):
+def test_supported_upgrade_request_but_wrong_ws_version(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
-    protocol = get_connected_protocol(app, protocol_cls, ws=ws_protocol)
+    protocol = get_connected_protocol(app, protocol_cls, ws="wsproto")
     protocol.data_received(UPGRADE_REQUEST_WRONG_WS_VERSION)
-
 
     assert b"HTTP/1.1 426 \r\nSec-WebSocket-Version: 13" in protocol.transport.buffer
 

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -61,12 +61,13 @@ GET_REQUEST_WITH_RAW_PATH = b"\r\n".join(
     [b"GET /one%2Ftwo HTTP/1.1", b"Host: example.org", b"", b""]
 )
 
-UPGRADE_REQUEST = b"\r\n".join(
+UPGRADE_REQUEST_WRONG_WS_VERSION = b"\r\n".join(
     [
         b"GET / HTTP/1.1",
         b"Host: example.org",
         b"Connection: upgrade",
         b"Upgrade: websocket",
+        b"Sec-WebSocket-Version: 11",
         b"",
         b"",
     ]
@@ -665,24 +666,26 @@ def test_100_continue_not_sent_when_body_not_consumed(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_unsupported_upgrade_request(protocol_cls):
+def test_unsupported_upgrade_request_no_protocol_set(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, protocol_cls, ws="none")
-    protocol.data_received(UPGRADE_REQUEST)
+    protocol.data_received(UPGRADE_REQUEST_WRONG_WS_VERSION)
 
     assert b"HTTP/1.1 400 Bad Request" in protocol.transport.buffer
     assert b"Unsupported upgrade request." in protocol.transport.buffer
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_supported_upgrade_request(protocol_cls):
+@pytest.mark.parametrize("ws_protocol", [("wsproto"), ("websockets")])
+def test_supported_upgrade_request_but_wrong_ws_version(protocol_cls, ws_protocol):
     app = Response("Hello, world", media_type="text/plain")
 
-    protocol = get_connected_protocol(app, protocol_cls, ws="wsproto")
-    protocol.data_received(UPGRADE_REQUEST)
+    protocol = get_connected_protocol(app, protocol_cls, ws=ws_protocol)
+    protocol.data_received(UPGRADE_REQUEST_WRONG_WS_VERSION)
 
-    assert b"HTTP/1.1 426 " in protocol.transport.buffer
+
+    assert b"HTTP/1.1 426 \r\nSec-WebSocket-Version: 13" in protocol.transport.buffer
 
 
 async def asgi3app(scope, receive, send):

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -665,7 +665,7 @@ def test_100_continue_not_sent_when_body_not_consumed(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_unsupported_upgrade(protocol_cls):
+def test_unsupported_upgrade_request(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, protocol_cls, ws="none")
@@ -676,7 +676,7 @@ def test_unsupported_upgrade(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_supported_upgrade(protocol_cls):
+def test_supported_upgrade_request(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, protocol_cls, ws="wsproto")

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -665,7 +665,7 @@ def test_100_continue_not_sent_when_body_not_consumed(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_unsupported_upgrade_request(protocol_cls):
+def test_unsupported_upgrade(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, protocol_cls, ws="none")
@@ -682,7 +682,7 @@ def test_supported_upgrade(protocol_cls):
     protocol = get_connected_protocol(app, protocol_cls, ws="wsproto")
     protocol.data_received(UPGRADE_REQUEST)
 
-    assert b"HTTP/1.1 426 \r\nSec-WebSocket-Version: 13" in protocol.transport.buffer
+    assert b"HTTP/1.1 426 " in protocol.transport.buffer
 
 
 async def asgi3app(scope, receive, send):

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from asyncio import StreamReader
 
 import pytest
 
@@ -92,7 +91,6 @@ class MockTransport:
         self.closed = False
         self.buffer = b""
         self.read_paused = False
-        self.reader = StreamReader()
 
     def get_extra_info(self, key):
         return {
@@ -122,9 +120,6 @@ class MockTransport:
         self.buffer = b""
 
     def set_protocol(self, protocol):
-        pass
-    
-    def set_write_buffer_limits(self, limit):
         pass
 
 

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -61,13 +61,12 @@ GET_REQUEST_WITH_RAW_PATH = b"\r\n".join(
     [b"GET /one%2Ftwo HTTP/1.1", b"Host: example.org", b"", b""]
 )
 
-UPGRADE_REQUEST_WRONG_WS_VERSION = b"\r\n".join(
+UPGRADE_REQUEST = b"\r\n".join(
     [
         b"GET / HTTP/1.1",
         b"Host: example.org",
         b"Connection: upgrade",
         b"Upgrade: websocket",
-        b"Sec-WebSocket-Version: 11",
         b"",
         b"",
     ]
@@ -666,22 +665,22 @@ def test_100_continue_not_sent_when_body_not_consumed(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_unsupported_upgrade_request_no_protocol_set(protocol_cls):
+def test_unsupported_upgrade_request(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, protocol_cls, ws="none")
-    protocol.data_received(UPGRADE_REQUEST_WRONG_WS_VERSION)
+    protocol.data_received(UPGRADE_REQUEST)
 
     assert b"HTTP/1.1 400 Bad Request" in protocol.transport.buffer
     assert b"Unsupported upgrade request." in protocol.transport.buffer
 
 
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_supported_upgrade_request_but_wrong_ws_version(protocol_cls):
+def test_supported_upgrade(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, protocol_cls, ws="wsproto")
-    protocol.data_received(UPGRADE_REQUEST_WRONG_WS_VERSION)
+    protocol.data_received(UPGRADE_REQUEST)
 
     assert b"HTTP/1.1 426 \r\nSec-WebSocket-Version: 13" in protocol.transport.buffer
 

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -666,11 +666,11 @@ def test_100_continue_not_sent_when_body_not_consumed(protocol_cls):
     assert b"HTTP/1.1 204 No Content" in protocol.transport.buffer
 
 
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-def test_unsupported_upgrade_request(http_protocol_cls):
+@pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
+def test_unsupported_upgrade_request(protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
-    protocol = get_connected_protocol(app, http_protocol_cls, ws="none")
+    protocol = get_connected_protocol(app, protocol_cls, ws="none")
     protocol.data_received(UPGRADE_REQUEST)
 
     assert b"HTTP/1.1 400 Bad Request" in protocol.transport.buffer

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -3,7 +3,6 @@ import logging
 
 import pytest
 
-from tests.protocols.test_websocket import WS_PROTOCOLS
 from tests.response import Response
 from uvicorn.config import Config
 from uvicorn.main import ServerState

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -3,6 +3,7 @@ import logging
 
 import pytest
 
+from tests.protocols.test_websocket import WS_PROTOCOLS
 from tests.response import Response
 from uvicorn.config import Config
 from uvicorn.main import ServerState
@@ -67,6 +68,7 @@ UPGRADE_REQUEST = b"\r\n".join(
         b"Host: example.org",
         b"Connection: upgrade",
         b"Upgrade: websocket",
+        b"Sec-WebSocket-Version: 11",
         b"",
         b"",
     ]
@@ -664,11 +666,11 @@ def test_100_continue_not_sent_when_body_not_consumed(protocol_cls):
     assert b"HTTP/1.1 204 No Content" in protocol.transport.buffer
 
 
-@pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
-def test_unsupported_upgrade_request(protocol_cls):
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+def test_unsupported_upgrade_request(http_protocol_cls):
     app = Response("Hello, world", media_type="text/plain")
 
-    protocol = get_connected_protocol(app, protocol_cls, ws="none")
+    protocol = get_connected_protocol(app, http_protocol_cls, ws="none")
     protocol.data_received(UPGRADE_REQUEST)
 
     assert b"HTTP/1.1 400 Bad Request" in protocol.transport.buffer

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -51,12 +51,12 @@ async def test_invalid_upgrade(protocol_cls):
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 "http://127.0.0.1:8000",
-            headers={
-                "upgrade": "websocket",
-                "connection": "upgrade",
-                "sec-websocket-version": "11",
-            },
-            timeout=5,
+                headers={
+                    "upgrade": "websocket",
+                    "connection": "upgrade",
+                    "sec-websocket-version": "11",
+                },
+                timeout=5,
             )
         if response.status_code == 426:
             # response.text == ""

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -51,11 +51,7 @@ async def test_invalid_upgrade(protocol_cls):
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 "http://127.0.0.1:8000",
-                headers={
-                    "upgrade": "websocket",
-                    "connection": "upgrade",
-                    "sec-websocket-version": "11",
-                },
+                headers={"upgrade": "websocket", "connection": "upgrade"},
                 timeout=5,
             )
         if response.status_code == 426:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -51,7 +51,11 @@ async def test_invalid_upgrade(protocol_cls):
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 "http://127.0.0.1:8000",
-                headers={"upgrade": "websocket", "connection": "upgrade"},
+                headers={
+                    "upgrade": "websocket",
+                    "connection": "upgrade",
+                    "sec-webSocket-version": "11",
+                },
                 timeout=5,
             )
         if response.status_code == 426:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -51,7 +51,7 @@ async def test_invalid_upgrade(protocol_cls):
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 "http://127.0.0.1:8000",
-                headers={"upgrade": "websocket", "connection": "upgrade"},
+                headers={"upgrade": "websocket", "connection": "upgrade", "sec-websocket-version": "11"},
                 timeout=5,
             )
         if response.status_code == 426:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -51,8 +51,12 @@ async def test_invalid_upgrade(protocol_cls):
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 "http://127.0.0.1:8000",
-                headers={"upgrade": "websocket", "connection": "upgrade", "sec-websocket-version": "11"},
-                timeout=5,
+            headers={
+                "upgrade": "websocket",
+                "connection": "upgrade",
+                "sec-websocket-version": "11",
+            },
+            timeout=5,
             )
         if response.status_code == 426:
             # response.text == ""


### PR DESCRIPTION
Fixes https://github.com/encode/uvicorn/issues/868

We have a few tests failing if using wsproto 1.0.* vs the one pinned that was 0.15.*

As noticed in the issue, the main difference comes from this diff in `src/wsproto/handshake.py` where `status_code=426,` becomes `status_code=426 if version else 400,` 

so the 426 we test in `test_supported_upgrade_request` can only appear if there is at least the `Sec-WebSocket-Version` header, and in order for the 426 to appear it need to bea wrong version.

Same reasoning on `test_invalid_upgrade` we provide a wrong sec-websocket-version (11 instead of 13) to trigger the 426 in wsproto and 400 on websockets
