### PR TITLE
fix(websocket): disconnect websocket when connection lost

### DIFF
--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -61,10 +61,11 @@ class WSProtocol(asyncio.Protocol):
         self.client = get_remote_addr(transport)
         self.scheme = "wss" if is_ssl(transport) else "ws"
 
-    def connection_lost(self, exc):
-        if exc is not None:
-            self.queue.put_nowait({"type": "websocket.disconnect"})
+    def connection_lost(self, exc: Exception):
+        self.queue.put_nowait({"type": "websocket.disconnect"})
         self.connections.remove(self)
+        if exc is not None:
+            raise exc
 
     def eof_received(self):
         pass


### PR DESCRIPTION
Whatever reason causes the connection lost, that marks the close of socket lifespan. Everything related to the socket should be cleaned, cancelled, completed, such as tasks awaiting for data received from that socket.

Finally, raise the exception to the main thread for error logging.