### PR TITLE
🐛 Fix resetting signals in Gunicorn UvicornWorker

### DIFF
--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -65,6 +65,7 @@ class UvicornWorker(Worker):
     def init_signals(self):
         # Reset signals so Gunicorn doesn't swallow subprocess return codes
         # other signals are set up by Server.install_signal_handlers()
+        # See: https://github.com/encode/uvicorn/issues/894
         for s in self.SIGNALS:
             signal.signal(s, signal.SIG_DFL)
 

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import signal
 
 from gunicorn.workers.base import Worker
 
@@ -62,7 +63,10 @@ class UvicornWorker(Worker):
         super(UvicornWorker, self).init_process()
 
     def init_signals(self):
-        pass
+        # Reset signals so Gunicorn doesn't swallow subprocess return codes
+        # other signals are set up by Server.install_signal_handlers()
+        for s in self.SIGNALS:
+            signal.signal(s, signal.SIG_DFL)
 
     def run(self):
         self.config.app = self.wsgi


### PR DESCRIPTION
🐛 Fix resetting signals in Gunicorn `UvicornWorker` to fix subprocesses that capture output having an incorrect `returncode`.

Fixes #894 

Very short version:

When starting Gunicorn with Uvicorn worker(s), if the app uses `subprocess` to start other processes and captures the output, their `returncode` is in most cases `0`, even if the actual exit code was `1`.

Lengthy explanation and self-contained reproducible example in this issue: https://github.com/encode/uvicorn/issues/894