### PR TITLE
Bump version in __init__.py

### DIFF
--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.13.1"
+__version__ = "0.13.2"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Prompted by https://github.com/encode/uvicorn/pull/890#issuecomment-748534651

I forgot to bump the version there, so the PyPI push fail (« version already exist »).

Plan is:

- Merge this PR
- Delete the 0.13.2 tag in the GitHub UI
- Tag 0.13.2 again from the fixed version of master