### PR TITLE
Fix lifespan tests

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -146,26 +146,33 @@ def test_lifespan_with_failed_startup(mode, raise_exception):
     loop.run_until_complete(test())
 
 
-@pytest.mark.parametrize("mode", ("auto", "on"))
-def test_lifespan_scope_asgi3app(mode):
+def test_lifespan_scope_asgi3app():
     async def asgi3app(scope, receive, send):
-        assert scope == {"version": "3.0", "spec_version": "2.0"}
+        assert scope == {
+            "type": "lifespan",
+            "asgi": {"version": "3.0", "spec_version": "2.0"},
+        }
 
     async def test():
-        config = Config(app=asgi3app, lifespan=mode)
+        config = Config(app=asgi3app, lifespan="on")
         lifespan = LifespanOn(config)
 
         await lifespan.startup()
+        assert not lifespan.startup_failed
+        assert not lifespan.error_occured
+        assert not lifespan.should_exit
         await lifespan.shutdown()
 
     loop = asyncio.new_event_loop()
     loop.run_until_complete(test())
 
 
-@pytest.mark.parametrize("mode", ("auto", "on"))
-def test_lifespan_scope_asgi2app(mode):
+def test_lifespan_scope_asgi2app():
     def asgi2app(scope):
-        assert scope == {"version": "2.0", "spec_version": "2.0"}
+        assert scope == {
+            "type": "lifespan",
+            "asgi": {"version": "2.0", "spec_version": "2.0"},
+        }
 
         async def asgi(receive, send):
             pass
@@ -173,7 +180,7 @@ def test_lifespan_scope_asgi2app(mode):
         return asgi
 
     async def test():
-        config = Config(app=asgi2app, lifespan=mode)
+        config = Config(app=asgi2app, lifespan="on")
         lifespan = LifespanOn(config)
 
         await lifespan.startup()


### PR DESCRIPTION
Fixes #911, alternative to #912 cc @euri10 

Fixes two lifespan tests that were silently failing (the assert scope didn't have the correct shape), and make it so that any regressions would result in failing tests.