### PR TITLE
Tweak detection of app factories

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -310,18 +310,18 @@ class Config:
             logger.error("Error loading ASGI app. %s" % exc)
             sys.exit(1)
 
-        if self.factory:
-            try:
-                self.loaded_app = self.loaded_app()
-            except TypeError as exc:
+        try:
+            self.loaded_app = self.loaded_app()
+        except TypeError as exc:
+            if self.factory:
                 logger.error("Error loading ASGI app factory: %s", exc)
                 sys.exit(1)
-        elif not inspect.signature(self.loaded_app).parameters:
-            logger.error(
-                "APP seems to be an application factory. "
-                "Run uvicorn with the --factory flag."
-            )
-            sys.exit(1)
+        else:
+            if not self.factory:
+                logger.warning(
+                    "ASGI app factory detected. Using it, "
+                    "but please consider setting the --factory flag explicitly."
+                )
 
         if self.interface == "auto":
             if inspect.isclass(self.loaded_app):


### PR DESCRIPTION
Fixes #900, cleanup for #875, based on https://github.com/encode/uvicorn/issues/900#issuecomment-748959580

Instead of inspecting the `app`, attempt to call it without arguments each time.

* When it fails without `--factory`, consider it as normal — the app is meant to be an app instance.
* When it fails with `--factory`, exit with an error message — the factory failed to load.
* When it succeeds without `--factory`, keep Uvicorn running, but issue a warning — explicit flag is preferred:

```console
$ uvicorn debug.app:create_app
WARNING:  ASGI app factory detected. Using it, but please consider setting the --factory flag explicitly.
INFO:     Started server process [202]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
```

This removes the `inspect.signature` code that was causing https://github.com/getsentry/sentry-python/issues/947.
