### PR TITLE
Refactor test_headers using pytest fixture factory and avoiding background thread use

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ mypy
 trustme
 cryptography
 coverage
+pytest-asyncio
+httpx
 
 # Documentation
 mkdocs

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -1,7 +1,7 @@
-import threading
-import time
+import asyncio
 
-import requests
+import httpx
+import pytest
 
 from uvicorn import Config, Server
 
@@ -12,79 +12,66 @@ async def app(scope, receive, send):
     await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
-def test_default_default_headers():
-    config = Config(app=app, loop="asyncio", limit_max_requests=1)
-    server = Server(config=config)
-    thread = threading.Thread(target=server.run)
-    thread.start()
-    while not server.started:
-        time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
+@pytest.fixture
+def server_fixture(event_loop, config_arg):
+    server = Server(config=config_arg)
+    cancel_handle = asyncio.ensure_future(server.serve(), loop=event_loop)
+    event_loop.run_until_complete(asyncio.sleep(0.1))
+    try:
+        yield
+    finally:
+        event_loop.run_until_complete(server.shutdown())
+        cancel_handle.cancel()
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config_arg", [Config(app=app, loop="asyncio", limit_max_requests=1)]
+)
+async def test_default_default_headers(server_fixture, config_arg):
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://127.0.0.1:8000")
     assert response.headers["server"] == "uvicorn" and response.headers["date"]
 
-    thread.join()
 
-
-def test_override_server_header():
-    config = Config(
-        app=app,
-        loop="asyncio",
-        limit_max_requests=1,
-        headers=[("Server", "over-ridden")],
-    )
-    server = Server(config=config)
-    thread = threading.Thread(target=server.run)
-    thread.start()
-    while not server.started:
-        time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
-
+# fmt: off
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config_arg", [Config(app=app, loop="asyncio", limit_max_requests=1, headers=[("Server", "over-ridden")])]  # noqa: E501
+)
+# fmt: on
+async def test_override_server_header(server_fixture, config_arg):
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://127.0.0.1:8000")
     assert response.headers["server"] == "over-ridden" and response.headers["date"]
 
-    thread.join()
 
-
-def test_override_server_header_multiple_times():
-    config = Config(
-        app=app,
-        loop="asyncio",
-        limit_max_requests=1,
-        headers=[("Server", "over-ridden"), ("Server", "another-value")],
-    )
-    server = Server(config=config)
-    thread = threading.Thread(target=server.run)
-    thread.start()
-    while not server.started:
-        time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
-
+# fmt: off
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config_arg", [Config(app=app, loop="asyncio", limit_max_requests=1, headers=[("Server", "over-ridden"), ("Server", "another-value")])]  # noqa: E501
+)
+# fmt: on
+async def test_override_server_header_multiple_times(server_fixture, config_arg):
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://127.0.0.1:8000")
     assert (
         response.headers["server"] == "over-ridden, another-value"
         and response.headers["date"]
     )
 
-    thread.join()
 
-
-def test_add_additional_header():
-    config = Config(
-        app=app,
-        loop="asyncio",
-        limit_max_requests=1,
-        headers=[("X-Additional", "new-value")],
-    )
-    server = Server(config=config)
-    thread = threading.Thread(target=server.run)
-    thread.start()
-    while not server.started:
-        time.sleep(0.01)
-    response = requests.get("http://127.0.0.1:8000")
-
+# fmt: off
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config_arg", [Config(app=app, loop="asyncio", limit_max_requests=1, headers=[("X-Additional", "new-value")])]  # noqa: E501
+)
+# fmt: on
+async def test_add_additional_header(server_fixture, config_arg):
+    async with httpx.AsyncClient() as client:
+        response = await client.get("http://127.0.0.1:8000")
     assert (
         response.headers["x-additional"] == "new-value"
         and response.headers["server"] == "uvicorn"
         and response.headers["date"]
     )
-
-    thread.join()


### PR DESCRIPTION
POC that just aims at showing we could use a server fixture instead of the threading approach in the tests suite.
What do you think ?