### PR TITLE
Make install requirements PEP 440 compliant.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,9 @@ extra_requirements = [
     "websockets==8.*",
     "httptools==0.1.* ;" + env_marker_cpython,
     "uvloop>=0.14.0 ;" + env_marker_cpython,
-    "colorama>=0.4.*;" + env_marker_win,
+    "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6,<0.7",
-    "python-dotenv>=0.13.*",
+    "python-dotenv>=0.13",
     "PyYAML>=5.1",
 ]
 


### PR DESCRIPTION
[PEP 440](https://www.python.org/dev/peps/pep-0440/#version-scheme) doesn't allow wildcards (`*`) in version specifiers using the `>=` comparison operator.  `*` wildcards are called "prefix matching" in PEP 440.  This PR removes the `*` wildcard characters from install requirements that use greater-than comparison operator to be compatible with PEP 440.  

This new requirements should be equivalent to the old.  The wildcard characters are not necessary because
> As with version matching, the release segment is zero padded as necessary to ensure the release segments are compared with the same length.

https://www.python.org/dev/peps/pep-0440/#inclusive-ordered-comparison

The existing specifiers raise `DeprecationWarning`s from `packaging.requirements.Requirement`: "Creating a LegacyVersion has been deprecated and will be removed in the next major release."

<details>

```
> python3 -Werror                                   
Python 3.9.1 (default, Dec 24 2020, 16:23:16) 
[Clang 12.0.0 (clang-1200.0.32.28)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from packaging.requirements import Requirement
>>> Requirement("colorama>=0.4.*")
Traceback (most recent call last):
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 678, in __init__
    parsed.add(Specifier(specifier))
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 103, in __init__
    raise InvalidSpecifier("Invalid specifier: '{0}'".format(spec))
packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=0.4.*'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/requirements.py", line 126, in __init__
    self.specifier = SpecifierSet(req.specifier)  # type: SpecifierSet
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 680, in __init__
    parsed.add(LegacySpecifier(specifier))
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 283, in __init__
    warnings.warn(
DeprecationWarning: Creating a LegacyVersion has been deprecated and will be removed in the next major release
>>> Requirement("python-dotenv>=0.13.*")
Traceback (most recent call last):
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 678, in __init__
    parsed.add(Specifier(specifier))
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 103, in __init__
    raise InvalidSpecifier("Invalid specifier: '{0}'".format(spec))
packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=0.13.*'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/requirements.py", line 126, in __init__
    self.specifier = SpecifierSet(req.specifier)  # type: SpecifierSet
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 680, in __init__
    parsed.add(LegacySpecifier(specifier))
  File "/Users/mclapp/git/pipx/venv/lib/python3.9/site-packages/packaging/specifiers.py", line 283, in __init__
    warnings.warn(
DeprecationWarning: Creating a LegacyVersion has been deprecated and will be removed in the next major release
>>> 
```

</details>