### PR TITLE
Version 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.13.3 - 2020-12-29
+
+### Fixed
+
+- Prevent swallowing of return codes from `subprocess` when running with Gunicorn by properly resetting signals. (Pull #895)
+- Tweak detection of app factories to be more robust. A warning is now logged when passing a factory without the `--factory` flag. (Pull #914)
+- Properly clean tasks when handshake is aborted when running with `--ws websockets`. (Pull #921)
+
 ## 0.13.2 - 2020-12-12
 
 ### Fixed

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.13.2"
+__version__ = "0.13.3"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Think we'll soon be ready to issue a new bugfix release.

Changelog source: https://github.com/encode/uvicorn/compare/0.13.2...HEAD

---

## 0.13.3 - 2020-12-29

### Fixed

- Prevent swallowing of return codes from `subprocess` when running with Gunicorn by properly resetting signals. (Pull #895)
- Tweak detection of app factories to be more robust. A warning is now logged when passing a factory without the `--factory` flag. (Pull #914)
- Properly clean tasks when handshake is aborted when running with `--ws websockets`. (Pull #921)
