### PR TITLE
Set `propagation=False` on the 'uvicorn' logger in case of LOGGING_CONFIG dictionary

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -92,9 +92,9 @@ LOGGING_CONFIG = {
         },
     },
     "loggers": {
-        "uvicorn": {"handlers": ["default"], "level": "INFO"},
+        "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
         "uvicorn.error": {"level": "INFO"},
-        "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
+        "uvicorn.access": {"handlers": ["access"], "level": "INFO"},
     },
 }
 


### PR DESCRIPTION
It seems that when running `uvicorn` locally, it works with the `LOGGING_CONFIG` dictionary, so it means that the `propagtion=False` set in the [workers.py](https://github.com/encode/uvicorn/blob/master/uvicorn/workers.py#L25) file won't work.

It `propagation=False` only the [access logs](https://github.com/encode/uvicorn/blob/master/uvicorn/config.py#L97).

It made everyone using the `logging` module with `debug/info/warning/error` in their main file propagate the `uvicron.error` and print the log twice, for example:

```
INFO:     Started server process [18600]
INFO:uvicorn.error:Started server process [18600]
```

Remember that using `logging.error` (or w/e) initializes the root logger because it calls the `basicConfig()` function inside,
so when the root logger initialized, he will see all descendant loggers, and in this case, will print them again.

The right solution is to set `propagattion=False` only on the `uvicorn` logger so the descendants `error` and `access` won't go up, but still can print their logs.