### PR TITLE
fix: h11 only support Response status_code between [200, 600)

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -22,7 +22,7 @@ def _get_status_phrase(status_code):
 
 
 STATUS_PHRASES = {
-    status_code: _get_status_phrase(status_code) for status_code in range(200, 599)
+    status_code: _get_status_phrase(status_code) for status_code in range(200, 600)
 }
 
 HIGH_WATER_LIMIT = 65536

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -22,7 +22,7 @@ def _get_status_phrase(status_code):
 
 
 STATUS_PHRASES = {
-    status_code: _get_status_phrase(status_code) for status_code in range(100, 600)
+    status_code: _get_status_phrase(status_code) for status_code in range(200, 599)
 }
 
 HIGH_WATER_LIMIT = 65536


### PR DESCRIPTION
limited by [there](https://github.com/python-hyper/h11/blob/master/h11/_events.py#L221)