### PR TITLE
Move `Config#load` out of `Server#serve` to enable Eager Asynchronous Construction of App

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,10 @@ from uvicorn import Config, Server
 @asynccontextmanager
 async def run_server(config: Config, sockets=None):
     server = Server(config=config)
+
+    if not config.loaded:
+        config.load()
+
     cancel_handle = asyncio.ensure_future(server.serve(sockets=sockets))
     await asyncio.sleep(0.1)
     try:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -44,7 +44,12 @@ class Server:
         self.last_notified = 0
 
     def run(self, sockets=None):
-        self.config.setup_event_loop()
+        config = self.config
+        config.setup_event_loop()
+
+        if not config.loaded:
+            config.load()
+
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.serve(sockets=sockets))
 
@@ -52,8 +57,6 @@ class Server:
         process_id = os.getpid()
 
         config = self.config
-        if not config.loaded:
-            config.load()
 
         self.lifespan = config.lifespan_class(config)
 

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -70,7 +70,12 @@ class UvicornWorker(Worker):
             signal.signal(s, signal.SIG_DFL)
 
     def run(self):
-        self.config.app = self.wsgi
+        config = self.config
+        config.app = self.wsgi
+
+        if not config.loaded:
+            config.load()
+
         server = Server(config=self.config)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(server.serve(sockets=self.sockets))


### PR DESCRIPTION
Fixes #941 by identifying the 3 call sites (test utility, gunicorn worker, uvicorn runner itself) `Server#serve` is used at and moving `Config#load` to those sites.