### PR TITLE
Relax watchgod up bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ extra_requirements = [
     "httptools==0.1.* ;" + env_marker_cpython,
     "uvloop>=0.14.0 ;" + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
-    "watchgod>=0.6,<0.7",
+    "watchgod>=0.6",
     "python-dotenv>=0.13",
     "PyYAML>=5.1",
 ]


### PR DESCRIPTION
watchgod released a 0.7 version with nice speed improvments (https://github.com/samuelcolvin/watchgod/releases/tag/v0.7)
this relaxes the up bound as it breaks dependency tree 