### PR TITLE
Implement gunicorn access log format

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,6 +74,8 @@ Options:
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
+  --access-log-format TEXT        Access log format (supports same fields as
+                                  gunicorn).
   --use-colors / --no-use-colors  Enable/Disable colorized logging.
   --proxy-headers / --no-proxy-headers
                                   Enable/Disable X-Forwarded-Proto,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -74,8 +74,8 @@ Options:
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
-  --access-log-format TEXT        Access log format (supports same fields as
-                                  gunicorn).
+  --access-log-format TEXT        Log format for access logger, check
+                                  documentation for details
   --use-colors / --no-use-colors  Enable/Disable colorized logging.
   --proxy-headers / --no-proxy-headers
                                   Enable/Disable X-Forwarded-Proto,

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,6 +143,8 @@ Options:
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
+  --access-log-format TEXT        Access log format (supports same fields as
+                                  gunicorn).
   --use-colors / --no-use-colors  Enable/Disable colorized logging.
   --proxy-headers / --no-proxy-headers
                                   Enable/Disable X-Forwarded-Proto,

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,8 +143,8 @@ Options:
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
-  --access-log-format TEXT        Access log format (supports same fields as
-                                  gunicorn).
+  --access-log-format TEXT        Log format for access logger, check
+                                  documentation for details
   --use-colors / --no-use-colors  Enable/Disable colorized logging.
   --proxy-headers / --no-proxy-headers
                                   Enable/Disable X-Forwarded-Proto,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -46,7 +46,27 @@ By default Uvicorn uses simple changes detection strategy that compares python f
 * `--log-level <str>` - Set the log level. **Options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.* **Default:** *'info'*.
 * `--no-access-log` - Disable access log only, without changing log level.
 * `--use-colors / --no-use-colors` - Enable / disable colorized formatting of the log records, in case this is not set it will be auto-detected. This option is ignored if the `--log-config` CLI option is used.
-
+* `--access-log-format` - Customized message for access log. Will override log formatter for `uvicorn.access` logger. Format string that supports the following placeholders:
+    * `%(h)s` - remote IP address
+    * `%(l)s` - prints `-`
+    * `%(u)s` - user name, currently not supported, prints `-`
+    * `%(t)s` - request timestamp (in Apache Common Log Format `[10/Oct/2000:13:55:36 -0700]`)
+    * `%(r)s` - status line (method, path & http version, e.g.)
+    * `%(m)s` - request method
+    * `%(U)s` - request path
+    * `%(q)s` - request query string
+    * `%(H)s` - request protocol
+    * `%(s)s` - response status code
+    * `%(B)s` - response body length (if body was empty, prints `0`)
+    * `%(b)s` - response body length (if body was empty, prints `-`)
+    * `%(f)s` - request referer
+    * `%(a)s` - request user agent
+    * `%(T)s` - request+response time (in seconds, integer number)
+    * `%(D)s` - request+response time (in milliseconds, integer number)
+    * `%(L)s` - request+response time (in seconds, decimal number)
+    * `%(p)s` - process id (pid) of request handler
+    * `%({...}i)s` - value of arbitrary request header, e.g. `%({Accept-Encoding}i)s`
+    * `%({...}o)s` - value of arbitrary response header, e.g. `%({Content-Encoding}o)s`
 
 ## Implementation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ coverage==5.5
 coverage-conditional-plugin==0.4.0
 httpx==1.0.0b0
 pytest-asyncio==0.15.1
+async_generator==1.10 ; python_version < '3.7'
+gunicorn==20.1.0
 
 
 # Documentation

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -1,8 +1,14 @@
 import socket
+import time
 
 import pytest
 
-from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_remote_addr
+from uvicorn.protocols.utils import (
+    RequestResponseTiming,
+    get_client_addr,
+    get_local_addr,
+    get_remote_addr,
+)
 
 
 class MockSocket:
@@ -91,3 +97,51 @@ def test_get_remote_addr():
 )
 def test_get_client_addr(scope, expected_client):
     assert get_client_addr(scope) == expected_client
+
+
+def test_request_response_timing_request_duration_seconds():
+    timing = RequestResponseTiming()
+    with pytest.raises(ValueError):
+        timing.request_duration_seconds()
+
+    timing.request_started()
+    with pytest.raises(ValueError):
+        timing.request_duration_seconds()
+
+    # Make sure time.monotonic is updated before calls (caused problems in
+    # windows tests)
+    time.sleep(0.02)
+    timing.request_ended()
+    assert timing.request_duration_seconds() > 0
+
+
+def test_request_response_timing_response_duration_seconds():
+    timing = RequestResponseTiming()
+    with pytest.raises(ValueError):
+        timing.response_duration_seconds()
+
+    timing.response_started()
+    with pytest.raises(ValueError):
+        timing.response_duration_seconds()
+
+    # Make sure time.monotonic is updated before calls (caused problems in
+    # windows tests)
+    time.sleep(0.02)
+    timing.response_ended()
+    assert timing.response_duration_seconds() > 0
+
+
+def test_request_response_timing_total_duration_seconds():
+    timing = RequestResponseTiming()
+    with pytest.raises(ValueError):
+        timing.total_duration_seconds()
+
+    timing.request_started()
+    with pytest.raises(ValueError):
+        timing.total_duration_seconds()
+
+    # Make sure time.monotonic is updated before calls (caused problems in
+    # windows tests)
+    time.sleep(0.02)
+    timing.response_ended()
+    assert timing.total_duration_seconds() > 0

--- a/tests/test_gunicorn_worker.py
+++ b/tests/test_gunicorn_worker.py
@@ -72,7 +72,8 @@ def test_gunicorn_worker_stdout_access_log_format(worker_class):
         pytest.fail("Access log line not found, stderr:\n" + stderr.decode())
 
     assert re.match(
-        r'hellotest 127\.0\.0\.1 - - \[[^]]+\] "GET / HTTP/1\.1" 204 - "-" "-"'
-        r' [0-9.]+ "request-header-val" "response-header-val"',
+        r'hellotest 127\.0\.0\.1 - - \[[^]]+\] "GET / HTTP/1\.1" 204 - "-"'
+        r' "python-requests/2.25.1" [0-9.]+ "request-header-val" '
+        '"response-header-val"',
         stdout_lines[0],
     )

--- a/tests/test_gunicorn_worker.py
+++ b/tests/test_gunicorn_worker.py
@@ -1,0 +1,78 @@
+import random
+import re
+import signal
+import subprocess
+import time
+
+import pytest
+import requests
+
+
+# XXX: copypaste from test_main
+async def app(scope, receive, send):
+    assert scope["type"] == "http"
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 204,
+            "headers": [(b"test-response-header", b"response-header-val")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+@pytest.mark.parametrize(
+    "worker_class",
+    [
+        "uvicorn.workers.UvicornWorker",
+        "uvicorn.workers.UvicornH11Worker",
+    ],
+)
+def test_gunicorn_worker_stdout_access_log_format(worker_class):
+    random_port = random.randint(1024, 49151)
+    access_logformat = (
+        'hellotest %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s"'
+        ' "%(a)s" %(L)s "%({test-request-header}i)s"'
+        ' "%({test-response-header}o)s"'
+    )
+    process = subprocess.Popen(
+        [
+            "gunicorn",
+            "tests.test_gunicorn_worker:app",
+            "-k=%s" % worker_class,
+            "--bind=127.0.0.1:%d" % random_port,
+            "--access-logfile=-",
+            "--access-logformat=%s" % access_logformat,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            resp = requests.get(
+                "http://127.0.0.1:%d" % random_port,
+                headers={"Test-Request-Header": "request-header-val"},
+            )
+        except requests.exceptions.ConnectionError:
+            if attempts > 10:
+                raise
+            time.sleep(0.05)
+        else:
+            break
+
+    assert resp.status_code == 204
+    process.send_signal(signal.SIGTERM)
+    stdout, stderr = process.communicate()
+
+    stdout_lines = stdout.decode().splitlines()
+    if not len(stdout_lines) == 1:
+        pytest.fail("Access log line not found, stderr:\n" + stderr.decode())
+
+    assert re.match(
+        r'hellotest 127\.0\.0\.1 - - \[[^]]+\] "GET / HTTP/1\.1" 204 - "-" "-"'
+        r' [0-9.]+ "request-header-val" "response-header-val"',
+        stdout_lines[0],
+    )

--- a/tests/test_gunicorn_worker.py
+++ b/tests/test_gunicorn_worker.py
@@ -2,6 +2,7 @@ import random
 import re
 import signal
 import subprocess
+import sys
 import time
 
 import pytest
@@ -9,7 +10,8 @@ import requests
 
 
 # XXX: copypaste from test_main
-async def app(scope, receive, send):
+# Exclude from coverage, because this code is executed in subprocess.
+async def app(scope, receive, send):  # pragma: no cover
     assert scope["type"] == "http"
     await send(
         {
@@ -21,6 +23,9 @@ async def app(scope, receive, send):
     await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32", reason="gunicorn process doesn't start on windows?"
+)
 @pytest.mark.parametrize(
     "worker_class",
     [

--- a/tests/test_gunicorn_worker.py
+++ b/tests/test_gunicorn_worker.py
@@ -59,7 +59,10 @@ def test_gunicorn_worker_stdout_access_log_format(worker_class):
         try:
             resp = requests.get(
                 "http://127.0.0.1:%d" % random_port,
-                headers={"Test-Request-Header": "request-header-val"},
+                headers={
+                    "Test-Request-Header": "request-header-val",
+                    "User-Agent": "request-user-agent",
+                },
             )
         except requests.exceptions.ConnectionError:
             if attempts > 10:
@@ -78,7 +81,7 @@ def test_gunicorn_worker_stdout_access_log_format(worker_class):
 
     assert re.match(
         r'hellotest 127\.0\.0\.1 - - \[[^]]+\] "GET / HTTP/1\.1" 204 - "-"'
-        r' "python-requests/2.25.1" [0-9.]+ "request-header-val" '
+        r' "request-user-agent" [0-9.]+ "request-header-val" '
         '"response-header-val"',
         stdout_lines[0],
     )

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -388,6 +388,10 @@ class Config:
                     self.log_config["formatters"]["access"][
                         "use_colors"
                     ] = self.use_colors
+                if self.access_log_format:
+                    self.log_config["formatters"]["access"][
+                        "fmt"
+                    ] = "%(levelprefix)s %(message)s"
                 logging.config.dictConfig(self.log_config)
             elif self.log_config.endswith(".json"):
                 with open(self.log_config) as file:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -240,6 +240,7 @@ class Config:
         ssl_ciphers: str = "TLSv1",
         headers: Optional[List[List[str]]] = None,
         factory: bool = False,
+        gunicorn_log=None,
     ):
         self.app = app
         self.host = host
@@ -283,6 +284,8 @@ class Config:
         self.headers: List[List[str]] = headers or []
         self.encoded_headers: List[Tuple[bytes, bytes]] = []
         self.factory = factory
+
+        self.gunicorn_log = gunicorn_log
 
         self.loaded = False
         self.configure_logging()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -211,6 +211,7 @@ class Config:
         log_config: Optional[Union[dict, str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
+        access_log_format: Optional[str] = None,
         use_colors: Optional[bool] = None,
         interface: InterfaceType = "auto",
         debug: bool = False,
@@ -240,7 +241,6 @@ class Config:
         ssl_ciphers: str = "TLSv1",
         headers: Optional[List[List[str]]] = None,
         factory: bool = False,
-        gunicorn_log=None,
     ):
         self.app = app
         self.host = host
@@ -285,7 +285,7 @@ class Config:
         self.encoded_headers: List[Tuple[bytes, bytes]] = []
         self.factory = factory
 
-        self.gunicorn_log = gunicorn_log
+        self.access_log_format = access_log_format
 
         self.loaded = False
         self.configure_logging()

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -133,7 +133,10 @@ class GunicornSafeAtoms(abc.Mapping):
     @property
     def request_headers(self):
         if self._request_headers is None:
-            self._request_headers = dict(self.scope['headers'])
+            self._request_headers = {
+                k.decode('ascii'): v.decode('ascii')
+                for k, v in self.scope['headers']
+            }
         return self._request_headers
 
     @property
@@ -144,7 +147,10 @@ class GunicornSafeAtoms(abc.Mapping):
     def on_asgi_message(self, message):
         if message['type'] == 'http.response.start':
             self.status_code = message['status']
-            self.response_headers = dict(message['headers'])
+            self.response_headers = {
+                k.decode('ascii'): v.decode('ascii')
+                for k, v in message['headers']
+            }
         elif message['type'] == 'http.response.body':
             self.response_length += len(message.get('body', ''))
 

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -130,8 +130,9 @@ class GunicornSafeAtoms(abc.Mapping):
     - escapes double quotes found in atom strings
     """
 
-    def __init__(self, scope):
+    def __init__(self, scope, timing):
         self.scope = scope
+        self.timing = timing
         self.status_code = None
         self.response_headers = {}
         self.response_length = 0
@@ -148,8 +149,7 @@ class GunicornSafeAtoms(abc.Mapping):
 
     @property
     def duration(self):
-        d = self.scope["response_end_time"] - self.scope["request_start_time"]
-        return d
+        return self.timing.total_duration_seconds()
 
     def on_asgi_message(self, message):
         if message["type"] == "http.response.start":

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -124,7 +124,7 @@ class AccessFormatter(ColourizedFormatter):
         return super().formatMessage(recordcopy)
 
 
-class GunicornSafeAtoms(abc.Mapping):
+class GunicornSafeAtoms(abc.Mapping):  # pragma: no cover
     """Implement atoms necessary for gunicorn log.
 
     This class does a few things:

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -102,6 +102,8 @@ class AccessFormatter(ColourizedFormatter):
         return status_and_phrase
 
     def formatMessage(self, record: logging.LogRecord) -> str:
+        if len(record.args) != 5:
+            return super().formatMessage(record)
         recordcopy = copy(record)
         (
             client_addr,

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -1,7 +1,10 @@
 import http
 import logging
 import sys
+import time
+from collections import abc
 from copy import copy
+from os import getpid
 from typing import Optional
 
 import click
@@ -115,3 +118,171 @@ class AccessFormatter(ColourizedFormatter):
             }
         )
         return super().formatMessage(recordcopy)
+
+
+class GunicornSafeAtoms(abc.Mapping):
+    """Implement atoms necessary for gunicorn log."""
+    def __init__(self, scope):
+        self.scope = scope
+        self.status_code = None
+        self.response_headers = {}
+        self.response_length = 0
+
+        self._request_headers = None
+
+    @property
+    def request_headers(self):
+        if self._request_headers is None:
+            self._request_headers = dict(self.scope['headers'])
+        return self._request_headers
+
+    @property
+    def duration(self):
+        d = self.scope['response_end_time'] - self.scope['request_start_time']
+        return d
+
+    def on_asgi_message(self, message):
+        if message['type'] == 'http.response.start':
+            self.status_code = message['status']
+            self.response_headers = dict(message['headers'])
+        elif message['type'] == 'http.response.body':
+            self.response_length += len(message.get('body', ''))
+
+    def _request_header(self, key):
+        return self.request_headers.get(key.lower())
+
+    def _response_header(self, key):
+        return self.response_headers.get(key.lower())
+
+    def _wsgi_environ_variable(self, key):
+        # FIXME: provide fallbacks to access WSGI environ (at least the
+        # required variables).
+        return None
+
+    def __getitem__(self, key):
+        if key in self.HANDLERS:
+            retval = self.HANDLERS[key](self)
+        elif key.startswith('{'):
+            if key.endswith('}i'):
+                retval = self._request_header(key[1:-2])
+            elif key.endswith('}o'):
+                retval = self._response_header(key[1:-2])
+            elif key.endswith('}e'):
+                retval = self._wsgi_environ_variable(key[1:-2])
+            else:
+                retval = None
+        else:
+            retval = None
+
+        if retval is None:
+            return '-'
+        if isinstance(retval, str):
+            return retval.replace('"', '\\"')
+        return retval
+
+    HANDLERS = {}
+
+    def _register_handler(key, handlers=HANDLERS):
+        def decorator(fn):
+            handlers[key] = fn
+            return fn
+        return decorator
+
+    @_register_handler('h')
+    def _remote_address(self, *args, **kwargs):
+        return self.scope['client'][0]
+
+    @_register_handler('l')
+    def _dash(self, *args, **kwargs):
+        return '-'
+
+    @_register_handler('u')
+    def _user_name(self, *args, **kwargs):
+        pass
+
+    @_register_handler('t')
+    def date_of_the_request(self, *args, **kwargs):
+        """Date and time in Apache Common Log Format"""
+        return time.strftime('[%d/%b/%Y:%H:%M:%S %z]')
+
+    @_register_handler('r')
+    def status_line(self, *args, **kwargs):
+        full_raw_path = (self.scope['raw_path'] + self.scope['query_string'])
+        full_path = full_raw_path.decode('ascii')
+        return '{method} {full_path} HTTP/{http_version}'.format(
+            full_path=full_path, **self.scope
+        )
+
+    @_register_handler('m')
+    def request_method(self, *args, **kwargs):
+        return self.scope['method']
+
+    @_register_handler('U')
+    def url_path(self, *args, **kwargs):
+        return self.scope['raw_path'].decode('ascii')
+
+    @_register_handler('q')
+    def query_string(self, *args, **kwargs):
+        return self.scope['query_string'].decode('ascii')
+
+    @_register_handler('H')
+    def protocol(self, *args, **kwargs):
+        return 'HTTP/%s' % self.scope['http_version']
+
+    @_register_handler('s')
+    def status(self, *args, **kwargs):
+        return self.status_code or '-'
+
+    @_register_handler('B')
+    def response_length(self, *args, **kwargs):
+        return self.response_length
+
+    @_register_handler('b')
+    def response_length_or_dash(self, *args, **kwargs):
+        return self.response_length or '-'
+
+    @_register_handler('f')
+    def referer(self, *args, **kwargs):
+        val = self.request_headers.get(b'referer')
+        if val is None:
+            return None
+        return val.decode('ascii')
+
+    @_register_handler('a')
+    def user_agent(self, *args, **kwargs):
+        val = self.request_headers.get(b'user-agent')
+        if val is None:
+            return None
+        return val.decode('ascii')
+
+    @_register_handler('T')
+    def request_time_seconds(self, *args, **kwargs):
+        return int(self.duration)
+
+    @_register_handler('D')
+    def request_time_microseconds(self, *args, **kwargs):
+        return int(self.duration * 1_000_000)
+
+    @_register_handler('L')
+    def request_time_decimal_seconds(self, *args, **kwargs):
+        return "%.6f" % self.duration
+
+    @_register_handler('p')
+    def process_id(self, *args, **kwargs):
+        return "<%s>" % getpid()
+
+    def __iter__(self):
+        # FIXME: add WSGI environ
+        yield from self.HANDLERS
+        for k, _ in self.scope['headers']:
+            yield '{%s}i' % k.lower()
+        for k in self.response_headers:
+            yield '{%s}o' % k.lower()
+
+    def __len__(self):
+        # FIXME: add WSGI environ
+        return (
+            len(self.HANDLERS)
+            + len(self.scope['headers'] or ())
+            + len(self.response_headers)
+        )

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -203,6 +203,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     help="Enable/Disable access log.",
 )
 @click.option(
+    "--access-log-format",
+    type=str,
+    default=None,
+    help="Access log format (supports same fields as gunicorn).",
+)
+@click.option(
     "--use-colors/--no-use-colors",
     is_flag=True,
     default=None,
@@ -365,6 +371,7 @@ def main(
     log_config: str,
     log_level: str,
     access_log: bool,
+    access_log_format: str,
     proxy_headers: bool,
     server_header: bool,
     date_header: bool,
@@ -403,6 +410,7 @@ def main(
         "log_config": LOGGING_CONFIG if log_config is None else log_config,
         "log_level": log_level,
         "access_log": access_log,
+        "access_log_format": access_log_format,
         "interface": interface,
         "debug": debug,
         "reload": reload,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -206,7 +206,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--access-log-format",
     type=str,
     default=None,
-    help="Access log format (supports same fields as gunicorn).",
+    help="Log format for access logger, check documentation for details",
 )
 @click.option(
     "--use-colors/--no-use-colors",

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -6,7 +6,7 @@ from urllib.parse import unquote
 
 import h11
 
-from uvicorn.logging import TRACE_LOG_LEVEL, GunicornSafeAtoms
+from uvicorn.logging import TRACE_LOG_LEVEL, AccessLogFields
 from uvicorn.protocols.http.flow_control import (
     CLOSE_HEADER,
     HIGH_WATER_LIMIT,
@@ -194,7 +194,7 @@ class H11Protocol(asyncio.Protocol):
                     logger=self.logger,
                     access_logger=self.access_logger,
                     access_log=self.access_log,
-                    gunicorn_log=self.config.gunicorn_log,
+                    access_log_format=self.config.access_log_format,
                     default_headers=self.default_headers,
                     message_event=asyncio.Event(),
                     on_response=self.on_response_complete,
@@ -335,7 +335,7 @@ class RequestResponseCycle:
         logger,
         access_logger,
         access_log,
-        gunicorn_log,
+        access_log_format,
         default_headers,
         message_event,
         on_response,
@@ -347,7 +347,7 @@ class RequestResponseCycle:
         self.logger = logger
         self.access_logger = access_logger
         self.access_log = access_log
-        self.gunicorn_log = gunicorn_log
+        self.access_log_format = access_log_format
         self.default_headers = default_headers
         self.message_event = message_event
         self.on_response = on_response
@@ -367,10 +367,7 @@ class RequestResponseCycle:
         self.timing = RequestResponseTiming()
 
         # For logging
-        if self.gunicorn_log:
-            self.gunicorn_atoms = GunicornSafeAtoms(self.scope, self.timing)
-        else:
-            self.gunicorn_atoms = None
+        self.access_log_fields = AccessLogFields(self.scope, self.timing)
 
     # ASGI exception wrapper
     async def run_asgi(self, app):
@@ -424,8 +421,8 @@ class RequestResponseCycle:
         if self.disconnected:
             return
 
-        if self.gunicorn_atoms is not None:
-            self.gunicorn_atoms.on_asgi_message(message)
+        if self.access_log_fields is not None:
+            self.access_log_fields.on_asgi_message(message)
 
         if not self.response_started:
             # Sending response status line and headers
@@ -442,16 +439,6 @@ class RequestResponseCycle:
 
             if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
-
-            if self.access_log and self.gunicorn_log is None:
-                self.access_logger.info(
-                    '%s - "%s %s HTTP/%s" %d',
-                    get_client_addr(self.scope),
-                    self.scope["method"],
-                    get_path_with_query_string(self.scope),
-                    self.scope["http_version"],
-                    status_code,
-                )
 
             # Write response status line and headers
             reason = STATUS_PHRASES[status_code]
@@ -484,18 +471,28 @@ class RequestResponseCycle:
                 self.message_event.set()
                 event = h11.EndOfMessage()
                 output = self.conn.send(event)
+                self.transport.write(output)
 
                 self.timing.response_ended()
-                if self.gunicorn_log is not None:
-                    try:
-                        self.gunicorn_log.access_log.info(
-                            self.gunicorn_log.cfg.access_log_format,
-                            self.gunicorn_atoms,
-                        )
-                    except:  # noqa
-                        self.gunicorn_log.error(traceback.format_exc())
 
-                self.transport.write(output)
+                if self.access_log:
+                    if self.access_log_format is None:
+                        self.access_logger.info(
+                            '%s - "%s %s HTTP/%s" %d',
+                            get_client_addr(self.scope),
+                            self.scope["method"],
+                            get_path_with_query_string(self.scope),
+                            self.scope["http_version"],
+                            self.access_log_fields.status_code,
+                        )
+                    else:
+                        try:
+                            self.access_logger.info(
+                                self.access_log_format,
+                                self.access_log_fields,
+                            )
+                        except:  # noqa
+                            self.logger.error(traceback.format_exc())
 
         else:
             # Response already sent

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -486,8 +486,8 @@ class RequestResponseCycle:
                 event = h11.EndOfMessage()
                 output = self.conn.send(event)
 
-                duration_extension = self.scope['extensions']['uvicorn_request_duration']
-                duration_extension["response_end_time"] = time.monotonic()
+                duration_scope = self.scope["extensions"]["uvicorn_request_duration"]
+                duration_scope["response_end_time"] = time.monotonic()
                 if self.gunicorn_log is not None:
                     try:
                         self.gunicorn_log.access_log.info(

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -5,8 +5,7 @@ import re
 import time
 import traceback
 import urllib
-from collections import abc, deque
-from os import getpid
+from collections import deque
 
 import httptools
 
@@ -524,8 +523,8 @@ class RequestResponseCycle:
                 if self.expected_content_length != 0:
                     raise RuntimeError("Response content shorter than Content-Length")
                 self.response_complete = True
-                duration_extension = self.scope['extensions']['uvicorn_request_duration']
-                duration_extension['response_end_time'] = time.monotonic()
+                duration_scope = self.scope["extensions"]["uvicorn_request_duration"]
+                duration_scope["response_end_time"] = time.monotonic()
 
                 if self.gunicorn_log is not None:
                     try:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -2,8 +2,10 @@ import asyncio
 import http
 import logging
 import re
+import time
 import urllib
-from collections import deque
+from collections import abc, deque
+from os import getpid
 
 import httptools
 
@@ -39,6 +41,174 @@ STATUS_LINE = {
 }
 
 
+class GunicornSafeAtoms(abc.Mapping):
+    def __init__(self, scope):
+        self.scope = scope
+        self.status_code = None
+        self.response_headers = {}
+        self.response_length = 0
+
+        self._request_headers = None
+
+    @property
+    def request_headers(self):
+        if self._request_headers is None:
+            self._request_headers = dict(self.scope['headers'])
+        return self._request_headers
+
+    @property
+    def duration(self):
+        duration_extension = self.scope['extensions']['uvicorn_request_duration']
+        d = duration_extension['response_end_time'] - duration_extension['request_start_time']
+        return d
+
+    def on_asgi_message(self, message):
+        if message['type'] == 'http.response.start':
+            self.status_code = message['status']
+            self.response_headers = dict(message['headers'])
+        elif message['type'] == 'http.response.body':
+            self.response_length += len(message.get('body', ''))
+
+    def _request_header(self, key):
+        return self.request_headers.get(key.lower())
+
+    def _response_header(self, key):
+        return self.response_headers.get(key.lower())
+
+    def _wsgi_environ_variable(self, key):
+        # FIXME: provide fallbacks to access WSGI environ (at least the
+        # required variables).
+        return None
+
+    def __getitem__(self, key):
+        if key in self.HANDLERS:
+            retval = self.HANDLERS[key](self)
+        elif key.startswith('{'):
+            if key.endswith('}i'):
+                retval = self._request_header(key[1:-2])
+            elif key.endswith('}o'):
+                retval = self._response_header(key[1:-2])
+            elif key.endswith('}e'):
+                retval = self._wsgi_environ_variable(key[1:-2])
+            else:
+                retval = None
+        else:
+            retval = None
+
+        if retval is None:
+            return '-'
+        if isinstance(retval, str):
+            return retval.replace('"', '\\"')
+        return retval
+
+    HANDLERS = {}
+
+    def _register_handler(key, handlers=HANDLERS):
+        def decorator(fn):
+            handlers[key] = fn
+            return fn
+        return decorator
+
+    @_register_handler('h')
+    def _remote_address(self, *args, **kwargs):
+        return self.scope['client'][0]
+
+    @_register_handler('l')
+    def _dash(self, *args, **kwargs):
+        return '-'
+
+    @_register_handler('u')
+    def _user_name(self, *args, **kwargs):
+        pass
+
+    @_register_handler('t')
+    def date_of_the_request(self, *args, **kwargs):
+        """Date and time in Apache Common Log Format"""
+        return time.strftime('[%d/%b/%Y:%H:%M:%S %z]')
+
+    @_register_handler('r')
+    def status_line(self, *args, **kwargs):
+        full_raw_path = (self.scope['raw_path'] + self.scope['query_string'])
+        full_path = full_raw_path.decode('ascii')
+        return '{method} {full_path} HTTP/{http_version}'.format(
+            full_path=full_path, **self.scope
+        )
+
+    @_register_handler('m')
+    def request_method(self, *args, **kwargs):
+        return self.scope['method']
+
+    @_register_handler('U')
+    def url_path(self, *args, **kwargs):
+        return self.scope['raw_path'].decode('ascii')
+
+    @_register_handler('q')
+    def query_string(self, *args, **kwargs):
+        return self.scope['query_string'].decode('ascii')
+
+    @_register_handler('H')
+    def protocol(self, *args, **kwargs):
+        return 'HTTP/%s' % self.scope['http_version']
+
+    @_register_handler('s')
+    def status(self, *args, **kwargs):
+        return self.status_code or '-'
+
+    @_register_handler('B')
+    def response_length(self, *args, **kwargs):
+        return self.response_length
+
+    @_register_handler('b')
+    def response_length_or_dash(self, *args, **kwargs):
+        return self.response_length or '-'
+
+    @_register_handler('f')
+    def referer(self, *args, **kwargs):
+        val = self.request_headers.get(b'referer')
+        if val is None:
+            return None
+        return val.decode('ascii')
+
+    @_register_handler('a')
+    def user_agent(self, *args, **kwargs):
+        val = self.request_headers.get(b'user-agent')
+        if val is None:
+            return None
+        return val.decode('ascii')
+
+    @_register_handler('T')
+    def request_time_seconds(self, *args, **kwargs):
+        return int(self.duration)
+
+    @_register_handler('D')
+    def request_time_microseconds(self, *args, **kwargs):
+        return int(self.duration * 1_000_000)
+
+    @_register_handler('L')
+    def request_time_decimal_seconds(self, *args, **kwargs):
+        return "%.6f" % self.duration
+
+    @_register_handler('p')
+    def process_id(self, *args, **kwargs):
+        return "<%s>" % getpid()
+
+    def __iter__(self):
+        # FIXME: add WSGI environ
+        yield from self.HANDLERS
+        for k, _ in self.scope['headers']:
+            yield '{%s}i' % k.lower()
+        for k in self.response_headers:
+            yield '{%s}o' % k.lower()
+
+    def __len__(self):
+        # FIXME: add WSGI environ
+        return (
+            len(self.HANDLERS)
+            + len(self.scope['headers'] or ())
+            + len(self.response_headers)
+        )
+
+
 class HttpToolsProtocol(asyncio.Protocol):
     def __init__(self, config, server_state, _loop=None):
         if not config.loaded:
@@ -50,6 +220,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.logger = logging.getLogger("uvicorn.error")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
+        self.gunicorn_log = config.gunicorn_log
         self.parser = httptools.HttpRequestParser(self)
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
@@ -203,6 +374,11 @@ class HttpToolsProtocol(asyncio.Protocol):
             "raw_path": raw_path,
             "query_string": parsed_url.query if parsed_url.query else b"",
             "headers": self.headers,
+            "extensions": {
+                "uvicorn_request_duration": {
+                    "request_start_time": time.monotonic(),
+                }
+            },
         }
 
     def on_header(self, name: bytes, value: bytes):
@@ -237,6 +413,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             logger=self.logger,
             access_logger=self.access_logger,
             access_log=self.access_log,
+            gunicorn_log=self.gunicorn_log,
             default_headers=self.default_headers,
             message_event=asyncio.Event(),
             expect_100_continue=self.expect_100_continue,
@@ -330,6 +507,7 @@ class RequestResponseCycle:
         logger,
         access_logger,
         access_log,
+        gunicorn_log,
         default_headers,
         message_event,
         expect_100_continue,
@@ -342,6 +520,7 @@ class RequestResponseCycle:
         self.logger = logger
         self.access_logger = access_logger
         self.access_log = access_log
+        self.gunicorn_log = gunicorn_log
         self.default_headers = default_headers
         self.message_event = message_event
         self.on_response = on_response
@@ -360,6 +539,12 @@ class RequestResponseCycle:
         self.response_complete = False
         self.chunked_encoding = None
         self.expected_content_length = 0
+
+        # For logging.
+        if self.gunicorn_log:
+            self.gunicorn_atoms = GunicornSafeAtoms(self.scope)
+        else:
+            self.gunicorn_atoms = None
 
     # ASGI exception wrapper
     async def run_asgi(self, app):
@@ -407,6 +592,9 @@ class RequestResponseCycle:
     async def send(self, message):
         message_type = message["type"]
 
+        if self.gunicorn_atoms is not None:
+            self.gunicorn_atoms.on_asgi_message(message)
+
         if self.flow.write_paused and not self.disconnected:
             await self.flow.drain()
 
@@ -428,7 +616,7 @@ class RequestResponseCycle:
             if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
 
-            if self.access_log:
+            if self.access_log and not self.gunicorn_log:
                 self.access_logger.info(
                     '%s - "%s %s HTTP/%s" %d',
                     get_client_addr(self.scope),
@@ -503,6 +691,19 @@ class RequestResponseCycle:
                 if self.expected_content_length != 0:
                     raise RuntimeError("Response content shorter than Content-Length")
                 self.response_complete = True
+                duration_extension = self.scope['extensions']['uvicorn_request_duration']
+                duration_extension['response_end_time'] = time.monotonic()
+
+                if self.gunicorn_log:
+                    try:
+                        self.gunicorn_log.access_log.info(
+                            self.gunicorn_log.cfg.access_log_format,
+                            self.gunicorn_atoms,
+                        )
+                    except:
+                        import traceback
+                        self.gunicorn_log.error(traceback.format_exc())
+
                 self.message_event.set()
                 if not self.keep_alive:
                     self.transport.close()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -252,7 +252,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             keep_alive=http_version != "1.0",
             on_response=self.on_response_complete,
         )
-        self.cycle.timing.request_start_time = self.request_start_time
+        self.cycle.timing._request_start_time = self.request_start_time
         if existing_cycle is None or existing_cycle.response_complete:
             # Standard case - start processing the request.
             task = self.loop.create_task(self.cycle.run_asgi(app))

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -9,7 +9,7 @@ from collections import deque
 
 import httptools
 
-from uvicorn.logging import TRACE_LOG_LEVEL, GunicornSafeAtoms
+from uvicorn.logging import TRACE_LOG_LEVEL, AccessLogFields
 from uvicorn.protocols.http.flow_control import (
     CLOSE_HEADER,
     HIGH_WATER_LIMIT,
@@ -53,7 +53,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.logger = logging.getLogger("uvicorn.error")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
-        self.gunicorn_log = config.gunicorn_log
+        self.access_log_format = config.access_log_format
         self.parser = httptools.HttpRequestParser(self)
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
@@ -245,7 +245,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             logger=self.logger,
             access_logger=self.access_logger,
             access_log=self.access_log,
-            gunicorn_log=self.gunicorn_log,
+            access_log_format=self.access_log_format,
             default_headers=self.default_headers,
             message_event=asyncio.Event(),
             expect_100_continue=self.expect_100_continue,
@@ -341,7 +341,7 @@ class RequestResponseCycle:
         logger,
         access_logger,
         access_log,
-        gunicorn_log,
+        access_log_format,
         default_headers,
         message_event,
         expect_100_continue,
@@ -354,7 +354,7 @@ class RequestResponseCycle:
         self.logger = logger
         self.access_logger = access_logger
         self.access_log = access_log
-        self.gunicorn_log = gunicorn_log
+        self.access_log_format = access_log_format
         self.default_headers = default_headers
         self.message_event = message_event
         self.on_response = on_response
@@ -376,10 +376,7 @@ class RequestResponseCycle:
         self.timing = RequestResponseTiming()
 
         # For logging.
-        if self.gunicorn_log:
-            self.gunicorn_atoms = GunicornSafeAtoms(self.scope, self.timing)
-        else:
-            self.gunicorn_atoms = None
+        self.access_log_fields = AccessLogFields(self.scope, self.timing)
 
     # ASGI exception wrapper
     async def run_asgi(self, app):
@@ -433,8 +430,7 @@ class RequestResponseCycle:
         if self.disconnected:
             return
 
-        if self.gunicorn_atoms is not None:
-            self.gunicorn_atoms.on_asgi_message(message)
+        self.access_log_fields.on_asgi_message(message)
 
         if not self.response_started:
             # Sending response status line and headers
@@ -451,16 +447,6 @@ class RequestResponseCycle:
 
             if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
-
-            if self.access_log and self.gunicorn_log is None:
-                self.access_logger.info(
-                    '%s - "%s %s HTTP/%s" %d',
-                    get_client_addr(self.scope),
-                    self.scope["method"],
-                    get_path_with_query_string(self.scope),
-                    self.scope["http_version"],
-                    status_code,
-                )
 
             # Write response status line and headers
             content = [STATUS_LINE[status_code]]
@@ -529,16 +515,27 @@ class RequestResponseCycle:
                 self.response_complete = True
                 self.timing.response_ended()
 
-                if self.gunicorn_log is not None:
-                    try:
-                        self.gunicorn_log.access_log.info(
-                            self.gunicorn_log.cfg.access_log_format,
-                            self.gunicorn_atoms,
-                        )
-                    except:  # noqa
-                        self.gunicorn_log.error(traceback.format_exc())
-
                 self.message_event.set()
+
+                if self.access_log:
+                    if self.access_log_format is None:
+                        self.access_logger.info(
+                            '%s - "%s %s HTTP/%s" %d',
+                            get_client_addr(self.scope),
+                            self.scope["method"],
+                            get_path_with_query_string(self.scope),
+                            self.scope["http_version"],
+                            self.access_log_fields.status_code,
+                        )
+                    else:
+                        try:
+                            self.access_logger.info(
+                                self.access_log_format,
+                                self.access_log_fields,
+                            )
+                        except:  # noqa
+                            self.logger.error(traceback.format_exc())
+
                 if not self.keep_alive:
                     self.transport.close()
                 self.on_response()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -3,13 +3,14 @@ import http
 import logging
 import re
 import time
+import traceback
 import urllib
 from collections import abc, deque
 from os import getpid
 
 import httptools
 
-from uvicorn.logging import TRACE_LOG_LEVEL
+from uvicorn.logging import TRACE_LOG_LEVEL, GunicornSafeAtoms
 from uvicorn.protocols.http.flow_control import (
     CLOSE_HEADER,
     HIGH_WATER_LIMIT,
@@ -39,174 +40,6 @@ def _get_status_line(status_code):
 STATUS_LINE = {
     status_code: _get_status_line(status_code) for status_code in range(100, 600)
 }
-
-
-class GunicornSafeAtoms(abc.Mapping):
-    def __init__(self, scope):
-        self.scope = scope
-        self.status_code = None
-        self.response_headers = {}
-        self.response_length = 0
-
-        self._request_headers = None
-
-    @property
-    def request_headers(self):
-        if self._request_headers is None:
-            self._request_headers = dict(self.scope['headers'])
-        return self._request_headers
-
-    @property
-    def duration(self):
-        duration_extension = self.scope['extensions']['uvicorn_request_duration']
-        d = duration_extension['response_end_time'] - duration_extension['request_start_time']
-        return d
-
-    def on_asgi_message(self, message):
-        if message['type'] == 'http.response.start':
-            self.status_code = message['status']
-            self.response_headers = dict(message['headers'])
-        elif message['type'] == 'http.response.body':
-            self.response_length += len(message.get('body', ''))
-
-    def _request_header(self, key):
-        return self.request_headers.get(key.lower())
-
-    def _response_header(self, key):
-        return self.response_headers.get(key.lower())
-
-    def _wsgi_environ_variable(self, key):
-        # FIXME: provide fallbacks to access WSGI environ (at least the
-        # required variables).
-        return None
-
-    def __getitem__(self, key):
-        if key in self.HANDLERS:
-            retval = self.HANDLERS[key](self)
-        elif key.startswith('{'):
-            if key.endswith('}i'):
-                retval = self._request_header(key[1:-2])
-            elif key.endswith('}o'):
-                retval = self._response_header(key[1:-2])
-            elif key.endswith('}e'):
-                retval = self._wsgi_environ_variable(key[1:-2])
-            else:
-                retval = None
-        else:
-            retval = None
-
-        if retval is None:
-            return '-'
-        if isinstance(retval, str):
-            return retval.replace('"', '\\"')
-        return retval
-
-    HANDLERS = {}
-
-    def _register_handler(key, handlers=HANDLERS):
-        def decorator(fn):
-            handlers[key] = fn
-            return fn
-        return decorator
-
-    @_register_handler('h')
-    def _remote_address(self, *args, **kwargs):
-        return self.scope['client'][0]
-
-    @_register_handler('l')
-    def _dash(self, *args, **kwargs):
-        return '-'
-
-    @_register_handler('u')
-    def _user_name(self, *args, **kwargs):
-        pass
-
-    @_register_handler('t')
-    def date_of_the_request(self, *args, **kwargs):
-        """Date and time in Apache Common Log Format"""
-        return time.strftime('[%d/%b/%Y:%H:%M:%S %z]')
-
-    @_register_handler('r')
-    def status_line(self, *args, **kwargs):
-        full_raw_path = (self.scope['raw_path'] + self.scope['query_string'])
-        full_path = full_raw_path.decode('ascii')
-        return '{method} {full_path} HTTP/{http_version}'.format(
-            full_path=full_path, **self.scope
-        )
-
-    @_register_handler('m')
-    def request_method(self, *args, **kwargs):
-        return self.scope['method']
-
-    @_register_handler('U')
-    def url_path(self, *args, **kwargs):
-        return self.scope['raw_path'].decode('ascii')
-
-    @_register_handler('q')
-    def query_string(self, *args, **kwargs):
-        return self.scope['query_string'].decode('ascii')
-
-    @_register_handler('H')
-    def protocol(self, *args, **kwargs):
-        return 'HTTP/%s' % self.scope['http_version']
-
-    @_register_handler('s')
-    def status(self, *args, **kwargs):
-        return self.status_code or '-'
-
-    @_register_handler('B')
-    def response_length(self, *args, **kwargs):
-        return self.response_length
-
-    @_register_handler('b')
-    def response_length_or_dash(self, *args, **kwargs):
-        return self.response_length or '-'
-
-    @_register_handler('f')
-    def referer(self, *args, **kwargs):
-        val = self.request_headers.get(b'referer')
-        if val is None:
-            return None
-        return val.decode('ascii')
-
-    @_register_handler('a')
-    def user_agent(self, *args, **kwargs):
-        val = self.request_headers.get(b'user-agent')
-        if val is None:
-            return None
-        return val.decode('ascii')
-
-    @_register_handler('T')
-    def request_time_seconds(self, *args, **kwargs):
-        return int(self.duration)
-
-    @_register_handler('D')
-    def request_time_microseconds(self, *args, **kwargs):
-        return int(self.duration * 1_000_000)
-
-    @_register_handler('L')
-    def request_time_decimal_seconds(self, *args, **kwargs):
-        return "%.6f" % self.duration
-
-    @_register_handler('p')
-    def process_id(self, *args, **kwargs):
-        return "<%s>" % getpid()
-
-    def __iter__(self):
-        # FIXME: add WSGI environ
-        yield from self.HANDLERS
-        for k, _ in self.scope['headers']:
-            yield '{%s}i' % k.lower()
-        for k in self.response_headers:
-            yield '{%s}o' % k.lower()
-
-    def __len__(self):
-        # FIXME: add WSGI environ
-        return (
-            len(self.HANDLERS)
-            + len(self.scope['headers'] or ())
-            + len(self.response_headers)
-        )
 
 
 class HttpToolsProtocol(asyncio.Protocol):

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -56,6 +56,11 @@ def get_path_with_query_string(scope: WWWScope) -> str:
 
 
 class RequestResponseTiming:
+    # XXX: switch to "time.perf_counter" because apparently on windows
+    # time.monotonis is using GetTickCount64 which has ~15ms resolution (it
+    # caused problems in tests on windows)
+    #
+    # ref: https://github.com/python-trio/trio/issues/33#issue-202432431
     def __init__(self) -> None:
         self._request_start_time: Optional[float] = None
         self._request_end_time: Optional[float] = None

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -56,29 +56,53 @@ def get_path_with_query_string(scope: WWWScope) -> str:
 
 
 class RequestResponseTiming:
-    def __init__(self):
-        self.request_start_time: Optional[int] = None
-        self.request_end_time: Optional[int] = None
-        self.response_start_time: Optional[int] = None
-        self.response_end_time: Optional[int] = None
+    def __init__(self) -> None:
+        self._request_start_time: Optional[float] = None
+        self._request_end_time: Optional[float] = None
+        self._response_start_time: Optional[float] = None
+        self._response_end_time: Optional[float] = None
 
-    def request_started(self):
-        self.request_start_time = time.monotonic()
+    def request_started(self) -> None:
+        self._request_start_time = time.monotonic()
 
-    def request_ended(self):
-        self.request_end_time = time.monotonic()
+    @property
+    def request_start_time(self) -> float:
+        if self._request_start_time is None:
+            raise ValueError("request_started() was not called")
+        return self._request_start_time
 
-    def response_started(self):
-        self.response_start_time = time.monotonic()
+    def request_ended(self) -> None:
+        self._request_end_time = time.monotonic()
 
-    def response_ended(self):
-        self.response_end_time = time.monotonic()
+    @property
+    def request_end_time(self) -> float:
+        if self._request_end_time is None:
+            raise ValueError("request_ended() was not called")
+        return self._request_end_time
 
-    def request_duration_seconds(self):
+    def response_started(self) -> None:
+        self._response_start_time = time.monotonic()
+
+    @property
+    def response_start_time(self) -> float:
+        if self._response_start_time is None:
+            raise ValueError("response_started() was not called")
+        return self._response_start_time
+
+    def response_ended(self) -> None:
+        self._response_end_time = time.monotonic()
+
+    @property
+    def response_end_time(self) -> float:
+        if self._response_end_time is None:
+            raise ValueError("response_ended() was not called")
+        return self._response_end_time
+
+    def request_duration_seconds(self) -> float:
         return self.request_end_time - self.request_start_time
 
-    def response_duration_seconds(self):
+    def response_duration_seconds(self) -> float:
         return self.response_end_time - self.response_start_time
 
-    def total_duration_seconds(self):
+    def total_duration_seconds(self) -> float:
         return self.response_end_time - self.request_start_time

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import urllib.parse
 from typing import Optional, Tuple
 
@@ -52,3 +53,32 @@ def get_path_with_query_string(scope: WWWScope) -> str:
             path_with_query_string, scope["query_string"].decode("ascii")
         )
     return path_with_query_string
+
+
+class RequestResponseTiming:
+    def __init__(self):
+        self.request_start_time: Optional[int] = None
+        self.request_end_time: Optional[int] = None
+        self.response_start_time: Optional[int] = None
+        self.response_end_time: Optional[int] = None
+
+    def request_started(self):
+        self.request_start_time = time.monotonic()
+
+    def request_ended(self):
+        self.request_end_time = time.monotonic()
+
+    def response_started(self):
+        self.response_start_time = time.monotonic()
+
+    def response_ended(self):
+        self.response_end_time = time.monotonic()
+
+    def request_duration_seconds(self):
+        return self.request_end_time - self.request_start_time
+
+    def response_duration_seconds(self):
+        return self.response_end_time - self.response_start_time
+
+    def total_duration_seconds(self):
+        return self.response_end_time - self.request_start_time

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -40,7 +40,7 @@ class UvicornWorker(Worker):
             "callback_notify": self.callback_notify,
             "limit_max_requests": self.max_requests,
             "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
-            'gunicorn_log': self.log,
+            "gunicorn_log": self.log,
         }
 
         if self.cfg.is_ssl:

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -40,7 +40,7 @@ class UvicornWorker(Worker):
             "callback_notify": self.callback_notify,
             "limit_max_requests": self.max_requests,
             "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
-            "gunicorn_log": self.log,
+            "access_log_format": self.log.cfg.access_log_format,
         }
 
         if self.cfg.is_ssl:

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -40,6 +40,7 @@ class UvicornWorker(Worker):
             "callback_notify": self.callback_notify,
             "limit_max_requests": self.max_requests,
             "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
+            'gunicorn_log': self.log,
         }
 
         if self.cfg.is_ssl:


### PR DESCRIPTION
This PR a very naïve and straightforward implementation of gunicorn access log format, which is currently ignored by uvicorn (see #527).

One notable omission is the WSGI variables: they should be rather straightforward to add, but I think it is important to agree on the approach first. And the approach goes as follows:

It puts the gunicorn log object all the way through to the `RequestResponseCycle`, and it unrolls `gunicorn_log.access` function

https://github.com/benoitc/gunicorn/blob/master/gunicorn/glogging.py#L331-L351

so that it is not necessary to recreate all the gunicorn primitives, like `gunicorn.http.wsgi.Response` and `gunicorn.http.message.Request`. 

The timing is implemented via `time.monotonic` so that it works well w.r.t. DST transitions and leap seconds. The timing values are added to the asgi scope. And obviously, to be able to measure the timing, the logging had to be moved to the end of response processing. 

~~Default uvicorn logging is kept intact to minimize the scope of this PR, and is only disabled when `gunicorn_log` is passed by gunicorn worker classes to avoid duplication.~~

`GunicornSafeAtoms` does several things:

- it provides the values for gunicorn log formatter in the most performant way I could imagine
- it aggregates response body size from ASGI messages
- and it does what [gunicorn.glogging.SafeAtoms](https://github.com/benoitc/gunicorn/blob/master/gunicorn/glogging.py#L97-L117]) does to provide fallbacks for missing values

Edit by @Kludex : closes #773, closes #527 