### PR TITLE
fix: pin uvloop to the lastest Python 3.6 supported version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,12 @@ minimal_requirements = [
     "typing-extensions;" + env_marker_below_38,
 ]
 
+
 extra_requirements = [
     "websockets==8.*",
     "httptools==0.1.* ;" + env_marker_cpython,
-    "uvloop==0.14.0;" + env_marker_cpython,
+    "uvloop==0.14.0; python_version == '3.6' and " + env_marker_cpython,
+    "uvloop>=0.14.0; python_version >= '3.7' and " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",
     "python-dotenv>=0.13",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ minimal_requirements = [
 extra_requirements = [
     "websockets==8.*",
     "httptools==0.1.* ;" + env_marker_cpython,
-    "uvloop>=0.14.0 ;" + env_marker_cpython,
+    "uvloop==0.14.0;" + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",
     "python-dotenv>=0.13",


### PR DESCRIPTION
Latest uvloop release (0.15.0) doesn't support Python 3.6 anymore. I don't know what decision `uvicorn` is going to take, but maybe before a deciison is made, we can pin uvloop 0.14.0. 

Alternatives:
- Uvicorn follows uvloop and stop supporting 3.6.