### PR TITLE
unpin uvloop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,7 @@ minimal_requirements = [
 extra_requirements = [
     "websockets==8.*",
     "httptools==0.1.* ;" + env_marker_cpython,
-    "uvloop==0.14.0; python_version == '3.6' and " + env_marker_cpython,
-    "uvloop>=0.14.0; python_version >= '3.7' and " + env_marker_cpython,
+    "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",
     "python-dotenv>=0.13",


### PR DESCRIPTION
Now that uvloop sets python_requires the pinning isn't needed, but we do need to
ignore the packages with missing python_requires

https://github.com/MagicStack/uvloop/pull/401