### PR TITLE
MessageLoggerMiddleware sometimes fails to return and hangs

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -368,7 +368,7 @@ async def test_asgi_return_value(protocol_cls):
         async with websockets.connect(url) as websocket:
             _ = await websocket.recv()
 
-    config = Config(app=app, ws=protocol_cls, lifespan="off")
+    config = Config(app=app, ws=protocol_cls, lifespan="off", log_level="trace")
     async with run_server(config):
         with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
             await connect("ws://127.0.0.1:8000")

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -58,7 +58,7 @@ class MessageLoggerMiddleware:
         log_text = "%s [%d] Started scope=%s"
         self.logger.trace(log_text, prefix, task_counter, logged_scope)
         try:
-            await self.app(scope, inner_receive, inner_send)
+            r = await self.app(scope, inner_receive, inner_send)
         except BaseException as exc:
             log_text = "%s [%d] Raised exception"
             self.logger.trace(log_text, prefix, task_counter)
@@ -66,3 +66,5 @@ class MessageLoggerMiddleware:
         else:
             log_text = "%s [%d] Completed"
             self.logger.trace(log_text, prefix, task_counter)
+            return r
+

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -67,4 +67,3 @@ class MessageLoggerMiddleware:
             log_text = "%s [%d] Completed"
             self.logger.trace(log_text, prefix, task_counter)
             return r
-


### PR DESCRIPTION
I discovered that accidentally playing rough with the test suite on trying to fix stuff for https://github.com/encode/uvicorn/pull/929

The 1st commit of this PR demonstrate the issue, if you just add `log_level="trace"` in the config in that test it hangs forever, for good reason since the middleware never returns.
