### PR TITLE
Prevent garbage collection of main lifespan task

### DIFF
--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -27,7 +27,9 @@ class LifespanOn:
         self.logger.info("Waiting for application startup.")
 
         loop = asyncio.get_event_loop()
-        loop.create_task(self.main())
+        main_lifespan_task = loop.create_task(self.main())  # noqa: F841
+        # Keep a hard reference to prevent garbage collection
+        # See https://github.com/encode/uvicorn/pull/972
 
         await self.receive_queue.put({"type": "lifespan.startup"})
         await self.startup_event.wait()


### PR DESCRIPTION
This maintains a reference to the created task in the lifespan to fix some subtle bugs that arise from the entire app being garbage collected due to no references of the running coroutine being kept.

TL;DR:
 - `asyncio.create_task(foo())` = bad
 - `task = asyncio.create_task(foo())` = good

This bug can be illustrated with a relatively simple app using `aioredis` (I could probably find an example without aioredis, but this example should suffice):

```python3
import aioredis
pool = None

async def app(scope, receive, send):
    global pool
    if scope['type'] == 'lifespan':
        message = await receive()  # On startup
        pool = await aioredis.create_redis_pool('redis://localhost:6379')
        await send({"type": "lifespan.startup.complete"})
        message = await receive()  # Wait until shutdown
    else:
        await pool.ping()  # (Use pool during requests)
```

When running this with `uvicorn example:app` it seems like everything works (the app starts up correctly), but if we force garbage collection on a specific line within the event loop, we consistently encounter the following error:

```
Task was destroyed but it is pending!
task: <Task pending name='Task-3' coro=<RedisConnection._read_data() running at .../site-packages/aioredis/connection.py:186> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7fb4af031f70>()]> cb=[RedisConnection.__init__.<locals>.<lambda>() at .../site-packages/aioredis/connection.py:168]>
Task was destroyed but it is pending!
task: <Task pending name='Task-2' coro=<LifespanOn.main() running at .../site-packages/uvicorn/lifespan/on.py:55> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7fb4aefbf070>()]>>
```

While a bit hacky, to debug we can force this garbage collection in the event loop as follows:

 - Edit `/usr/lib/python3.*/asyncio/base_events.py` and within `def _run_once`, near the bottom immediately within the `for i in range(ntodo):`, add `import gc; gc.collect()`.
 - Force Uvicorn to use the `asyncio` event loop so that it uses this modified code by running with: `uvicorn example:app --loop asyncio`

After this change, every execution of `uvicorn` should result in the error shown above.

If we apply the changes from this PR we can see this will no longer error.

Note, this was initially discovered and [reported within aioredis](https://github.com/aio-libs/aioredis/issues/878). However, I've since realized that the error lied in the uvicorn code that ran above it.