### PR TITLE
Fix mkdocs syntax highlight

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,8 @@ nav:
     - Server Behavior: 'server-behavior.md'
 
 markdown_extensions:
-  - markdown.extensions.codehilite:
+  - codehilite:
+      css_class: highlight
       guess_lang: false
   - toc:
       permalink: true


### PR DESCRIPTION
Should be an easy one, same as https://github.com/encode/httpx/commit/06559f8266f52a8ce86842d5068e2ba3855a3f6a