### PR TITLE
Fix socket port 0 error

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -187,7 +187,7 @@ class Server:
 
             port = config.port
             if port == 0:
-                port = listeners[0].getpeername()[1]
+                port = listeners[0].getsockname()[1]
 
             protocol_name = "https" if config.ssl else "http"
             message = f"Uvicorn running on {addr_format} (Press CTRL+C to quit)"


### PR DESCRIPTION
Fixes  #974 from possibly a typo introduced in https://github.com/encode/uvicorn/pull/930/files#diff-716652db9a2feab62038753117d5e4fd4294f213f4c7f2edcb47b5788e5209f6L158-R190

I wanted to write a test, natural place seemed to be in https://github.com/encode/uvicorn/blob/83303ffe492e95fd60b9ec07a5b9c8de88a86e34/tests/test_main.py#L29-L43

unfortunately I can see now way of getting the random assigned port (or the server socket for the same purpose) when we pass a port=0 after it has been created.
do you have an idea @florimondmanca  ?