### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@
 
 # Explicit optionals
 wsproto==1.0.*
+httptools==0.1.*
+uvloop==0.15.*; python_version >= '3.7'
+
 
 # Packaging
 twine


### PR DESCRIPTION
We need some requirements. Maybe it's not full list of requirements, but I missed only this two.

`httptools` is used in following code:
https://github.com/encode/uvicorn/blob/d5d62d49cb0ab1a46a4704d5f489ad1964e18747/uvicorn/protocols/http/httptools_impl.py#L7

`uvloop` is used in following code:
https://github.com/encode/uvicorn/blob/d5d62d49cb0ab1a46a4704d5f489ad1964e18747/uvicorn/loops/uvloop.py#L3