### PR TITLE
Force reload_dirs to be a list

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,11 @@ def test_config_should_reload_is_set(app, expected_should_reload):
     assert config_reload.should_reload is expected_should_reload
 
 
+def test_reload_dir_is_set():
+    config = Config(app=asgi_app, reload=True, reload_dirs="reload_me")
+    assert config.reload_dirs == ["reload_me"]
+
+
 def test_wsgi_app():
     config = Config(app=wsgi_app, interface="wsgi", proxy_headers=False)
     config.load()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -201,7 +201,7 @@ class Config:
             self.reload_dirs = [os.getcwd()]
         else:
             if isinstance(reload_dirs, str):
-               self.reload_dirs = [reload_dirs]
+                self.reload_dirs = [reload_dirs]
             else:
                 self.reload_dirs = reload_dirs
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -200,7 +200,10 @@ class Config:
         if reload_dirs is None:
             self.reload_dirs = [os.getcwd()]
         else:
-            self.reload_dirs = reload_dirs
+            if isinstance(reload_dirs, str):
+               self.reload_dirs = [reload_dirs]
+            else:
+                self.reload_dirs = reload_dirs
 
         if env_file is not None:
             from dotenv import load_dotenv


### PR DESCRIPTION
Fixes #976 
If the user runs programmatically uvicorn he can do a:      ` uvicorn.run(.....,reload_dirs="/home/maxou/dev/proj")`
OP suggested we complain about that not being a list, I'd prefer we do it directly for him.
I added a test too
That kind of stuff makes me thing we should mypy the project, but this is another story