### PR TITLE
tests: add ssl coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def tls_certificate_authority() -> trustme.CA:
 
 
 @pytest.fixture
-def tls_certificate(tls_certificate_authority):
+def tls_certificate(tls_certificate_authority: trustme.CA) -> trustme.LeafCert:
     return tls_certificate_authority.issue_server_cert(
         "localhost",
         "127.0.0.1",
@@ -21,13 +21,13 @@ def tls_certificate(tls_certificate_authority):
 
 
 @pytest.fixture
-def tls_ca_certificate_pem_path(tls_certificate_authority):
+def tls_ca_certificate_pem_path(tls_certificate_authority: trustme.CA):
     with tls_certificate_authority.cert_pem.tempfile() as ca_cert_pem:
         yield ca_cert_pem
 
 
 @pytest.fixture
-def tls_ca_certificate_private_key_path(tls_certificate_authority):
+def tls_ca_certificate_private_key_path(tls_certificate_authority: trustme.CA):
     with tls_certificate_authority.private_key_pem.tempfile() as private_key:
         yield private_key
 
@@ -49,13 +49,13 @@ def tls_ca_certificate_private_key_encrypted_path(tls_certificate_authority):
 
 
 @pytest.fixture
-def tls_certificate_pem_path(tls_certificate):
+def tls_certificate_pem_path(tls_certificate: trustme.LeafCert):
     with tls_certificate.private_key_and_cert_chain_pem.tempfile() as cert_pem:
         yield cert_pem
 
 
 @pytest.fixture
-def tls_ca_ssl_context(tls_certificate):
+def tls_ca_ssl_context(tls_certificate: trustme.LeafCert) -> ssl.SSLContext:
     ssl_ctx = ssl.SSLContext()
     tls_certificate.configure_cert(ssl_ctx)
     return ssl_ctx

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -55,6 +55,7 @@ async def test_run_password(
         ssl_keyfile=tls_ca_certificate_private_key_encrypted_path,
         ssl_certfile=tls_ca_certificate_pem_path,
         ssl_keyfile_password="uvicorn password for the win",
+        ssl_ca_certs=tls_ca_certificate_pem_path,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -21,6 +21,7 @@ async def test_run(
         limit_max_requests=1,
         ssl_keyfile=tls_ca_certificate_private_key_path,
         ssl_certfile=tls_ca_certificate_pem_path,
+        ssl_ca_certs=tls_ca_certificate_pem_path,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
@@ -29,12 +30,15 @@ async def test_run(
 
 
 @pytest.mark.asyncio
-async def test_run_chain(tls_ca_ssl_context, tls_certificate_pem_path):
+async def test_run_chain(
+    tls_ca_ssl_context, tls_certificate_pem_path, tls_ca_certificate_pem_path
+):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_pem_path,
+        ssl_ca_certs=tls_ca_certificate_pem_path,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:


### PR DESCRIPTION
I'm 0% sure about this. Comments are welcome.

The intention here is to cover this line: https://github.com/encode/uvicorn/blob/d5d62d49cb0ab1a46a4704d5f489ad1964e18747/uvicorn/config.py#L112

The type hints on the conftest are a plus, I can remove them if you wish.