### PR TITLE
tests: ignore test on supervisors init file

### DIFF
--- a/uvicorn/supervisors/__init__.py
+++ b/uvicorn/supervisors/__init__.py
@@ -2,7 +2,7 @@ from uvicorn.supervisors.multiprocess import Multiprocess
 
 try:
     from uvicorn.supervisors.watchgodreload import WatchGodReload as ChangeReload
-except ImportError:
+except ImportError:  # pragma: no cover
     from uvicorn.supervisors.statreload import StatReload as ChangeReload
 
 __all__ = ["Multiprocess", "ChangeReload"]


### PR DESCRIPTION
Both classes are already being tested on `test_reload.py`. I don't feel the need to reach those lines in the tests, do you?

I'm accepting suggestions on how to test it if so :)