### PR TITLE
Send disconnect event on connection lost for `wsproto`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 97.85
+fail_under = 97.84
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 97.84
+fail_under = 97.82
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 97.79
+fail_under = 97.85
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -10,6 +10,7 @@ from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
 try:
     import websockets
+    import websockets.client
     import websockets.exceptions
     from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
 
@@ -64,7 +65,6 @@ async def test_invalid_upgrade(ws_protocol_cls, http_protocol_cls):
                     "connection": "upgrade",
                     "sec-webSocket-version": "11",
                 },
-                timeout=5,
             )
         if response.status_code == 426:
             # response.text == ""
@@ -515,6 +515,40 @@ async def test_client_close(ws_protocol_cls, http_protocol_cls):
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
     async with run_server(config):
         await websocket_session("ws://127.0.0.1:8000")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_client_connection_lost(ws_protocol_cls, http_protocol_cls):
+    got_disconnect_event = False
+
+    async def app(scope, receive, send):
+        nonlocal got_disconnect_event
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                print("accepted")
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+        got_disconnect_event = True
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=0.0,
+    )
+    async with run_server(config):
+        async with websockets.client.connect("ws://127.0.0.1:8000") as websocket:
+            websocket.transport.close()
+            await asyncio.sleep(0.1)
+            got_disconnect_event_before_shutdown = got_disconnect_event
+
+    assert got_disconnect_event_before_shutdown is True
 
 
 @pytest.mark.anyio

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -70,8 +70,7 @@ class WSProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection made", prefix)
 
     def connection_lost(self, exc):
-        if exc is not None:
-            self.queue.put_nowait({"type": "websocket.disconnect"})
+        self.queue.put_nowait({"type": "websocket.disconnect"})
         self.connections.remove(self)
 
         if self.logger.level <= TRACE_LOG_LEVEL:


### PR DESCRIPTION
Using uvicorn with wsproto implementation, if clients do not close websocket connections properly, no `exc` will be sent to `connection_lost` (see code below).

As in the current version of uvicorn, this creates two issues:
- apps will not receive `websocket.disconnect` events;
- a zombie `run_asgi` (asyncio) task running for each non properly closed connection;

In order to reproduce the issue, follow instructions on this repo: https://github.com/sephioh/uvicorn-wsproto-issue

Edit by @Kludex :
- Closes #997