### PR TITLE
Use `surrogateescape` to encode headers on `websockets` implementation

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -139,10 +139,13 @@ async def test_headers(protocol_cls):
             headers = self.scope.get("headers")
             headers = dict(headers)
             assert headers[b"host"].startswith(b"127.0.0.1")
+            assert headers[b"username"] == bytes("abraão", "utf-8")
             await self.send({"type": "websocket.accept"})
 
     async def open_connection(url):
-        async with websockets.connect(url) as websocket:
+        async with websockets.connect(
+            url, extra_headers=[("username", "abraão")]
+        ) as websocket:
             return websocket.open
 
     config = Config(app=App, ws=protocol_cls, lifespan="off")

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -99,7 +99,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             subprotocols.extend([token.strip() for token in header.split(",")])
 
         asgi_headers = [
-            (name.encode("ascii"), value.encode("ascii"))
+            (name.encode("ascii"), value.encode("ascii", errors="surrogateescape"))
             for name, value in headers.raw_items()
         ]
 


### PR DESCRIPTION
Currently, any non-ascii header value sent to uvicorn running with websockets implementation will raise a `UnicodeEncodeError`. 
As [websockets package represents non-ascii characters in headers using surrogate escapes](https://github.com/aaugustin/websockets/blob/3401751d4f1200d398c5e69f9c4a0ece862ff36b/src/websockets/legacy/http.py#L142), this PR makes websockets implementation to follow the same pattern when encoding them.

Edit by @Kludex:
- Closes #968