### PR TITLE
Added --reload-exclude-dir param

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,6 +39,9 @@ Options:
   --reload-dir TEXT               Set reload directories explicitly, instead
                                   of using the current working directory.
 
+  --reload-exclude-dir TEXT       Exclude directories from being watched by
+                                  auto-reloader.
+
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,6 +109,9 @@ Options:
   --reload-dir TEXT               Set reload directories explicitly, instead
                                   of using the current working directory.
 
+  --reload-exclude-dir TEXT       Exclude directories from being watched by
+                                  auto-reloader.
+
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -21,6 +21,8 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 
 * `--reload` - Enable auto-reload.
 * `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default all directories in current directory will be watched.
+* `--reload-exclude-dir <path>` - Specify which directories exclude from watching for python file changes. Can not be
+                                   used with **--reload-dir** at the same time. May be used multiple times. 
 
 ## Production
 

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -96,3 +96,20 @@ class TestBaseReload:
             assert self._reload_tester(reloader, app_ext_file)
 
             reloader.shutdown()
+
+    def test_should_not_reload_when_directories_excluded(self):
+        file = "excluded.py"
+
+        excluded_dir = self.tmp_path.joinpath("excluded")
+        excluded_dir.mkdir()
+        excluded_file = excluded_dir.joinpath(file)
+        excluded_file.touch()
+
+        with self.tmpdir.as_cwd():
+            config = Config(
+                app=None, reload=True, reload_exclude_dirs=[str(excluded_dir)]
+            )
+            reloader = self._setup_reloader(config)
+            assert not self._reload_tester(reloader, excluded_file)
+
+            reloader.shutdown()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,18 @@ def test_config_should_reload_is_set(app, expected_should_reload):
     assert config_reload.should_reload is expected_should_reload
 
 
+def test_can_not_use_both_exclude_and_reload_dir_params():
+    with pytest.raises(SystemExit) as exit_error:
+        Config(
+            app=None,
+            reload=True,
+            reload_dirs=["included/dir"],
+            reload_exclude_dirs=["excluded/dir"],
+        )
+
+    assert exit_error.value.code == 1
+
+
 def test_wsgi_app():
     config = Config(app=wsgi_app, interface="wsgi", proxy_headers=False)
     config.load()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -7,6 +7,7 @@ import os
 import socket
 import ssl
 import sys
+from pathlib import Path
 from typing import List, Tuple
 
 import click
@@ -136,6 +137,7 @@ class Config:
         debug=False,
         reload=False,
         reload_dirs=None,
+        reload_exclude_dirs=None,
         reload_delay=None,
         workers=None,
         proxy_headers=True,
@@ -197,9 +199,18 @@ class Config:
         self.loaded = False
         self.configure_logging()
 
-        if reload_dirs is None:
-            self.reload_dirs = [os.getcwd()]
-        else:
+        if reload_dirs is not None and reload_exclude_dirs is not None:
+            logger.error("Can not specify both --reload-dirs and --reload-exclude-dirs")
+            sys.exit(1)
+
+        self.reload_dirs = [os.getcwd()]
+        self.reload_exclude_dirs = []
+
+        if reload_exclude_dirs is not None:
+            self.reload_exclude_dirs = [
+                Path(directory).absolute() for directory in reload_exclude_dirs
+            ]
+        elif reload_dirs is not None:
             self.reload_dirs = reload_dirs
 
         if env_file is not None:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -78,6 +78,12 @@ def print_version(ctx, param, value):
     " directory.",
 )
 @click.option(
+    "--reload-exclude-dir",
+    "reload_exclude_dirs",
+    multiple=True,
+    help="Exclude directories from being watched by auto-reloader.",
+)
+@click.option(
     "--reload-delay",
     type=float,
     default=0.25,
@@ -294,6 +300,7 @@ def main(
     debug: bool,
     reload: bool,
     reload_dirs: typing.List[str],
+    reload_exclude_dirs: typing.List[str],
     reload_delay: float,
     workers: int,
     env_file: str,
@@ -339,6 +346,7 @@ def main(
         "debug": debug,
         "reload": reload,
         "reload_dirs": reload_dirs if reload_dirs else None,
+        "reload_exclude_dirs": reload_exclude_dirs if reload_exclude_dirs else None,
         "reload_delay": reload_delay,
         "workers": workers,
         "proxy_headers": proxy_headers,

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -36,6 +36,11 @@ class StatReload(BaseReload):
     def iter_py_files(self):
         for reload_dir in self.config.reload_dirs:
             for subdir, dirs, files in os.walk(reload_dir):
+                if (
+                    self.config.reload_exclude_dirs
+                    and Path(subdir).absolute() in self.config.reload_exclude_dirs
+                ):
+                    continue
                 for file in files:
                     if file.endswith(".py"):
                         yield subdir + os.sep + file


### PR DESCRIPTION
---
New CLI feature
---
New `--reload-exclude-dir` parameter for uvicorn-CLI allows to exclude folder from being watched by reloader. As a `--reload-dir` param, it can be specified multiple times. 
## Purpose
The idea was already described in #984. I would also mention, that WatchGod (which is used by default) reloads project even if changes were made not only to source code (Unlike Statreload). So when you have a folder with static files and user uploads image, the project gets reloaded. And adding lots of folders with param `--reload-dir`, instead of just excluding one folder, can be really annoying.

## Working mechanism
I thought, that idea of pattern matching is not the best. Also it would be better for both of reloaders to have same excluding mechanism. So, I just compare absolute paths of files. You can not specify both included and excluded folders. Also added a few tests for this param.