### PR TITLE
update httptools from 0.1.* to 0.2.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ minimal_requirements = [
 
 extra_requirements = [
     "websockets>=8.*",
-    "httptools==0.1.* ;" + env_marker_cpython,
+    "httptools==0.2.* ;" + env_marker_cpython,
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",


### PR DESCRIPTION
Httptools 0.2 replaces the underlying HTTP parser with llhttp as http-parser is
no longer actively maintained. See https://github.com/MagicStack/httptools/pull/56