### PR TITLE
add ws_max_size

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -55,6 +55,9 @@ Options:
                                   WebSocket protocol implementation.
                                   [default: auto]
 
+  --ws-max-size INTEGER           WebSocket max message size in bytes
+                                  [default: 1048576]
+
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --interface [auto|asgi3|asgi2|wsgi]
                                   Select ASGI3, ASGI2, or WSGI as the
@@ -273,7 +276,7 @@ http {
       root /path/to/app/static;
     }
   }
-  
+
   map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,6 +125,9 @@ Options:
                                   WebSocket protocol implementation.
                                   [default: auto]
 
+  --ws-max-size INTEGER           WebSocket max message size in bytes
+                                  [default: 1048576]
+
   --lifespan [auto|on|off]        Lifespan implementation.  [default: auto]
   --interface [auto|asgi3|asgi2|wsgi]
                                   Select ASGI3, ASGI2, or WSGI as the

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -40,6 +40,7 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 * `--loop <str>` - Set the event loop implementation. The uvloop implementation provides greater performance, but is not compatible with Windows or PyPy. **Options:** *'auto', 'asyncio', 'uvloop'.* **Default:** *'auto'*.
 * `--http <str>` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy, and requires compilation on Windows. **Options:** *'auto', 'h11', 'httptools'.* **Default:** *'auto'*.
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to deny all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
+* `--ws-max-size <int>` - Set the WebSocket max message size, in bytes. **Please note that this can be used only with the default `websockets` protocol**.
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.
 
 ## Application Interface

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -126,6 +126,7 @@ class Config:
         loop="auto",
         http="auto",
         ws="auto",
+        ws_max_size=2 ** 20,
         lifespan="auto",
         env_file=None,
         log_config=LOGGING_CONFIG,
@@ -165,6 +166,7 @@ class Config:
         self.loop = loop
         self.http = http
         self.ws = ws
+        self.ws_max_size = ws_max_size
         self.lifespan = lifespan
         self.log_config = log_config
         self.log_level = log_level

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -114,6 +114,13 @@ def print_version(ctx, param, value):
     show_default=True,
 )
 @click.option(
+    "--ws-max-size",
+    type=int,
+    default=2 ** 20,
+    help="WebSocket max message size in bytes",
+    show_default=True,
+)
+@click.option(
     "--lifespan",
     type=LIFESPAN_CHOICES,
     default="auto",
@@ -289,6 +296,7 @@ def main(
     loop: str,
     http: str,
     ws: str,
+    ws_max_size: int,
     lifespan: str,
     interface: str,
     debug: bool,
@@ -330,6 +338,7 @@ def main(
         "loop": loop,
         "http": http,
         "ws": ws,
+        "ws_max_size": ws_max_size,
         "lifespan": lifespan,
         "env_file": env_file,
         "log_config": LOGGING_CONFIG if log_config is None else log_config,

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -59,6 +59,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             ws_handler=self.ws_handler,
             ws_server=self.ws_server,
             extensions=[ServerPerMessageDeflateFactory()],
+            max_size=self.config.ws_max_size,
         )
 
     def connection_made(self, transport):


### PR DESCRIPTION
add `ws_max_size` flag for websocket messages max size. Default is same as before (websockets default).

I used @euri10 PR (https://github.com/encode/uvicorn/pull/538) as a reference.
Closes #306 