### PR TITLE
Update docs about reload_dirs

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -20,7 +20,7 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 ## Development
 
 * `--reload` - Enable auto-reload.
-* `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default all directories in current directory will be watched.
+* `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default all directories in current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.
 
 ## Production
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,7 +2,7 @@
 
 Use the following options to configure Uvicorn, when running from the command line.
 
-If you're running using programmatically, using `uvicorn.run(...)`, then use
+If you're running programmatically, using `uvicorn.run(...)`, then use
 equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=True, access_log=False)`.
 
 ## Application


### PR DESCRIPTION
It is confusing that the reload_dirs parameter when running programmatically, differs from the reload-dir when using CLI. So I think it would be good to document this.