### PR TITLE
Relax click version upper bound to 8.0

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,7 +45,7 @@ Options:
 
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
-                                  available, or 1. Not valid with --reload.
+                                  available. Not valid with --reload.
 
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
@@ -61,9 +61,7 @@ Options:
                                   application interface.  [default: auto]
 
   --env-file PATH                 Environment configuration file.
-  --log-config PATH               Logging configuration file. Supported
-                                  formats: .ini, .json, .yaml.
-
+  --log-config PATH               Logging configuration file.
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
@@ -97,7 +95,6 @@ Options:
 
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
-  --ssl-keyfile-password TEXT     SSL keyfile password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 2]
 
@@ -115,9 +112,6 @@ Options:
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
-
-  --factory                       Treat APP as an application factory, i.e. a
-                                  () -> <ASGI app> callable.  [default: False]
 
   --help                          Show this message and exit.
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,7 +115,7 @@ Options:
 
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
-                                  available, or 1. Not valid with --reload.
+                                  available. Not valid with --reload.
 
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
@@ -131,9 +131,7 @@ Options:
                                   application interface.  [default: auto]
 
   --env-file PATH                 Environment configuration file.
-  --log-config PATH               Logging configuration file. Supported
-                                  formats: .ini, .json, .yaml.
-
+  --log-config PATH               Logging configuration file.
   --log-level [critical|error|warning|info|debug|trace]
                                   Log level. [default: info]
   --access-log / --no-access-log  Enable/Disable access log.
@@ -167,7 +165,6 @@ Options:
 
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
-  --ssl-keyfile-password TEXT     SSL keyfile password
   --ssl-version INTEGER           SSL version to use (see stdlib ssl module's)
                                   [default: 2]
 
@@ -185,9 +182,6 @@ Options:
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
-
-  --factory                       Treat APP as an application factory, i.e. a
-                                  () -> <ASGI app> callable.  [default: False]
 
   --help                          Show this message and exit.
 ```

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
-    "click==8.*",
+    "click>=7.*",
     "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
-    "click==7.*",
+    "click==8.*",
     "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,
 ]


### PR DESCRIPTION
Requested in https://github.com/encode/uvicorn/issues/1016

Click 8.0 has security patches