### PR TITLE
Moved FlowControl class and globals to its own file in uvicorn/protocols/http/

### DIFF
--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,0 +1,54 @@
+import asyncio
+
+
+CLOSE_HEADER = (b"connection", b"close")
+
+HIGH_WATER_LIMIT = 65536
+
+TRACE_LOG_LEVEL = 5
+
+
+class FlowControl:
+    def __init__(self, transport):
+        self._transport = transport
+        self.read_paused = False
+        self.write_paused = False
+        self._is_writable_event = asyncio.Event()
+        self._is_writable_event.set()
+
+    async def drain(self):
+        await self._is_writable_event.wait()
+
+    def pause_reading(self):
+        if not self.read_paused:
+            self.read_paused = True
+            self._transport.pause_reading()
+
+    def resume_reading(self):
+        if self.read_paused:
+            self.read_paused = False
+            self._transport.resume_reading()
+
+    def pause_writing(self):
+        if not self.write_paused:
+            self.write_paused = True
+            self._is_writable_event.clear()
+
+    def resume_writing(self):
+        if self.write_paused:
+            self.write_paused = False
+            self._is_writable_event.set()
+
+
+async def service_unavailable(scope, receive, send):
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 503,
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"connection", b"close"),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": b"Service Unavailable"})

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,6 +1,5 @@
 import asyncio
 
-
 CLOSE_HEADER = (b"connection", b"close")
 
 HIGH_WATER_LIMIT = 65536

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -4,14 +4,14 @@ import logging
 from urllib.parse import unquote
 
 import h11
-from flow_control import (
+
+from uvicorn.protocols.http.flow_control import (
     CLOSE_HEADER,
     HIGH_WATER_LIMIT,
     TRACE_LOG_LEVEL,
     FlowControl,
     service_unavailable,
 )
-
 from uvicorn.protocols.utils import (
     get_client_addr,
     get_local_addr,

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -4,6 +4,13 @@ import logging
 from urllib.parse import unquote
 
 import h11
+from flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    TRACE_LOG_LEVEL,
+    FlowControl,
+    service_unavailable,
+)
 
 from uvicorn.protocols.utils import (
     get_client_addr,
@@ -24,58 +31,6 @@ def _get_status_phrase(status_code):
 STATUS_PHRASES = {
     status_code: _get_status_phrase(status_code) for status_code in range(100, 600)
 }
-
-CLOSE_HEADER = (b"connection", b"close")
-
-HIGH_WATER_LIMIT = 65536
-
-TRACE_LOG_LEVEL = 5
-
-
-class FlowControl:
-    def __init__(self, transport):
-        self._transport = transport
-        self.read_paused = False
-        self.write_paused = False
-        self._is_writable_event = asyncio.Event()
-        self._is_writable_event.set()
-
-    async def drain(self):
-        await self._is_writable_event.wait()
-
-    def pause_reading(self):
-        if not self.read_paused:
-            self.read_paused = True
-            self._transport.pause_reading()
-
-    def resume_reading(self):
-        if self.read_paused:
-            self.read_paused = False
-            self._transport.resume_reading()
-
-    def pause_writing(self):
-        if not self.write_paused:
-            self.write_paused = True
-            self._is_writable_event.clear()
-
-    def resume_writing(self):
-        if self.write_paused:
-            self.write_paused = False
-            self._is_writable_event.set()
-
-
-async def service_unavailable(scope, receive, send):
-    await send(
-        {
-            "type": "http.response.start",
-            "status": 503,
-            "headers": [
-                (b"content-type", b"text/plain; charset=utf-8"),
-                (b"connection", b"close"),
-            ],
-        }
-    )
-    await send({"type": "http.response.body", "body": b"Service Unavailable"})
 
 
 class H11Protocol(asyncio.Protocol):

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -5,14 +5,14 @@ import re
 import urllib
 
 import httptools
-from flow_control import (
+
+from uvicorn.protocols.http.flow_control import (
     CLOSE_HEADER,
     HIGH_WATER_LIMIT,
     TRACE_LOG_LEVEL,
     FlowControl,
     service_unavailable,
 )
-
 from uvicorn.protocols.utils import (
     get_client_addr,
     get_local_addr,

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -5,6 +5,13 @@ import re
 import urllib
 
 import httptools
+from flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    TRACE_LOG_LEVEL,
+    FlowControl,
+    service_unavailable,
+)
 
 from uvicorn.protocols.utils import (
     get_client_addr,
@@ -29,58 +36,6 @@ def _get_status_line(status_code):
 STATUS_LINE = {
     status_code: _get_status_line(status_code) for status_code in range(100, 600)
 }
-
-CLOSE_HEADER = (b"connection", b"close")
-
-HIGH_WATER_LIMIT = 65536
-
-TRACE_LOG_LEVEL = 5
-
-
-class FlowControl:
-    def __init__(self, transport):
-        self._transport = transport
-        self.read_paused = False
-        self.write_paused = False
-        self._is_writable_event = asyncio.Event()
-        self._is_writable_event.set()
-
-    async def drain(self):
-        await self._is_writable_event.wait()
-
-    def pause_reading(self):
-        if not self.read_paused:
-            self.read_paused = True
-            self._transport.pause_reading()
-
-    def resume_reading(self):
-        if self.read_paused:
-            self.read_paused = False
-            self._transport.resume_reading()
-
-    def pause_writing(self):
-        if not self.write_paused:
-            self.write_paused = True
-            self._is_writable_event.clear()
-
-    def resume_writing(self):
-        if self.write_paused:
-            self.write_paused = False
-            self._is_writable_event.set()
-
-
-async def service_unavailable(scope, receive, send):
-    await send(
-        {
-            "type": "http.response.start",
-            "status": 503,
-            "headers": [
-                (b"content-type", b"text/plain; charset=utf-8"),
-                (b"connection", b"close"),
-            ],
-        }
-    )
-    await send({"type": "http.response.body", "body": b"Service Unavailable"})
 
 
 class HttpToolsProtocol(asyncio.Protocol):


### PR DESCRIPTION
As I have spotted most of the parts of `h11_impl.py` and `httptools_impl.py` files are shared. The most notable duplication is FlowControl class and "constants", my suggestion is to move this part to separate file `flow_control.py` and then use it, this will reduce the duplicated code portion.