### PR TITLE
Fix PEP 508 violation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ def get_packages(package):
 
 env_marker_cpython = (
     "sys_platform != 'win32'"
-    " and sys_platform != 'cygwin'"
-    " and platform_python_implementation != 'PyPy'"
+    " and (sys_platform != 'cygwin'"
+    " and platform_python_implementation != 'PyPy')"
 )
 
 env_marker_win = "sys_platform == 'win32'"


### PR DESCRIPTION
Hi,
I was using [pipoe](https://pypi.org/project/pipoe/) to port `uvicorn` on an embedded target and I couldn't generate a recipe for it.

The parsing of the requirements for `httptools` and `uvloop` with `pep508_parser` failed because of missing parenthesis in `env_marker_cpython`.
```python
from pep508_parser import parser

# Without parenthesis
env_marker_cpython = (
    "sys_platform != 'win32'"
    " and sys_platform != 'cygwin'"
    " and platform_python_implementation != 'PyPy'"
)

# These lines failed
parser.parse("httptools==0.1.* ;" + env_marker_cpython)
parser.parse("uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython)

# With parenthesis
env_marker_cpython = (
    "sys_platform != 'win32'"
    " and (sys_platform != 'cygwin'"
    " and platform_python_implementation != 'PyPy')"
)

# These lines are parsed successfully
parser.parse("httptools==0.1.* ;" + env_marker_cpython)
parser.parse("uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython)
```