### PR TITLE
🔨 Add precision option on coverage command

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=95
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=96 --precision=2


### PR DESCRIPTION
To achieve 100% coverage, we should always increase that number. But as the number gets close to the goal, it may happen that we don't take some PRs into account and actually decrease its value.

This PR adds a `precision` parameter to be sure that we're not decreasing it by mistake.