### PR TITLE
Type-annotate uvicorn/config.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ isort
 pytest
 pytest-mock
 mypy
+types-pyyaml
 trustme
 cryptography
 coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ files =
     uvicorn/lifespan,
     tests/test_lifespan.py,
     uvicorn/config.py,
+    tests/test_config.py,
     uvicorn/middleware/message_logger.py,
     uvicorn/supervisors/basereload.py,
     uvicorn/importer.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ files =
     uvicorn/middleware/message_logger.py,
     uvicorn/supervisors/basereload.py,
     uvicorn/importer.py,
+    tests/importer/test_importer.py,
     uvicorn/protocols/utils.py,
     uvicorn/loops,
     uvicorn/main.py,

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ follow_imports = silent
 files =
     uvicorn/lifespan,
     tests/test_lifespan.py,
+    uvicorn/config.py,
     uvicorn/middleware/message_logger.py,
     uvicorn/supervisors/basereload.py,
     uvicorn/importer.py,

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -3,40 +3,40 @@ import pytest
 from uvicorn.importer import ImportFromStringError, import_from_string
 
 
-def test_invalid_format():
+def test_invalid_format() -> None:
     with pytest.raises(ImportFromStringError) as exc_info:
         import_from_string("example:")
     expected = 'Import string "example:" must be in format "<module>:<attribute>".'
     assert expected in str(exc_info.value)
 
 
-def test_invalid_module():
+def test_invalid_module() -> None:
     with pytest.raises(ImportFromStringError) as exc_info:
         import_from_string("module_does_not_exist:myattr")
     expected = 'Could not import module "module_does_not_exist".'
     assert expected in str(exc_info.value)
 
 
-def test_invalid_attr():
+def test_invalid_attr() -> None:
     with pytest.raises(ImportFromStringError) as exc_info:
         import_from_string("tempfile:attr_does_not_exist")
     expected = 'Attribute "attr_does_not_exist" not found in module "tempfile".'
     assert expected in str(exc_info.value)
 
 
-def test_internal_import_error():
+def test_internal_import_error() -> None:
     with pytest.raises(ImportError):
         import_from_string("tests.importer.raise_import_error:myattr")
 
 
-def test_valid_import():
+def test_valid_import() -> None:
     instance = import_from_string("tempfile:TemporaryFile")
     from tempfile import TemporaryFile
 
     assert instance == TemporaryFile
 
 
-def test_no_import_needed():
+def test_no_import_needed() -> None:
     from tempfile import TemporaryFile
 
     instance = import_from_string(TemporaryFile)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,10 @@ import logging
 import os
 import socket
 import sys
+import typing
 from copy import deepcopy
 from pathlib import Path
 from types import TracebackType
-from typing import Callable, Iterable, Iterator, MutableMapping, Optional, Tuple, Type
 from unittest.mock import MagicMock
 
 if sys.version_info < (3, 8):
@@ -25,8 +25,13 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
 
-ExcInfo = Tuple[Type[BaseException], BaseException, Optional[TracebackType]]
-StartResponse = Callable[[str, Iterable[Tuple[str, str]], Optional[ExcInfo]], None]
+Environ = typing.MutableMapping[str, typing.Any]
+ExcInfo = typing.Tuple[
+    typing.Type[BaseException], BaseException, typing.Optional[TracebackType]
+]
+StartResponse = typing.Callable[
+    [str, typing.Iterable[typing.Tuple[str, str]], typing.Optional[ExcInfo]], None
+]
 
 
 @pytest.fixture
@@ -55,7 +60,7 @@ async def asgi_app(
     pass  # pragma: nocover
 
 
-def wsgi_app(environ: MutableMapping, start_response: StartResponse) -> None:
+def wsgi_app(environ: Environ, start_response: StartResponse) -> None:
     pass  # pragma: nocover
 
 
@@ -188,7 +193,7 @@ def test_ssl_config_combined(tls_certificate_pem_path: str) -> None:
     assert config.is_ssl is True
 
 
-def asgi2_app(scope: Scope) -> Callable:
+def asgi2_app(scope: Scope) -> typing.Callable:
     async def asgi(
         receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:  # pragma: nocover
@@ -219,8 +224,8 @@ def test_asgi_version(
 )
 def test_log_config_default(
     mocked_logging_config_module: MagicMock,
-    use_colors: Optional[bool],
-    expected: Optional[bool],
+    use_colors: typing.Optional[bool],
+    expected: typing.Optional[bool],
 ) -> None:
     """
     Test that one can specify the use_colors option when using the default logging
@@ -290,14 +295,14 @@ def test_log_config_file(mocked_logging_config_module: MagicMock) -> None:
 
 
 @pytest.fixture(params=[0, 1])
-def web_concurrency(request: pytest.FixtureRequest) -> Iterator[int]:
+def web_concurrency(request: pytest.FixtureRequest) -> typing.Iterator[int]:
     yield getattr(request, "param")
     if os.getenv("WEB_CONCURRENCY"):
         del os.environ["WEB_CONCURRENCY"]
 
 
 @pytest.fixture(params=["127.0.0.1", "127.0.0.2"])
-def forwarded_allow_ips(request: pytest.FixtureRequest) -> Iterator[str]:
+def forwarded_allow_ips(request: pytest.FixtureRequest) -> typing.Iterator[str]:
     yield getattr(request, "param")
     if os.getenv("FORWARDED_ALLOW_IPS"):
         del os.environ["FORWARDED_ALLOW_IPS"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,21 @@ import json
 import logging
 import os
 import socket
+import sys
 from copy import deepcopy
+from pathlib import Path
+from typing import Any, Callable, Iterator, Optional
+from unittest.mock import MagicMock
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
 import pytest
 import yaml
+from asgiref.typing import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Scope
+from pytest_mock import MockerFixture
 
 from uvicorn.config import LOGGING_CONFIG, Config
 from uvicorn.middleware.debug import DebugMiddleware
@@ -15,34 +26,36 @@ from uvicorn.protocols.http.h11_impl import H11Protocol
 
 
 @pytest.fixture
-def mocked_logging_config_module(mocker):
+def mocked_logging_config_module(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("logging.config")
 
 
 @pytest.fixture(scope="function")
-def logging_config():
+def logging_config() -> dict:
     return deepcopy(LOGGING_CONFIG)
 
 
 @pytest.fixture
-def json_logging_config(logging_config):
+def json_logging_config(logging_config: dict) -> str:
     return json.dumps(logging_config)
 
 
 @pytest.fixture
-def yaml_logging_config(logging_config):
+def yaml_logging_config(logging_config: dict) -> str:
     return yaml.dump(logging_config)
 
 
-async def asgi_app(scope, receive, send):
+async def asgi_app(
+    scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+) -> None:
     pass  # pragma: nocover
 
 
-def wsgi_app(environ, start_response):
+def wsgi_app(environ: Any, start_response: Any) -> None:
     pass  # pragma: nocover
 
 
-def test_debug_app():
+def test_debug_app() -> None:
     config = Config(app=asgi_app, debug=True, proxy_headers=False)
     config.load()
 
@@ -54,7 +67,9 @@ def test_debug_app():
     "app, expected_should_reload",
     [(asgi_app, False), ("tests.test_config:asgi_app", True)],
 )
-def test_config_should_reload_is_set(app, expected_should_reload):
+def test_config_should_reload_is_set(
+    app: ASGIApplication, expected_should_reload: bool
+) -> None:
     config_debug = Config(app=app, debug=True)
     assert config_debug.debug is True
     assert config_debug.should_reload is expected_should_reload
@@ -64,12 +79,12 @@ def test_config_should_reload_is_set(app, expected_should_reload):
     assert config_reload.should_reload is expected_should_reload
 
 
-def test_reload_dir_is_set():
+def test_reload_dir_is_set() -> None:
     config = Config(app=asgi_app, reload=True, reload_dirs="reload_me")
     assert config.reload_dirs == ["reload_me"]
 
 
-def test_wsgi_app():
+def test_wsgi_app() -> None:
     config = Config(app=wsgi_app, interface="wsgi", proxy_headers=False)
     config.load()
 
@@ -78,7 +93,7 @@ def test_wsgi_app():
     assert config.asgi_version == "3.0"
 
 
-def test_proxy_headers():
+def test_proxy_headers() -> None:
     config = Config(app=asgi_app)
     config.load()
 
@@ -86,13 +101,13 @@ def test_proxy_headers():
     assert isinstance(config.loaded_app, ProxyHeadersMiddleware)
 
 
-def test_app_unimportable_module():
+def test_app_unimportable_module() -> None:
     config = Config(app="no.such:app")
     with pytest.raises(ImportError):
         config.load()
 
 
-def test_app_unimportable_other(caplog):
+def test_app_unimportable_other(caplog: pytest.LogCaptureFixture) -> None:
     config = Config(app="tests.test_config:app")
     with pytest.raises(SystemExit):
         config.load()
@@ -107,8 +122,8 @@ def test_app_unimportable_other(caplog):
     )
 
 
-def test_app_factory(caplog):
-    def create_app():
+def test_app_factory(caplog: pytest.LogCaptureFixture) -> None:
+    def create_app() -> ASGIApplication:
         return asgi_app
 
     config = Config(app=create_app, factory=True, proxy_headers=False)
@@ -125,19 +140,19 @@ def test_app_factory(caplog):
     assert len(caplog.records) == 1
     assert "--factory" in caplog.records[0].message
 
-    # App not a no-arguments callable.
+    # App not a no-arguments ASGIApplication.
     config = Config(app=asgi_app, factory=True)
     with pytest.raises(SystemExit):
         config.load()
 
 
-def test_concrete_http_class():
+def test_concrete_http_class() -> None:
     config = Config(app=asgi_app, http=H11Protocol)
     config.load()
     assert config.http_protocol_class is H11Protocol
 
 
-def test_socket_bind():
+def test_socket_bind() -> None:
     config = Config(app=asgi_app)
     config.load()
     sock = config.bind_socket()
@@ -145,7 +160,10 @@ def test_socket_bind():
     sock.close()
 
 
-def test_ssl_config(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_path):
+def test_ssl_config(
+    tls_ca_certificate_pem_path: str,
+    tls_ca_certificate_private_key_path: str,
+) -> None:
     config = Config(
         app=asgi_app,
         ssl_certfile=tls_ca_certificate_pem_path,
@@ -156,7 +174,7 @@ def test_ssl_config(tls_ca_certificate_pem_path, tls_ca_certificate_private_key_
     assert config.is_ssl is True
 
 
-def test_ssl_config_combined(tls_certificate_pem_path):
+def test_ssl_config_combined(tls_certificate_pem_path: str) -> None:
     config = Config(
         app=asgi_app,
         ssl_certfile=tls_certificate_pem_path,
@@ -166,8 +184,10 @@ def test_ssl_config_combined(tls_certificate_pem_path):
     assert config.is_ssl is True
 
 
-def asgi2_app(scope):
-    async def asgi(receive, send):  # pragma: nocover
+def asgi2_app(scope: Scope) -> Callable:
+    async def asgi(
+        receive: ASGIReceiveCallable, send: ASGISendCallable
+    ) -> None:  # pragma: nocover
         pass
 
     return asgi  # pragma: nocover
@@ -176,7 +196,9 @@ def asgi2_app(scope):
 @pytest.mark.parametrize(
     "app, expected_interface", [(asgi_app, "3.0"), (asgi2_app, "2.0")]
 )
-def test_asgi_version(app, expected_interface):
+def test_asgi_version(
+    app: ASGIApplication, expected_interface: Literal["2.0", "3.0"]
+) -> None:
     config = Config(app=app)
     config.load()
     assert config.asgi_version == expected_interface
@@ -191,7 +213,11 @@ def test_asgi_version(app, expected_interface):
         pytest.param(False, False, id="use_colors_disabled"),
     ],
 )
-def test_log_config_default(mocked_logging_config_module, use_colors, expected):
+def test_log_config_default(
+    mocked_logging_config_module: MagicMock,
+    use_colors: Optional[bool],
+    expected: Optional[bool],
+) -> None:
     """
     Test that one can specify the use_colors option when using the default logging
     config.
@@ -206,8 +232,11 @@ def test_log_config_default(mocked_logging_config_module, use_colors, expected):
 
 
 def test_log_config_json(
-    mocked_logging_config_module, logging_config, json_logging_config, mocker
-):
+    mocked_logging_config_module: MagicMock,
+    logging_config: dict,
+    json_logging_config: str,
+    mocker: MockerFixture,
+) -> None:
     """
     Test that one can load a json config from disk.
     """
@@ -224,12 +253,12 @@ def test_log_config_json(
 
 @pytest.mark.parametrize("config_filename", ["log_config.yml", "log_config.yaml"])
 def test_log_config_yaml(
-    mocked_logging_config_module,
-    logging_config,
-    yaml_logging_config,
-    mocker,
-    config_filename,
-):
+    mocked_logging_config_module: MagicMock,
+    logging_config: dict,
+    yaml_logging_config: str,
+    mocker: MockerFixture,
+    config_filename: str,
+) -> None:
     """
     Test that one can load a yaml config from disk.
     """
@@ -244,7 +273,7 @@ def test_log_config_yaml(
     mocked_logging_config_module.dictConfig.assert_called_once_with(logging_config)
 
 
-def test_log_config_file(mocked_logging_config_module):
+def test_log_config_file(mocked_logging_config_module: MagicMock) -> None:
     """
     Test that one can load a configparser config from disk.
     """
@@ -257,20 +286,25 @@ def test_log_config_file(mocked_logging_config_module):
 
 
 @pytest.fixture(params=[0, 1])
-def web_concurrency(request):
+def web_concurrency(request: Any) -> Iterator[int]:
     yield request.param
     if os.getenv("WEB_CONCURRENCY"):
         del os.environ["WEB_CONCURRENCY"]
 
 
 @pytest.fixture(params=["127.0.0.1", "127.0.0.2"])
-def forwarded_allow_ips(request):
+def forwarded_allow_ips(request: Any) -> Iterator[str]:
     yield request.param
     if os.getenv("FORWARDED_ALLOW_IPS"):
         del os.environ["FORWARDED_ALLOW_IPS"]
 
 
-def test_env_file(web_concurrency: int, forwarded_allow_ips: str, caplog, tmp_path):
+def test_env_file(
+    web_concurrency: int,
+    forwarded_allow_ips: str,
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+) -> None:
     """
     Test that one can load environment variables using an env file.
     """
@@ -284,7 +318,7 @@ def test_env_file(web_concurrency: int, forwarded_allow_ips: str, caplog, tmp_pa
         config = Config(app=asgi_app, env_file=fp)
         config.load()
 
-    assert config.workers == int(os.getenv("WEB_CONCURRENCY"))
+    assert config.workers == int(str(os.getenv("WEB_CONCURRENCY")))
     assert config.forwarded_allow_ips == os.getenv("FORWARDED_ALLOW_IPS")
     assert len(caplog.records) == 1
     assert f"Loading environment from '{fp}'" in caplog.records[0].message
@@ -297,7 +331,7 @@ def test_env_file(web_concurrency: int, forwarded_allow_ips: str, caplog, tmp_pa
         pytest.param(False, 0, id="access log disabled shouldn't have handlers"),
     ],
 )
-def test_config_access_log(access_log: bool, handlers: int):
+def test_config_access_log(access_log: bool, handlers: int) -> None:
     config = Config(app=asgi_app, access_log=access_log)
     config.load()
 
@@ -306,7 +340,7 @@ def test_config_access_log(access_log: bool, handlers: int):
 
 
 @pytest.mark.parametrize("log_level", [5, 10, 20, 30, 40, 50])
-def test_config_log_level(log_level):
+def test_config_log_level(log_level: int) -> None:
     config = Config(app=asgi_app, log_level=log_level)
     config.load()
 
@@ -316,7 +350,7 @@ def test_config_log_level(log_level):
     assert config.log_level == log_level
 
 
-def test_ws_max_size():
+def test_ws_max_size() -> None:
     config = Config(app=asgi_app, ws_max_size=1000)
     config.load()
     assert config.ws_max_size == 1000

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,6 @@ import sys
 import typing
 from copy import deepcopy
 from pathlib import Path
-from types import TracebackType
 from unittest.mock import MagicMock
 
 if sys.version_info < (3, 8):
@@ -19,19 +18,12 @@ import yaml
 from asgiref.typing import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Scope
 from pytest_mock import MockerFixture
 
+from uvicorn._types import Environ, StartResponse
 from uvicorn.config import LOGGING_CONFIG, Config
 from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
-
-Environ = typing.MutableMapping[str, typing.Any]
-ExcInfo = typing.Tuple[
-    typing.Type[BaseException], BaseException, typing.Optional[TracebackType]
-]
-StartResponse = typing.Callable[
-    [str, typing.Iterable[typing.Tuple[str, str]], typing.Optional[ExcInfo]], None
-]
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,7 +149,7 @@ def test_app_factory(caplog: pytest.LogCaptureFixture) -> None:
     assert len(caplog.records) == 1
     assert "--factory" in caplog.records[0].message
 
-    # App not a no-arguments ASGIApplication.
+    # App not a no-arguments callable.
     config = Config(app=asgi_app, factory=True)
     with pytest.raises(SystemExit):
         config.load()

--- a/uvicorn/_handlers/http.py
+++ b/uvicorn/_handlers/http.py
@@ -36,7 +36,7 @@ async def handle_http(
     connection_lost = loop.create_future()
 
     # Switch the protocol from the stream reader to our own HTTP protocol class.
-    protocol = config.http_protocol_class(
+    protocol = config.http_protocol_class(  # type: ignore[call-arg, operator]
         config=config,
         server_state=server_state,
         on_connection_lost=lambda: connection_lost.set_result(True),

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -1,0 +1,11 @@
+import types
+import typing
+
+# WSGI
+Environ = typing.MutableMapping[str, typing.Any]
+ExcInfo = typing.Tuple[
+    typing.Type[BaseException], BaseException, typing.Optional[types.TracebackType]
+]
+StartResponse = typing.Callable[
+    [str, typing.Iterable[typing.Tuple[str, str]], typing.Optional[ExcInfo]], None
+]

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -8,7 +8,7 @@ import socket
 import ssl
 import sys
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -137,8 +137,8 @@ class Config:
         uds: Optional[str] = None,
         fd: Optional[int] = None,
         loop: str = "auto",
-        http: str = "auto",
-        ws: str = "auto",
+        http: Union[Type[asyncio.Protocol], str] = "auto",
+        ws: Union[Type[asyncio.Protocol], str] = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
         lifespan: str = "auto",
         env_file: Optional[Union[Path, str]] = None,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -8,7 +8,7 @@ import socket
 import ssl
 import sys
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -16,6 +16,7 @@ else:
     from typing import Literal
 
 import click
+from asgiref.typing import ASGIApplication
 
 try:
     import yaml
@@ -130,7 +131,7 @@ def create_ssl_context(
 class Config:
     def __init__(
         self,
-        app,
+        app: Union[ASGIApplication, Awaitable, Callable, str],
         host: str = "127.0.0.1",
         port: int = 8000,
         uds: Optional[str] = None,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -8,7 +8,7 @@ import socket
 import ssl
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -141,7 +141,7 @@ class Config:
         ws_max_size: int = 16 * 1024 * 1024,
         lifespan: str = "auto",
         env_file: Optional[str] = None,
-        log_config: Union[Dict[str, Any], str] = LOGGING_CONFIG,
+        log_config: Optional[Union[dict, str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
         use_colors: Optional[bool] = None,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -32,6 +32,12 @@ from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 
+HttpProtocolType = Literal["auto", "h11", "httptools"]
+WsProtocolType = Literal["auto", "none", "websockets", "wsproto"]
+LifespanType = Literal["auto", "on", "off"]
+LoopSetupType = Literal["none", "auto", "asyncio", "uvloop"]
+InterfaceType = Literal["auto", "asgi3", "asgi2", "wsgi"]
+
 TRACE_LOG_LEVEL: int = 5
 
 LOG_LEVELS: Dict[str, int] = {
@@ -42,29 +48,29 @@ LOG_LEVELS: Dict[str, int] = {
     "debug": logging.DEBUG,
     "trace": TRACE_LOG_LEVEL,
 }
-HTTP_PROTOCOLS: Dict[str, str] = {
+HTTP_PROTOCOLS: Dict[HttpProtocolType, str] = {
     "auto": "uvicorn.protocols.http.auto:AutoHTTPProtocol",
     "h11": "uvicorn.protocols.http.h11_impl:H11Protocol",
     "httptools": "uvicorn.protocols.http.httptools_impl:HttpToolsProtocol",
 }
-WS_PROTOCOLS: Dict[str, Optional[str]] = {
+WS_PROTOCOLS: Dict[WsProtocolType, Optional[str]] = {
     "auto": "uvicorn.protocols.websockets.auto:AutoWebSocketsProtocol",
     "none": None,
     "websockets": "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
     "wsproto": "uvicorn.protocols.websockets.wsproto_impl:WSProtocol",
 }
-LIFESPAN: Dict[str, str] = {
+LIFESPAN: Dict[LifespanType, str] = {
     "auto": "uvicorn.lifespan.on:LifespanOn",
     "on": "uvicorn.lifespan.on:LifespanOn",
     "off": "uvicorn.lifespan.off:LifespanOff",
 }
-LOOP_SETUPS: Dict[str, Optional[str]] = {
+LOOP_SETUPS: Dict[LoopSetupType, Optional[str]] = {
     "none": None,
     "auto": "uvicorn.loops.auto:auto_loop_setup",
     "asyncio": "uvicorn.loops.asyncio:asyncio_setup",
     "uvloop": "uvicorn.loops.uvloop:uvloop_setup",
 }
-INTERFACES: List[str] = ["auto", "asgi3", "asgi2", "wsgi"]
+INTERFACES: List[InterfaceType] = ["auto", "asgi3", "asgi2", "wsgi"]
 
 
 # Fallback to 'ssl.PROTOCOL_SSLv23' in order to support Python < 3.5.3.
@@ -135,19 +141,19 @@ class Config:
         port: int = 8000,
         uds: Optional[str] = None,
         fd: Optional[int] = None,
-        loop: str = "auto",
-        http: Union[Type[asyncio.Protocol], str] = "auto",
-        ws: Union[Type[asyncio.Protocol], str] = "auto",
+        loop: LoopSetupType = "auto",
+        http: Union[Type[asyncio.Protocol], HttpProtocolType] = "auto",
+        ws: Union[Type[asyncio.Protocol], WsProtocolType] = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
         ws_ping_interval: int = 20,
         ws_ping_timeout: int = 20,
-        lifespan: str = "auto",
+        lifespan: LifespanType = "auto",
         env_file: Optional[Union[str, os.PathLike]] = None,
         log_config: Optional[Union[dict, str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
         use_colors: Optional[bool] = None,
-        interface: Literal["auto", "asgi3", "asgi2", "wsgi"] = "auto",
+        interface: InterfaceType = "auto",
         debug: bool = False,
         reload: bool = False,
         reload_dirs: Optional[Union[List[str], str]] = None,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -7,7 +7,7 @@ import os
 import socket
 import ssl
 import sys
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -136,7 +136,7 @@ def create_ssl_context(
 class Config:
     def __init__(
         self,
-        app: Union[ASGIApplication, Awaitable, Callable, str],
+        app: Union[ASGIApplication, Callable, str],
         host: str = "127.0.0.1",
         port: int = 8000,
         uds: Optional[str] = None,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -32,8 +32,8 @@ from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 
-HttpProtocolType = Literal["auto", "h11", "httptools"]
-WsProtocolType = Literal["auto", "none", "websockets", "wsproto"]
+HTTPProtocolType = Literal["auto", "h11", "httptools"]
+WSProtocolType = Literal["auto", "none", "websockets", "wsproto"]
 LifespanType = Literal["auto", "on", "off"]
 LoopSetupType = Literal["none", "auto", "asyncio", "uvloop"]
 InterfaceType = Literal["auto", "asgi3", "asgi2", "wsgi"]
@@ -48,12 +48,12 @@ LOG_LEVELS: Dict[str, int] = {
     "debug": logging.DEBUG,
     "trace": TRACE_LOG_LEVEL,
 }
-HTTP_PROTOCOLS: Dict[HttpProtocolType, str] = {
+HTTP_PROTOCOLS: Dict[HTTPProtocolType, str] = {
     "auto": "uvicorn.protocols.http.auto:AutoHTTPProtocol",
     "h11": "uvicorn.protocols.http.h11_impl:H11Protocol",
     "httptools": "uvicorn.protocols.http.httptools_impl:HttpToolsProtocol",
 }
-WS_PROTOCOLS: Dict[WsProtocolType, Optional[str]] = {
+WS_PROTOCOLS: Dict[WSProtocolType, Optional[str]] = {
     "auto": "uvicorn.protocols.websockets.auto:AutoWebSocketsProtocol",
     "none": None,
     "websockets": "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
@@ -142,8 +142,8 @@ class Config:
         uds: Optional[str] = None,
         fd: Optional[int] = None,
         loop: LoopSetupType = "auto",
-        http: Union[Type[asyncio.Protocol], HttpProtocolType] = "auto",
-        ws: Union[Type[asyncio.Protocol], WsProtocolType] = "auto",
+        http: Union[Type[asyncio.Protocol], HTTPProtocolType] = "auto",
+        ws: Union[Type[asyncio.Protocol], WSProtocolType] = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
         ws_ping_interval: int = 20,
         ws_ping_timeout: int = 20,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -149,7 +149,7 @@ class Config:
         interface: Literal["auto", "asgi3", "asgi2", "wsgi"] = "auto",
         debug: bool = False,
         reload: bool = False,
-        reload_dirs: Optional[List[str]] = None,
+        reload_dirs: Optional[Union[List[str], str]] = None,
         reload_delay: Optional[float] = None,
         workers: Optional[int] = None,
         proxy_headers: bool = True,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -108,7 +108,7 @@ logger = logging.getLogger("uvicorn.error")
 
 
 def create_ssl_context(
-    certfile: Optional[str],
+    certfile: Union[Path, str],
     keyfile: Optional[str],
     password: Optional[str],
     ssl_version: int,
@@ -161,7 +161,7 @@ class Config:
         timeout_notify: int = 30,
         callback_notify: Callable[..., None] = None,
         ssl_keyfile: Optional[str] = None,
-        ssl_certfile: Optional[str] = None,
+        ssl_certfile: Optional[Union[Path, str]] = None,
         ssl_keyfile_password: Optional[str] = None,
         ssl_version: int = SSL_PROTOCOL_VERSION,
         ssl_cert_reqs: int = ssl.CERT_NONE,
@@ -286,9 +286,8 @@ class Config:
     def load(self) -> None:
         assert not self.loaded
 
-        self.ssl: Optional[ssl.SSLContext]
-        if self.is_ssl:
-            self.ssl = create_ssl_context(
+        if self.is_ssl and self.ssl_certfile:
+            self.ssl: Optional[ssl.SSLContext] = create_ssl_context(
                 keyfile=self.ssl_keyfile,
                 certfile=self.ssl_certfile,
                 password=self.ssl_keyfile_password,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -385,13 +385,8 @@ class Config:
         self.loaded = True
 
     def setup_event_loop(self) -> None:
-        loop_setup_str: Optional[str] = LOOP_SETUPS[self.loop]
-        if loop_setup_str:
-            loop_setup: Callable = import_from_string(loop_setup_str)
-            if not inspect.isfunction(loop_setup):
-                raise ImportFromStringError("Asyncio event loop must be a callable.")
-            else:
-                loop_setup()
+        loop_setup: Callable = import_from_string(LOOP_SETUPS[self.loop])
+        loop_setup()
 
     def bind_socket(self) -> socket.socket:
         family = socket.AF_INET

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -7,7 +7,6 @@ import os
 import socket
 import ssl
 import sys
-from pathlib import Path
 from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
 if sys.version_info < (3, 8):
@@ -109,12 +108,12 @@ logger = logging.getLogger("uvicorn.error")
 
 
 def create_ssl_context(
-    certfile: Union[Path, str],
-    keyfile: Optional[str],
+    certfile: Union[str, os.PathLike],
+    keyfile: Optional[Union[str, os.PathLike]],
     password: Optional[str],
     ssl_version: int,
     cert_reqs: int,
-    ca_certs: Optional[str],
+    ca_certs: Optional[Union[str, os.PathLike]],
     ciphers: Optional[str],
 ) -> ssl.SSLContext:
     ctx = ssl.SSLContext(ssl_version)
@@ -141,7 +140,7 @@ class Config:
         ws: Union[Type[asyncio.Protocol], str] = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
         lifespan: str = "auto",
-        env_file: Optional[Union[Path, str]] = None,
+        env_file: Optional[Union[str, os.PathLike]] = None,
         log_config: Optional[Union[dict, str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
@@ -162,7 +161,7 @@ class Config:
         timeout_notify: int = 30,
         callback_notify: Callable[..., None] = None,
         ssl_keyfile: Optional[str] = None,
-        ssl_certfile: Optional[Union[Path, str]] = None,
+        ssl_certfile: Optional[Union[str, os.PathLike]] = None,
         ssl_keyfile_password: Optional[str] = None,
         ssl_version: int = SSL_PROTOCOL_VERSION,
         ssl_cert_reqs: int = ssl.CERT_NONE,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -305,7 +305,8 @@ class Config:
     def load(self) -> None:
         assert not self.loaded
 
-        if self.is_ssl and self.ssl_certfile:
+        if self.is_ssl:
+            assert self.ssl_certfile
             self.ssl: Optional[ssl.SSLContext] = create_ssl_context(
                 keyfile=self.ssl_keyfile,
                 certfile=self.ssl_certfile,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -7,7 +7,8 @@ import os
 import socket
 import ssl
 import sys
-from typing import List, Tuple, Union
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -107,8 +108,14 @@ logger = logging.getLogger("uvicorn.error")
 
 
 def create_ssl_context(
-    certfile, keyfile, password, ssl_version, cert_reqs, ca_certs, ciphers
-):
+    certfile: Optional[str],
+    keyfile: Optional[str],
+    password: Optional[str],
+    ssl_version: int,
+    cert_reqs: int,
+    ca_certs: Optional[str],
+    ciphers: Optional[str],
+) -> ssl.SSLContext:
     ctx = ssl.SSLContext(ssl_version)
     get_password = (lambda: password) if password else None
     ctx.load_cert_chain(certfile, keyfile, get_password)
@@ -124,44 +131,44 @@ class Config:
     def __init__(
         self,
         app,
-        host="127.0.0.1",
-        port=8000,
-        uds=None,
-        fd=None,
-        loop="auto",
-        http="auto",
-        ws="auto",
-        ws_max_size=16 * 1024 * 1024,
-        lifespan="auto",
-        env_file=None,
-        log_config=LOGGING_CONFIG,
-        log_level=None,
-        access_log=True,
-        use_colors=None,
-        interface="auto",
-        debug=False,
-        reload=False,
-        reload_dirs=None,
-        reload_delay=None,
-        workers=None,
-        proxy_headers=True,
-        forwarded_allow_ips=None,
-        root_path="",
-        limit_concurrency=None,
-        limit_max_requests=None,
-        backlog=2048,
-        timeout_keep_alive=5,
-        timeout_notify=30,
-        callback_notify=None,
-        ssl_keyfile=None,
-        ssl_certfile=None,
-        ssl_keyfile_password=None,
-        ssl_version=SSL_PROTOCOL_VERSION,
-        ssl_cert_reqs=ssl.CERT_NONE,
-        ssl_ca_certs=None,
-        ssl_ciphers="TLSv1",
-        headers=None,
-        factory=False,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+        uds: Optional[str] = None,
+        fd: Optional[int] = None,
+        loop: str = "auto",
+        http: str = "auto",
+        ws: str = "auto",
+        ws_max_size: int = 16 * 1024 * 1024,
+        lifespan: str = "auto",
+        env_file: Optional[str] = None,
+        log_config: Union[Dict[str, Any], str] = LOGGING_CONFIG,
+        log_level: Optional[Union[str, int]] = None,
+        access_log: bool = True,
+        use_colors: Optional[bool] = None,
+        interface: str = "auto",
+        debug: bool = False,
+        reload: bool = False,
+        reload_dirs: Optional[List[str]] = None,
+        reload_delay: Optional[float] = None,
+        workers: Optional[int] = None,
+        proxy_headers: bool = True,
+        forwarded_allow_ips: Optional[str] = None,
+        root_path: str = "",
+        limit_concurrency: Optional[int] = None,
+        limit_max_requests: Optional[int] = None,
+        backlog: int = 2048,
+        timeout_keep_alive: int = 5,
+        timeout_notify: int = 30,
+        callback_notify: Callable[..., None] = None,
+        ssl_keyfile: Optional[str] = None,
+        ssl_certfile: Optional[str] = None,
+        ssl_keyfile_password: Optional[str] = None,
+        ssl_version: int = SSL_PROTOCOL_VERSION,
+        ssl_cert_reqs: int = ssl.CERT_NONE,
+        ssl_ca_certs: Optional[str] = None,
+        ssl_ciphers: str = "TLSv1",
+        headers: Optional[List[List[str]]] = None,
+        factory: bool = False,
     ):
         self.app = app
         self.host = host
@@ -197,8 +204,8 @@ class Config:
         self.ssl_cert_reqs = ssl_cert_reqs
         self.ssl_ca_certs = ssl_ca_certs
         self.ssl_ciphers = ssl_ciphers
-        self.headers = headers if headers else []  # type: List[str]
-        self.encoded_headers = None  # type: List[Tuple[bytes, bytes]]
+        self.headers: List[List[str]] = headers if headers else []
+        self.encoded_headers: Optional[List[Tuple[bytes, bytes]]] = None
         self.factory = factory
 
         self.loaded = False
@@ -229,14 +236,14 @@ class Config:
             self.forwarded_allow_ips = forwarded_allow_ips
 
     @property
-    def asgi_version(self) -> Union[Literal["2.0"], Literal["3.0"]]:
+    def asgi_version(self) -> str:
         return {"asgi2": "2.0", "asgi3": "3.0", "wsgi": "3.0"}[self.interface]
 
     @property
     def is_ssl(self) -> bool:
         return bool(self.ssl_keyfile or self.ssl_certfile)
 
-    def configure_logging(self):
+    def configure_logging(self) -> None:
         logging.addLevelName(TRACE_LOG_LEVEL, "TRACE")
 
         if self.log_config is not None:
@@ -276,9 +283,10 @@ class Config:
             logging.getLogger("uvicorn.access").handlers = []
             logging.getLogger("uvicorn.access").propagate = False
 
-    def load(self):
+    def load(self) -> None:
         assert not self.loaded
 
+        self.ssl: Optional[ssl.SSLContext]
         if self.is_ssl:
             self.ssl = create_ssl_context(
                 keyfile=self.ssl_keyfile,
@@ -300,7 +308,7 @@ class Config:
             encoded_headers
             if b"server" in dict(encoded_headers)
             else [(b"server", b"uvicorn")] + encoded_headers
-        )  # type: List[Tuple[bytes, bytes]]
+        )
 
         if isinstance(self.http, str):
             self.http_protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])
@@ -360,12 +368,12 @@ class Config:
 
         self.loaded = True
 
-    def setup_event_loop(self):
+    def setup_event_loop(self) -> None:
         loop_setup = import_from_string(LOOP_SETUPS[self.loop])
         if loop_setup is not None:
             loop_setup()
 
-    def bind_socket(self):
+    def bind_socket(self) -> socket.socket:
         family = socket.AF_INET
         addr_format = "%s://%s:%d"
 
@@ -400,5 +408,5 @@ class Config:
         return sock
 
     @property
-    def should_reload(self):
+    def should_reload(self) -> bool:
         return isinstance(self.app, str) and (self.debug or self.reload)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -390,8 +390,9 @@ class Config:
         self.loaded = True
 
     def setup_event_loop(self) -> None:
-        loop_setup: Callable = import_from_string(LOOP_SETUPS[self.loop])
-        loop_setup()
+        loop_setup: Optional[Callable] = import_from_string(LOOP_SETUPS[self.loop])
+        if loop_setup is not None:
+            loop_setup()
 
     def bind_socket(self) -> socket.socket:
         family = socket.AF_INET

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -205,7 +205,7 @@ class Config:
         self.ssl_cert_reqs = ssl_cert_reqs
         self.ssl_ca_certs = ssl_ca_certs
         self.ssl_ciphers = ssl_ciphers
-        self.headers: List[List[str]] = headers if headers else []
+        self.headers: List[List[str]] = headers or []
         self.encoded_headers: Optional[List[Tuple[bytes, bytes]]] = None
         self.factory = factory
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -326,7 +326,7 @@ class Config:
             [(b"server", b"uvicorn")] + encoded_headers
             if b"server" not in dict(encoded_headers) and self.server_header
             else encoded_headers
-        )  # type: List[Tuple[bytes, bytes]]
+        )
 
         if isinstance(self.http, str):
             http_protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -33,9 +33,9 @@ from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 
-TRACE_LOG_LEVEL = 5
+TRACE_LOG_LEVEL: int = 5
 
-LOG_LEVELS = {
+LOG_LEVELS: Dict[str, int] = {
     "critical": logging.CRITICAL,
     "error": logging.ERROR,
     "warning": logging.WARNING,
@@ -43,36 +43,36 @@ LOG_LEVELS = {
     "debug": logging.DEBUG,
     "trace": TRACE_LOG_LEVEL,
 }
-HTTP_PROTOCOLS = {
+HTTP_PROTOCOLS: Dict[str, str] = {
     "auto": "uvicorn.protocols.http.auto:AutoHTTPProtocol",
     "h11": "uvicorn.protocols.http.h11_impl:H11Protocol",
     "httptools": "uvicorn.protocols.http.httptools_impl:HttpToolsProtocol",
 }
-WS_PROTOCOLS = {
+WS_PROTOCOLS: Dict[str, Optional[str]] = {
     "auto": "uvicorn.protocols.websockets.auto:AutoWebSocketsProtocol",
     "none": None,
     "websockets": "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
     "wsproto": "uvicorn.protocols.websockets.wsproto_impl:WSProtocol",
 }
-LIFESPAN = {
+LIFESPAN: Dict[str, str] = {
     "auto": "uvicorn.lifespan.on:LifespanOn",
     "on": "uvicorn.lifespan.on:LifespanOn",
     "off": "uvicorn.lifespan.off:LifespanOff",
 }
-LOOP_SETUPS = {
+LOOP_SETUPS: Dict[str, Optional[str]] = {
     "none": None,
     "auto": "uvicorn.loops.auto:auto_loop_setup",
     "asyncio": "uvicorn.loops.asyncio:asyncio_setup",
     "uvloop": "uvicorn.loops.uvloop:uvloop_setup",
 }
-INTERFACES = ["auto", "asgi3", "asgi2", "wsgi"]
+INTERFACES: List[str] = ["auto", "asgi3", "asgi2", "wsgi"]
 
 
 # Fallback to 'ssl.PROTOCOL_SSLv23' in order to support Python < 3.5.3.
-SSL_PROTOCOL_VERSION = getattr(ssl, "PROTOCOL_TLS", ssl.PROTOCOL_SSLv23)
+SSL_PROTOCOL_VERSION: int = getattr(ssl, "PROTOCOL_TLS", ssl.PROTOCOL_SSLv23)
 
 
-LOGGING_CONFIG = {
+LOGGING_CONFIG: dict = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -146,7 +146,7 @@ class Config:
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
         use_colors: Optional[bool] = None,
-        interface: str = "auto",
+        interface: Literal["auto", "asgi3", "asgi2", "wsgi"] = "auto",
         debug: bool = False,
         reload: bool = False,
         reload_dirs: Optional[List[str]] = None,
@@ -237,8 +237,13 @@ class Config:
             self.forwarded_allow_ips = forwarded_allow_ips
 
     @property
-    def asgi_version(self) -> str:
-        return {"asgi2": "2.0", "asgi3": "3.0", "wsgi": "3.0"}[self.interface]
+    def asgi_version(self) -> Literal["2.0", "3.0"]:
+        mapping: Dict[str, Literal["2.0", "3.0"]] = {
+            "asgi2": "2.0",
+            "asgi3": "3.0",
+            "wsgi": "3.0",
+        }
+        return mapping[self.interface]
 
     @property
     def is_ssl(self) -> bool:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -141,7 +141,7 @@ class Config:
         ws: str = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
         lifespan: str = "auto",
-        env_file: Optional[str] = None,
+        env_file: Optional[Union[Path, str]] = None,
         log_config: Optional[Union[dict, str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,

--- a/uvicorn/importer.py
+++ b/uvicorn/importer.py
@@ -1,13 +1,12 @@
 import importlib
-from types import ModuleType
-from typing import Union
+from typing import Any
 
 
 class ImportFromStringError(Exception):
     pass
 
 
-def import_from_string(import_str: Union[ModuleType, str]) -> ModuleType:
+def import_from_string(import_str: Any) -> Any:
     if not isinstance(import_str, str):
         return import_str
 

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -30,7 +30,7 @@ class UvicornWorker(Worker):
         logger.setLevel(self.log.access_log.level)
         logger.propagate = False
 
-        config_kwargs = {
+        config_kwargs: dict = {
             "app": None,
             "log_config": None,
             "timeout_keep_alive": self.cfg.keepalive,


### PR DESCRIPTION
## Description

This PR will add type annotations and mypy type checking to _uvicorn/config.py_, the associated tests in _tests/test_config.py_, and the related code that is impacted by the new type annotations.

Supersedes the changes to _uvicorn/config.py_ in #992, and closes #1046.

## Changes

### _uvicorn/config.py_

- Add changes from PR #992 (0db3bc2): This commit will bring in changes to _uvicorn/config.py_ added by @Kludex in PR #992, updating for the latest master branch.
- Correct SSL type annotations (eee7fba)
  - `certfile` is a required positional argument when running [`SSLContext.load_cert_chain`](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain), so annotating as `Optional` (which allows `None`) would not be ideal. Path-like objects are acceptable, so after `from pathlib import Path`, the annotation is `certfile: Union[Path, str]`.
  - `if self.is_ssl and self.ssl_certfile` will help ensure that the `self.ssl_certfile` required positional argument is present.
- Simplify `log_config` type annotation (b2a1548)
- Add type annotation for app (12d323c):
  - app is sometimes a string, as described in _uvicorn/main.py_. In other cases, especially in the tests, app is an ASGI application callable.
  - This commit will add a type annotation for the app argument to address these use cases.
- Simplify if expression in `Config().headers` (b188fd1)
- Allow paths to be used for `Config(env_file)` (d31fddd)
- Add asyncio Protocol types to class `Config` kwargs (9c8e70d): Protocol classes are sometimes used for the app kwarg, such as in _tests/test_config.py_.
- Improve use of `Literal` type for ASGI interfaces (14cb546)
  - This commit will retain the use of [literals](https://mypy.readthedocs.io/en/stable/literal_types.html) to define ASGI protocol versions, but improve and correct the use of literal types.
  - As described in the mypy docs, `Literal["2.0", "3.0"]` is a simpler way to write `Union[Literal["2.0"], Literal["3.0"]]`.
- Add type annotation to `Config` kwargs in _uvicorn/workers.py_ (459544d)
- Add type annotations to _tests/test_config.py_ (c436bba)
- Type-annotate constants in _uvicorn/config.py_ (8d2cd6f): Helps prevent mypy `[has-type]` errors ("Cannot determine type of {object}")

### _uvicorn/importer.py_

Correct type annotations in _uvicorn/importer.py_ (e9e59e9)

The relationship between module imports and calls in _uvicorn/config.py_ was previously unclear. In encode/uvicorn#991, `import_from_string` was annotated as returning a `ModuleType`, but the function is used to return callables and other types. Mypy was raising "module not callable" errors, as reported in #1046.

https://github.com/encode/uvicorn/blob/87da6cf4082cd28306bdb78d7d42552d131cc179/uvicorn/config.py#L317-L325

Current use cases of `import_from_string` include:

- `uvicorn.Config.HTTP_PROTOCOLS`, `uvicorn.Config.WS_PROTOCOLS`: `Type[asyncio.Protocol]` (these are subclasses of asyncio protocols, so they are annotated with `Type[Class]` as explained in the [mypy docs](https://mypy.readthedocs.io/en/stable/kinds_of_types.html#the-type-of-class-objects))
- `uvicorn.Config.LOOP_SETUPS`: `Callable` (each of the loops is a function)
- `uvicorn.Config().loaded_app`: `ASGIApplication` (should be an ASGI application instance, like `Starlette()` or `FastAPI()`)

Ideally, the return type of `import_from_string` would reflect these use cases, but the complex typing will be difficult to maintain. For easier maintenance, the return type will be `Any`, and objects returned by `import_from_string` will be annotated directly.

## Related

encode/uvicorn#990
encode/uvicorn#991
encode/uvicorn#992
encode/uvicorn#998
encode/uvicorn#1046

