### PR TITLE
When receiving a SIGTERM supervisors should terminate their processes before joining them

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -75,6 +75,7 @@ class BaseReload:
         self.process.start()
 
     def shutdown(self) -> None:
+        self.process.terminate()
         self.process.join()
         message = "Stopping reloader process [{}]".format(str(self.pid))
         color_message = "Stopping reloader process [{}]".format(

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -64,6 +64,7 @@ class Multiprocess:
 
     def shutdown(self) -> None:
         for process in self.processes:
+            process.terminate()
             process.join()
 
         message = "Stopping parent process [{}]".format(str(self.pid))


### PR DESCRIPTION
Fixes #852 

By calling `process.terminate()`, it sends a SIGTERM to the child processes which should handle it appropriately. That said, I have a very naive understanding of multiprocessing so this may not be the right resolution.