### PR TITLE
Coverage server

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -334,6 +334,7 @@ def test_config_rebind_socket():
     sock.bind((config.host, config.port))
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         config.bind_socket()
-    sock.close()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
+    sock.close()
+    assert sock.fileno() == -1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -323,18 +323,23 @@ def test_ws_max_size():
     assert config.ws_max_size == 1000
 
 
+@pytest.fixture
+def socket_fixture():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 8000))
+    yield
+    sock.close()
+    assert sock.fileno() == -1
+
+
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="Skipping unix domain tests on Windows",
 )
-def test_config_rebind_socket():
-    sock = socket.socket()
+def test_config_rebind_socket(socket_fixture):
     config = Config(app=asgi_app)
     config.load()
-    sock.bind((config.host, config.port))
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         config.bind_socket()
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
-    sock.close()
-    assert sock.fileno() == -1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -329,12 +329,11 @@ def test_ws_max_size():
 )
 def test_config_rebind_socket():
     sock = socket.socket()
-    config = Config(app=asgi_app, port=10000)
-    try:
-        sock.bind((config.host, config.port))
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            config.bind_socket()
-        assert pytest_wrapped_e.type == SystemExit
-        assert pytest_wrapped_e.value.code == 1
-    finally:
-        sock.close()
+    config = Config(app=asgi_app)
+    config.load()
+    sock.bind((config.host, config.port))
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        config.bind_socket()
+    sock.close()
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 1

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -35,7 +35,7 @@ logger = logging.getLogger("uvicorn.error")
 def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> None:
     if not value or ctx.resilient_parsing:
         return
-    click.echo(
+    click.echo(  # pragma: no cover
         "Running uvicorn %s with %s %s on %s"
         % (
             uvicorn.__version__,
@@ -44,7 +44,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
             platform.system(),
         )
     )
-    ctx.exit()
+    ctx.exit()  # pragma: no cover
 
 
 @click.command()


### PR DESCRIPTION
start from
```
+ coverage report --show-missing --skip-covered --fail-under=95
Name                                              Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------
uvicorn/_handlers/http.py                            28      3    89%   63-72, 83
uvicorn/config.py                                   207     12    94%   13, 21-25, 233, 368-370, 378-379, 385-387
uvicorn/main.py                                      85     16    81%   38-47, 393-411, 415
uvicorn/protocols/http/flow_control.py               35      6    83%   27, 40-42, 46-47
uvicorn/protocols/http/h11_impl.py                  296     14    95%   89-90, 96-97, 117, 124-125, 239-240, 309, 315, 413, 416, 431
uvicorn/protocols/http/httptools_impl.py            317     11    97%   124-125, 152-153, 157, 311, 317, 415, 418, 450, 452
uvicorn/protocols/utils.py                           37      2    95%   14-17
uvicorn/protocols/websockets/websockets_impl.py     153      2    99%   89-90
uvicorn/protocols/websockets/wsproto_impl.py        210     27    87%   24, 70, 78, 88, 101, 103, 113, 119, 122-125, 157-168, 206-213
uvicorn/server.py                                   172     58    66%   48-50, 69, 73-75, 84-85, 100-116, 120-126, 130-139, 151-154, 173-174, 180, 193, 230-232, 236, 248, 259-262, 266-269, 278, 291-294
uvicorn/subprocess.py                                21      4    81%   69-76
uvicorn/supervisors/basereload.py                    49      6    88%   43-48, 86
uvicorn/supervisors/watchgodreload.py                47      2    96%   16, 59
-------------------------------------------------------------------------------
TOTAL                                              3957    163    96%
```