### PR TITLE
Exit with status 3 when worker starts failed

### DIFF
--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -4,6 +4,7 @@ import signal
 import sys
 from typing import Any
 
+from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
 
 from uvicorn.config import Config
@@ -80,7 +81,7 @@ class UvicornWorker(Worker):
         # can shut it down to avoid infinite start/stop cycles.
         # See: https://github.com/encode/uvicorn/issues/1066
         if not server.started:
-            sys.exit(3)
+            sys.exit(Arbiter.WORKER_BOOT_ERROR)
 
     async def callback_notify(self) -> None:
         self.notify()

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -76,7 +76,7 @@ class UvicornWorker(Worker):
         server = Server(config=self.config)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(server.serve(sockets=self.sockets))
-        # Exit with status 3 when worker starts failed, so Gunicorn 
+        # Exit with status 3 when worker starts failed, so Gunicorn
         # can shut it down to avoid infinite start/stop cycles.
         # See: https://github.com/encode/uvicorn/issues/1066
         if not server.started:

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -77,7 +77,7 @@ class UvicornWorker(Worker):
         loop = asyncio.get_event_loop()
         loop.run_until_complete(server.serve(sockets=self.sockets))
         # Exit with status 3 when worker starts failed, so Gunicorn 
-        # can shut it down to aviod infinite start/stop cycles.
+        # can shut it down to avoid infinite start/stop cycles.
         # See: https://github.com/encode/uvicorn/issues/1066
         if not server.started:
             sys.exit(3)

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import signal
+import sys
 from typing import Any
 
 from gunicorn.workers.base import Worker
@@ -75,6 +76,11 @@ class UvicornWorker(Worker):
         server = Server(config=self.config)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(server.serve(sockets=self.sockets))
+        # Exit with status 3 when worker starts failed, so Gunicorn 
+        # can shut it down to aviod infinite start/stop cycles.
+        # See: https://github.com/encode/uvicorn/issues/1066
+        if not server.started:
+            sys.exit(3)
 
     async def callback_notify(self) -> None:
         self.notify()


### PR DESCRIPTION
This PR fixes #1066 .

When starting Gunicorn with Uvicorn worker, if exceptions raised at startup events, `UvicornWorker` exits with zero exit code, therefore Gunicorn will keep booting worker.

This PR sets exit code 3 when worker starts failed, Gunicorn will then handle `SIGCHLD` correctly and could shut it down to avoid infinite start/stop cycles.