### PR TITLE
👷 Add Python 3.10 beta to the CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10.0-beta.2"]
         os: [windows-latest, ubuntu-latest]
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
Following the same idea as https://github.com/encode/httpx/issues/1678