### PR TITLE
Revert propagate status after exiting context caplog_for_logger()

### DIFF
--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -11,13 +11,13 @@ from uvicorn import Config
 @contextlib.contextmanager
 def caplog_for_logger(caplog, logger_name):
     logger = logging.getLogger(logger_name)
-    if logger.propagate:
-        logger.propagate = False
+    logger.propagate, old_propagate = False, logger.propagate
     logger.addHandler(caplog.handler)
     try:
         yield caplog
     finally:
         logger.removeHandler(caplog.handler)
+        logger.propagate = old_propagate
 
 
 async def app(scope, receive, send):


### PR DESCRIPTION
Tests related bug.

The logging may be `caplog`ged/redirected to an **existing** logger, like
`uvicorn`, `uvicorn.error`, `uvicorn.access`. Revert the `.propagate`
status to avoid breaking tests which depend on logging propagate.
E.g. `test_default_logging()` would fail if `.propagate` is set to `False`
on logger "uvicorn.error" by calling `caplog_for_logger(caplog, "uvicorn.error")`.

---

A bug found during writing tests in GH-1083. Firstly, I tried to capture the trace logs on protocols
to an existing logger `uvicorn.error`. Cause the `.propagate` is set to `False` permanently,
it breaks the latter test `test_default_logging()`. After this, I chose to redirect/capture the trace log
to a non-existing logger `uvicorn.protocol` to avoid the bug temporarily.

Here's a way to trigger the bug manually.

```diff
@pytest.mark.asyncio
@pytest.mark.parametrize("use_colors", [(True), (False)])
async def test_default_logging(use_colors, caplog):
+    with caplog_for_logger(caplog, "uvicorn.error"):
+        pass
    config = Config(app=app, use_colors=use_colors)
    with caplog_for_logger(caplog, "uvicorn.access"):
        async with run_server(config):
            async with httpx.AsyncClient() as client:
                response = await client.get("http://127.0.0.1:8000")
```

`pytest tests/middleware/test_logging.py::test_default_logging`