### PR TITLE
Allow use custom server class

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -404,12 +404,17 @@ def main(
         "use_colors": use_colors,
         "factory": factory,
     }
-    run(app, **kwargs)
+    run(app, server_class=Server, **kwargs)
 
 
-def run(app: typing.Union[ASGIApplication, str], **kwargs: typing.Any) -> None:
+def run(
+    app: typing.Union[ASGIApplication, str],
+    *,
+    server_class: typing.Type[Server] = Server,
+    **kwargs: typing.Any,
+) -> None:
     config = Config(app, **kwargs)
-    server = Server(config=config)
+    server = server_class(config=config)
 
     if (config.reload or config.workers > 1) and not isinstance(app, str):
         logger = logging.getLogger("uvicorn.error")


### PR DESCRIPTION
Related links:
- https://stackoverflow.com/questions/58133694/graceful-shutdown-of-uvicorn-starlette-app-with-websockets

This PR will allow passing `Server` to `uvicorn.run` via parameters. This will make it easier to handle the problem of long connections that cannot be closed normally.

```python
class Server(uvicorn.Server):
    def handle_exit(self, sig, frame):
        application = self.config.loaded_app
        while not isinstance(application, Starlette):
            application = application.app
        application.should_exit = True
        return super().handle_exit(sig, frame)


uvicorn.run(app, server_class=Server)
```