### PR TITLE
⬆️ Bump uvloop extra requirements to >=0.15.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ minimal_requirements = [
 extra_requirements = [
     "websockets>=9.1",
     "httptools==0.2.*",
-    "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
+    "uvloop>=0.15.2; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",
     "python-dotenv>=0.13",


### PR DESCRIPTION
This is a recommendation made by @1st1 (@MagicStack member) in https://github.com/encode/uvicorn/pull/952#r578815980.