### PR TITLE
Implement PEP 561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     author="Tom Christie",
     author_email="tom@tomchristie.com",
     packages=get_packages("uvicorn"),
+    package_data={"uvicorn": ["py.typed"]},
     install_requires=minimal_requirements,
     extras_require={"standard": extra_requirements},
     include_package_data=True,


### PR DESCRIPTION
After completing the [mypy project](https://github.com/encode/uvicorn/projects/2) we can be compliant with [PEP 561](https://www.python.org/dev/peps/pep-0561/).

This PR adds a `py.typed` and includes it in the `setup.py` as specified by the PEP. 