### PR TITLE
⬆️ Bump asgiref to 3.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
-    "asgiref>=3.3.4",
+    "asgiref>=3.4.0",
     "click>=7.*",
     "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -16,7 +16,7 @@ from asgiref.typing import (
     ASGISendCallable,
     HTTPScope,
     Scope,
-    WebsocketScope,
+    WebSocketScope,
 )
 
 
@@ -47,7 +47,7 @@ class ProxyHeadersMiddleware:
         self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:
         if scope["type"] in ("http", "websocket"):
-            scope = cast(Union[HTTPScope, WebsocketScope], scope)
+            scope = cast(Union[HTTPScope, WebSocketScope], scope)
             client_addr: Optional[Tuple[str, int]] = scope.get("client")
             client_host = client_addr[0] if client_addr else None
 


### PR DESCRIPTION
Due to recent upgrade on https://github.com/django/asgiref/pull/272, the `Websocket` types are still available, but `mypy` is unable to recognize them. Instead, this PR introduces `WebSocket`, with upper **_S_** instead of the previous format.