### PR TITLE
✅ Increase coverage threshold from 95 to 96

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=95
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=97

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=97
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=96


### PR DESCRIPTION
It's important to keep updating the coverage threshold, so we don't lose coverage, and we can achieve the 100% that we always wanted.

EDIT: The first time it failed, it was because I've set to 97. Now it passes with 96. :smile: 