### PR TITLE
Read uvicorn settings from environment variables

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -7,6 +7,13 @@ equivalent keyword arguments, eg. `uvicorn.run("example:app", port=5000, reload=
 Please note that in this case, if you use `reload=True` or `workers=NUM`,
 you should put `uvicorn.run` into `if __name__ == '__main__'` clause in the main module.
 
+You can also configure Uvicorn using environment variables with the prefix `UVICORN_`.
+For example, in case you want to run the app on port `5000`, just set the environment variable `UVICORN_PORT` to `5000`.
+
+!!! note
+    CLI options and the arguments for `uvicorn.run()` take precedence over environment variables.
+
+
 ## Application
 
 * `APP` - The ASGI application to run, in the format `"<module>:<attribute>"`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,10 +15,12 @@ nav:
     - Server Behavior: 'server-behavior.md'
 
 markdown_extensions:
+  - admonition
   - codehilite:
       css_class: highlight
   - toc:
       permalink: true
+
 
 extra_javascript:
   - 'js/chat.js'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,13 +45,13 @@ def test_env_variables(load_env_h11_protocol: None):
     runner = CliRunner(env=os.environ)
     with mock.patch.object(main, "run") as mock_run:
         runner.invoke(cli, ["tests.test_cli:App"])
-        mock_run.assert_called_once()
-        assert mock_run.call_args.kwargs["http"] == "h11"
+        _, kwargs = mock_run.call_args
+        assert kwargs["http"] == "h11"
 
 
 def test_mistmatch_env_variables(load_env_h11_protocol: None):
     runner = CliRunner(env=os.environ)
     with mock.patch.object(main, "run") as mock_run:
         runner.invoke(cli, ["tests.test_cli:App", "--http=httptools"])
-        mock_run.assert_called_once()
-        assert mock_run.call_args.kwargs["http"] == "httptools"
+        _, kwargs = mock_run.call_args
+        assert kwargs["http"] == "httptools"

--- a/uvicorn/__main__.py
+++ b/uvicorn/__main__.py
@@ -1,4 +1,4 @@
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.main()
+    uvicorn.main(auto_envvar_prefix="UVICORN")

--- a/uvicorn/__main__.py
+++ b/uvicorn/__main__.py
@@ -1,4 +1,4 @@
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.main(auto_envvar_prefix="UVICORN")
+    uvicorn.main()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -48,7 +48,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     ctx.exit()
 
 
-@click.command()
+@click.command(context_settings={"auto_envvar_prefix": "UVICORN"})
 @click.argument("app")
 @click.option(
     "--host",


### PR DESCRIPTION
Closes #693

This is a further implementation proposed by #696. The solution proposed there only enabled `uvicorn` to read environment variables in case it was run using `python -m uvicorn` instead of the usual `uvicorn` entry point. This PR solves that issue.

Here we go further and add a test that loads one of the many settings options, and check that it's used successfully by `uvicorn`, and also shows a priority between CLI arguments and environment variables i.e. CLI arguments always have priority in case environment variables are present. 

### Do we have alternatives for this?

Yes. Gunicorn uses a single environment variable called `GUNICORN_CMD_ARGS`, instead of using a prefix. See more about it [here](https://docs.gunicorn.org/en/stable/settings.html#settings).