### PR TITLE
Remove non reachable return statement

### DIFF
--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -31,17 +31,15 @@ class ProxyHeadersMiddleware:
             self.trusted_hosts = set(trusted_hosts)
         self.always_trust = "*" in self.trusted_hosts
 
-    def get_trusted_client_host(
+    def get_trusted_client_host(  # type: ignore[return]
         self, x_forwarded_for_hosts: List[str]
-    ) -> Optional[str]:
+    ) -> str:
         if self.always_trust:
             return x_forwarded_for_hosts[0]
 
         for host in reversed(x_forwarded_for_hosts):
             if host not in self.trusted_hosts:
                 return host
-
-        return None
 
     async def __call__(
         self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable


### PR DESCRIPTION
I'm not 100% sure about this.

I was the one who added the `return None` a month ago, but I've noticed it's not covered, so I went back to see what would be a good test for it. But I don't think it should return `None`. I'm also uncertain if it's possible to not get a `host` on the `get_trusted_client_host`.

I'm going to check more closely about this later on, but thoughts are already welcome. 