### PR TITLE
Ignore coverage on get_remote_addr() condition

### DIFF
--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -11,7 +11,7 @@ def get_remote_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:
         try:
             info = socket_info.getpeername()
             return (str(info[0]), int(info[1])) if isinstance(info, tuple) else None
-        except OSError:
+        except OSError:  # pragma: no cover
             # This case appears to inconsistently occur with uvloop
             # bound to a unix domain socket.
             return None


### PR DESCRIPTION
This exception was added on #495, and it's really needed, as we can see that [getpeername](https://docs.python.org/3/library/socket.html#socket.socket.getpeername) is not supported on some systems.

Related: 
- #494