### PR TITLE
🐛 Fix the need of httptools on minimal installation

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -9,16 +9,20 @@ import threading
 import time
 from email.utils import formatdate
 from types import FrameType
-from typing import Any, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple, Union
 
 import click
 
 from uvicorn._handlers.http import handle_http
 from uvicorn.config import Config
-from uvicorn.protocols.http.h11_impl import H11Protocol
-from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
-from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
-from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
+
+if TYPE_CHECKING:
+    from uvicorn.protocols.http.h11_impl import H11Protocol
+    from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+    from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
+    from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
+
+    Protocols = Union[H11Protocol, HttpToolsProtocol, WSProtocol, WebSocketProtocol]
 
 if sys.platform != "win32":
     from asyncio import start_unix_server as _start_unix_server
@@ -35,8 +39,6 @@ HANDLED_SIGNALS = (
 
 logger = logging.getLogger("uvicorn.error")
 
-Protocols = Union[H11Protocol, HttpToolsProtocol, WSProtocol, WebSocketProtocol]
-
 
 class ServerState:
     """
@@ -45,7 +47,7 @@ class ServerState:
 
     def __init__(self) -> None:
         self.total_requests = 0
-        self.connections: Set[Protocols] = set()
+        self.connections: Set["Protocols"] = set()
         self.tasks: Set[asyncio.Task] = set()
         self.default_headers: List[Tuple[bytes, bytes]] = []
 


### PR DESCRIPTION
This solves the following bug, caused when you installed `uvicorn` via `pip install uvicorn`.
 
```bash
>>> import uvicorn
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/__init__.py", line 2, in <module>
    from uvicorn.main import Server, main, run
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/main.py", line 23, in <module>
    from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/server.py", line 19, in <module>
    from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/protocols/http/httptools_impl.py", line 8, in <module>
    import httptools
ModuleNotFoundError: No module named 'httptools'
```