### PR TITLE
Add changelog URL for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,5 +98,6 @@ setup(
     project_urls={
         "Funding": "https://github.com/sponsors/encode",
         "Source": "https://github.com/encode/uvicorn",
+        "Changelog": "https://github.com/encode/uvicorn/blob/master/CHANGELOG.md",
     },
 )


### PR DESCRIPTION
Alternative to https://github.com/encode/uvicorn/pull/1134.