### PR TITLE
Allow fallback to AF_INET

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -132,7 +132,10 @@ class Server:
 
         elif config.fd is not None:
             # Use an existing socket, from a file descriptor.
-            sock = socket.fromfd(config.fd, socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                sock = socket.fromfd(config.fd, socket.AF_UNIX, socket.SOCK_STREAM)
+            except AttributeError:
+                sock = socket.fromfd(config.fd, socket.AF_INET, socket.SOCK_STREAM)
             server = await asyncio.start_server(
                 handler, sock=sock, ssl=config.ssl, backlog=config.backlog
             )


### PR DESCRIPTION
### Checklist

<!-- Please make sure you check all these items before submitting your bug report. -->

- [x] The bug is reproducible against the latest release and/or `master`.
- [x] There are no similar issues or pull requests to fix it yet.

### Describe the bug

When passed a socket via file descriptor using Circus on Windows, Uvicorn produces an AttributeError due to missing AF_UNIX support.

### To reproduce

1. Create a new venv
2. Install Uvicorn
2. Install Circus
3. Create a minimal Circus config using web sockets
```
[watcher:web]
cmd = uvicorn --fd $(circus.sockets.web) run:app
use_sockets = True
numprocesses = 1

[socket:web]
host = 127.0.0.1
port = 80
```
4. Create a minimal app
```
async def program():
    return 'Hello World'


app = program()
```
5. Run the app using circusd in the venv
`circusd circus.ini`



### Expected behavior

Navigating to http://localhost will display the output of the web app

### Actual behavior

An AttributeError is thrown and Circus loops as it attempts to start the process

### Debugging material
```
Traceback (most recent call last):
  File "C:\Users\____\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\____\AppData\Local\Programs\Python\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\____\venv\Scripts\uvicorn.exe\__main__.py", line 9, in <module>
  File "c:\users\____\venv\lib\site-packages\click\core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\____\venv\lib\site-packages\click\core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "c:\users\____\venv\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\____\venv\lib\site-packages\click\core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "c:\users\____\venv\lib\site-packages\uvicorn\main.py", line 371, in main
    run(app, **kwargs)
  File "c:\users\____\venv\lib\site-packages\uvicorn\main.py", line 393, in run
    server.run()
  File "c:\users\____\venv\lib\site-packages\uvicorn\server.py", line 50, in run
    loop.run_until_complete(self.serve(sockets=sockets))
  File "C:\Users\____\AppData\Local\Programs\Python\Python37\lib\asyncio\base_events.py", line 579, in run_until_complete
    return future.result()
  File "c:\users\____\venv\lib\site-packages\uvicorn\server.py", line 67, in serve
    await self.startup(sockets=sockets)
  File "c:\users\____\venv\lib\site-packages\uvicorn\server.py", line 120, in startup
    sock = socket.fromfd(config.fd, socket.AF_UNIX, socket.SOCK_STREAM)
AttributeError: module 'socket' has no attribute 'AF_UNIX'
```

### Environment

- OS / Python / Uvicorn version: Running uvicorn 0.14.0 with CPython 3.7.5 on Windows (also occurs on 3.7.9)
- Run using Circus as described above

---

### Original post

Fixes exception when given a file descriptor by a process manager on Windows, where AF_UNIX is not supported

```
Traceback (most recent call last):
  File "C:\Python\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Python\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "____\venv\Scripts\uvicorn.exe\__main__.py", line 7, in <module>
  File "____\venv\lib\site-packages\click\core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "____\venv\lib\site-packages\click\core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "____\venv\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "____\venv\lib\site-packages\click\core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "____\venv\lib\site-packages\uvicorn\main.py", line 371, in main
    run(app, **kwargs)
  File "____\venv\lib\site-packages\uvicorn\main.py", line 393, in run
    server.run()
  File "____\venv\lib\site-packages\uvicorn\server.py", line 50, in run
    loop.run_until_complete(self.serve(sockets=sockets))
  File "C:\Python\Python37\lib\asyncio\base_events.py", line 587, in run_until_complete
    return future.result()
  File "____\venv\lib\site-packages\uvicorn\server.py", line 67, in serve
    await self.startup(sockets=sockets)
  File "____\venv\lib\site-packages\uvicorn\server.py", line 120, in startup
    sock = socket.fromfd(config.fd, socket.AF_UNIX, socket.SOCK_STREAM)
AttributeError: module 'socket' has no attribute 'AF_UNIX'
```