### PR TITLE
Apply coverage only on Python 3.8 using Linux

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,9 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=95
+python_version=$(python -c "import platform; print(platform.python_version())")
+system=$(python -c "import platform; print(platform.system())")
+
+if [ ! "$python_version" = "${python_version#3.8}" ] && [ ! "$system" = "${system#Linux}" ]; then
+    ${PREFIX}coverage report --show-missing --skip-covered --fail-under=97
+fi


### PR DESCRIPTION
This PR goes in line with the discussion on https://github.com/encode/uvicorn/issues/102#issuecomment-797004995 some time ago.

Currently, we have a `--fail-under` flag that is applied to all environments. The thing is that we have different coverage percentages on each environment.

To keep increasing coverage, and not dropping it on the way, the idea here is to consider only `Linux` as platform and `Python 3.8` as Python version.

Alternative solutions:
1. Store artifacts on the CI (coverage files) and create another job to compute the total coverage. 
2. Use codecov.

Also, if members want, I can also add the previous 95% threshold for the non-Linux-3.8 versions.

Edit: JFYK, I'm more in favor of 1/2 than this solution. But it's the shortest one, and it doesn't bring an extra plugin (codecov) to the project.