### PR TITLE
[Alternative] Apply coverage only on Python 3.8 using Linux

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -34,4 +34,5 @@ jobs:
         shell: bash
       - name: "Enforce coverage"
         run: "scripts/coverage"
+        if: ${{ matrix.python-version }} == "3.8" && ${{ matrix.os }} == "ubuntu-latest"
         shell: bash

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,9 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=95
+python_version=$(python -c "import platform; print(platform.python_version())")
+system=$(python -c "import platform; print(platform.system())")
+
+if [ ! "$python_version" = "${python_version#3.8}" ] && [ ! "$system" = "${system#Linux}" ]; then
+    ${PREFIX}coverage report --show-missing --skip-covered --fail-under=97
+fi

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,9 +8,4 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-python_version=$(python -c "import platform; print(platform.python_version())")
-system=$(python -c "import platform; print(platform.system())")
-
-if [ ! "$python_version" = "${python_version#3.8}" ] && [ ! "$system" = "${system#Linux}" ]; then
-    ${PREFIX}coverage report --show-missing --skip-covered --fail-under=97
-fi
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=97


### PR DESCRIPTION
Alternative to #1157

IMO This solution is worse than the original, as developers on their environment would always have their test set failing.  