### PR TITLE
Create event loop on non-main threads 

### DIFF
--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -5,3 +5,6 @@ import sys
 def asyncio_setup() -> None:  # pragma: no cover
     if sys.version_info >= (3, 8) and sys.platform == "win32":
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    else:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)

--- a/uvicorn/loops/uvloop.py
+++ b/uvicorn/loops/uvloop.py
@@ -1,7 +1,11 @@
 import asyncio
+import threading
 
 import uvloop
 
 
 def uvloop_setup() -> None:
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    if threading.current_thread() is threading.main_thread():
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    else:
+        asyncio.set_event_loop(uvloop.new_event_loop())


### PR DESCRIPTION
When we create a new thread, we need to create an event loop.

This behavior was removed on https://github.com/encode/uvicorn/pull/1070/files#r691270112

Edit: I've also added the same behavior for `uvloop`. 
There's a huge discussion about all of this here: https://github.com/encode/uvicorn/issues/742#issuecomment-798766443