### PR TITLE
Revert "When receiving a SIGTERM supervisors should terminate their processes before joining them"

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -74,7 +74,6 @@ class BaseReload:
         self.process.start()
 
     def shutdown(self) -> None:
-        self.process.terminate()
         self.process.join()
         message = "Stopping reloader process [{}]".format(str(self.pid))
         color_message = "Stopping reloader process [{}]".format(

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -64,7 +64,6 @@ class Multiprocess:
 
     def shutdown(self) -> None:
         for process in self.processes:
-            process.terminate()
             process.join()
 
         message = "Stopping parent process [{}]".format(str(self.pid))


### PR DESCRIPTION
Reverts encode/uvicorn#1069

Closes #1160

I've taken my time to understand the situation. I'm going to explain it and then suggest a solution to the previous issue.

Right now, the issue on #1160 (`CancelledError`) is caused because the `CTRL + C` sends a `SIGINT (2)` to both parent and child processes, and given that we merged #1069, we have that the parent is also sending a `SIGTERM (15)` to the child. In other words, the child is receiving two signals, and the way `uvicorn` deals with multiple signals (two) is to forcefully exit the process.

To be more precise, when we press `CTRL + C` we send a `kill` signal to the process group, not to a single process.

Ok. Now, let's go back to the original issue: if we send `SIGINT` to the parent process, it doesn't terminate the children. And that's expected, because `kill -2 <uvicorn_pid>` will only send a signal to the `<uvicorn_pid>`.

The solution here would be to use `kill -2 -<uvicorn_pid>`, which sends a signal to the process group instead of only the parent. That being said, this solves the issue that #1069 (`process.terminate()`) solved, but we also avoid #1160 (`CancelledError`). 

Reference: https://stackoverflow.com/a/392155