### PR TITLE
Add check if childs are still alive and shutdown instead of hanging

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,5 +116,35 @@ def test_cli_incomplete_app_parameter() -> None:
     assert result.exit_code == 1
 
 
+def test_cli_multiprocess_incomplete_app_parameter(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    runner = CliRunner()
+
+    runner.invoke(cli, ["tests.test_cli", "--workers=2"])
+
+    captured = capfd.readouterr()
+
+    assert (
+        'Error loading ASGI app. Import string "tests.test_cli" '
+        'must be in format "<module>:<attribute>".'
+    ) in captured.err
+
+
+def test_cli_reloader_incomplete_app_parameter(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    runner = CliRunner()
+
+    runner.invoke(cli, ["tests.test_cli", "--reload"])
+
+    captured = capfd.readouterr()
+
+    assert (
+        'Error loading ASGI app. Import string "tests.test_cli" '
+        'must be in format "<module>:<attribute>".'
+    ) in captured.err
+
+
 class App:
     pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,21 +116,6 @@ def test_cli_incomplete_app_parameter() -> None:
     assert result.exit_code == 1
 
 
-def test_cli_multiprocess_incomplete_app_parameter(
-    capfd: pytest.CaptureFixture[str],
-) -> None:
-    runner = CliRunner()
-
-    runner.invoke(cli, ["tests.test_cli", "--workers=2"])
-
-    captured = capfd.readouterr()
-
-    assert (
-        'Error loading ASGI app. Import string "tests.test_cli" '
-        'must be in format "<module>:<attribute>".'
-    ) in captured.err
-
-
 def test_cli_reloader_incomplete_app_parameter(
     capfd: pytest.CaptureFixture[str],
 ) -> None:

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -45,6 +45,9 @@ class BaseReload:
             if self.should_restart():
                 self.restart()
 
+            if self.process.exitcode is not None:
+                break
+
         self.shutdown()
 
     def startup(self) -> None:
@@ -76,6 +79,10 @@ class BaseReload:
     def shutdown(self) -> None:
         self.process.terminate()
         self.process.join()
+
+        for _socket in self.sockets:
+            _socket.close()
+
         message = "Stopping reloader process [{}]".format(str(self.pid))
         color_message = "Stopping reloader process [{}]".format(
             click.style(str(self.pid), fg="cyan", bold=True)

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -80,8 +80,8 @@ class BaseReload:
         self.process.terminate()
         self.process.join()
 
-        for _socket in self.sockets:
-            _socket.close()
+        for sock in self.sockets:
+            sock.close()
 
         message = "Stopping reloader process [{}]".format(str(self.pid))
         color_message = "Stopping reloader process [{}]".format(

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -42,7 +42,11 @@ class Multiprocess:
 
     def run(self) -> None:
         self.startup()
-        self.should_exit.wait()
+
+        while not self.should_exit.wait(self.config.reload_delay):
+            if not any(p.exitcode is None for p in self.processes):
+                break
+
         self.shutdown()
 
     def startup(self) -> None:
@@ -66,6 +70,9 @@ class Multiprocess:
         for process in self.processes:
             process.terminate()
             process.join()
+
+        for _socket in self.sockets:
+            _socket.close()
 
         message = "Stopping parent process [{}]".format(str(self.pid))
         color_message = "Stopping parent process [{}]".format(

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -42,11 +42,7 @@ class Multiprocess:
 
     def run(self) -> None:
         self.startup()
-
-        while not self.should_exit.wait(self.config.reload_delay):
-            if not any(p.exitcode is None for p in self.processes):
-                break
-
+        self.should_exit.wait()
         self.shutdown()
 
     def startup(self) -> None:
@@ -70,9 +66,6 @@ class Multiprocess:
         for process in self.processes:
             process.terminate()
             process.join()
-
-        for _socket in self.sockets:
-            _socket.close()
 
         message = "Stopping parent process [{}]".format(str(self.pid))
         color_message = "Stopping parent process [{}]".format(


### PR DESCRIPTION
Fix: #1115 

Since server closes with `sys.exit(1)` on child process without communicating with the parent supervisor we need to check if the process is still alive.

I used the same interval as the one already setup for the reloader, but it could be another one as well.

Also added the tests for the direct call from the command line, and also ensured sockets are closed at the end of the shutdown. Since child dies before being able to properly close their sockets.