### PR TITLE
Ignore `asyncio.sleep` warnings on tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import warnings
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -15,7 +16,11 @@ from uvicorn import Config, Server
 async def run_server(config: Config, sockets=None):
     server = Server(config=config)
     cancel_handle = asyncio.ensure_future(server.serve(sockets=sockets))
-    await asyncio.sleep(0.1)
+
+    # Workaround for Python 3.9.7 (see https://bugs.python.org/issue45097)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        await asyncio.sleep(0.1)
     try:
         yield server
     finally:


### PR DESCRIPTION
On Python 3.9.7, `asyncio.sleep` and `asyncio.gather` were raising warnings. Next patch will solve the issue.

Check https://bugs.python.org/issue45097 for more information.

## Alternative solution

Pin Python 3.9.6 on the pipeline.