### PR TITLE
Fix keepalive timeout task will not execute to close transport

### DIFF
--- a/uvicorn/_handlers/http.py
+++ b/uvicorn/_handlers/http.py
@@ -79,8 +79,7 @@ async def handle_http(
     # yet: all data that the client might have already sent since the connection has
     # been established is in the `_buffer`.
     data = reader._buffer  # type: ignore
-    if data:
-        protocol.data_received(data)
+    protocol.data_received(data)
 
     # Let the transport run in the background. When closed, this future will complete
     # and we'll exit here.

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -126,6 +126,11 @@ class H11Protocol(asyncio.Protocol):
 
     def data_received(self, data):
         self._unset_keepalive_if_required()
+        if data == b"":
+            self.timeout_keep_alive_task = self.loop.call_later(
+                self.timeout_keep_alive, self.timeout_keep_alive_handler
+            )
+            return
 
         self.conn.receive_data(data)
         self.handle_events()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -126,6 +126,11 @@ class HttpToolsProtocol(asyncio.Protocol):
 
     def data_received(self, data):
         self._unset_keepalive_if_required()
+        if data == b"":
+            self.timeout_keep_alive_task = self.loop.call_later(
+                self.timeout_keep_alive, self.timeout_keep_alive_handler
+            )
+            return
 
         try:
             self.parser.feed_data(data)


### PR DESCRIPTION
When transport can not kick off the HTTP protocol, the `on_response_complete` method will not be executed to start a keep-alive timeout task, in this situation if the client-side stream sends EOF, the server-side will not close this transport by timeout task and this TCP connection will keep `CLOSE_WAIT` status.

Start a TCP connection with telnet can replicate this issue. Expect the connection should be close after the keep-alive is timeout.
```bash
telnet 127.0.0.1 8000
```
Relates to #160. Some applications like Chrome or wrk will start a TCP connection to send empty-bytes at first before start the HTTP protocol TCP connection.