### PR TITLE
Version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.16.0 - <date>
+
+- Bump websockets version to 10.0 on Python 3.7+ (#1180)
+
 ## 0.15.0 - 2021-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.16.0 - <date>
 
+### Changed
 - Bump websockets version to 10.0 on Python 3.7+ (#1180)
 
 ## 0.15.0 - 2021-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump websockets version to 10.0 on Python 3.7+ (#1180)
 
+### Fixed
+
+- Terminate reload process in case startup event fails (#1177)
+
 ## 0.15.0 - 2021-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.16.0 - <date>
 
 ### Changed
+
 - Bump websockets version to 10.0 on Python 3.7+ (#1180)
 
 ## 0.15.0 - 2021-08-13

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
This release will complete the milestone [Version 0.16.0](https://github.com/encode/uvicorn/milestone/5). 

## Missing

- https://github.com/encode/uvicorn/pull/1173
- https://github.com/encode/uvicorn/pull/1194
- https://github.com/encode/uvicorn/pull/1159
- https://github.com/encode/uvicorn/pull/1110
- https://github.com/encode/uvicorn/pull/1114
- https://github.com/encode/uvicorn/pull/1177
- https://github.com/encode/uvicorn/pull/1128
- https://github.com/encode/uvicorn/pull/1165

## Anything else?

Let me know if there are PRs missing.

## Draft release?

Still not created. I'll create later on.