### PR TITLE
Remove illogical wording in docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -39,12 +39,12 @@ Options:
                                   of using the current working directory.
   --reload-include TEXT           Set glob patterns to include while watching
                                   for files. Includes '*.py' by default; these
-                                  defaults can be overridden in --reload-
-                                  exclude.
+                                  defaults can be overridden in `--reload-
+                                  exclude`.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files. Includes '.*, .py[cod], .sw.*,
-                                  ~*' by default; the defaults can be
-                                  overridden in --reload-include.
+                                  ~*' by default; these defaults can be
+                                  overridden in `--reload-include`.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,12 +38,13 @@ Options:
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
   --reload-include TEXT           Set glob patterns to include while watching
-                                  for files. Includes '*.py' by default, which
-                                  can be overridden in reload-excludes.
+                                  for files. Includes '*.py' by default; these
+                                  defaults can be overridden in --reload-
+                                  exclude.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files. Includes '.*, .py[cod], .sw.*,
-                                  ~*' by default, which can be overridden in
-                                  reload-excludes.
+                                  ~*' by default; the defaults can be
+                                  overridden in --reload-include.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,11 +111,13 @@ Options:
   --reload-dir PATH               Set reload directories explicitly, instead
                                   of using the current working directory.
   --reload-include TEXT           Set glob patterns to include while watching
-                                  for files. Includes '*.py' by default, which
-                                  can be overridden in reload-excludes.
+                                  for files. Includes '*.py' by default; these
+                                  defaults can be overridden in --reload-
+                                  exclude.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files. Includes '.*, .py[cod], .sw.*,
-                                  ~*' by default.
+                                  ~*' by default; the defaults can be
+                                  overridden in --reload-include.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,12 +112,12 @@ Options:
                                   of using the current working directory.
   --reload-include TEXT           Set glob patterns to include while watching
                                   for files. Includes '*.py' by default; these
-                                  defaults can be overridden in --reload-
-                                  exclude.
+                                  defaults can be overridden in `--reload-
+                                  exclude`.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files. Includes '.*, .py[cod], .sw.*,
-                                  ~*' by default; the defaults can be
-                                  overridden in --reload-include.
+                                  ~*' by default; these defaults can be
+                                  overridden in `--reload-include`.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,8 +115,7 @@ Options:
                                   can be overridden in reload-excludes.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files. Includes '.*, .py[cod], .sw.*,
-                                  ~*' by default, which can be overridden in
-                                  reload-excludes.
+                                  ~*' by default.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -23,8 +23,8 @@ you should put `uvicorn.run` into `if __name__ == '__main__'` clause in the main
 
 * `--reload` - Enable auto-reload.
 * `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default the whole current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.
-* `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in --reload-exclude.
-* `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These defaults can be overwritten by including them in --reload-include.
+* `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in `--reload-exclude`.
+* `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These defaults can be overwritten by including them in `--reload-include`.
 
 By default Uvicorn uses simple changes detection strategy that compares python files modification times few times a second. If this approach doesn't work for your project (eg. because of its complexity), or you need watching of non python files you can install [watchgod](https://pypi.org/project/watchgod/) or install uvicorn with `uvicorn[standard]`, which will include watchgod.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -23,8 +23,8 @@ you should put `uvicorn.run` into `if __name__ == '__main__'` clause in the main
 
 * `--reload` - Enable auto-reload.
 * `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default the whole current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.
-* `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These can be overwritten by explicitly excluding them.
-* `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These can be overwritten by explicitly including them.
+* `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in --reload-exclude.
+* `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These defaults can be overwritten by including them in --reload-include.
 
 By default Uvicorn uses simple changes detection strategy that compares python files modification times few times a second. If this approach doesn't work for your project (eg. because of its complexity), or you need watching of non python files you can install [watchgod](https://pypi.org/project/watchgod/) or install uvicorn with `uvicorn[standard]`, which will include watchgod.
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -85,14 +85,15 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "reload_includes",
     multiple=True,
     help="Set glob patterns to include while watching for files. Includes '*.py' "
-    "by default, which can be overridden in reload-excludes.",
+    "by default; these defaults can be overridden in --reload-exclude.",
 )
 @click.option(
     "--reload-exclude",
     "reload_excludes",
     multiple=True,
     help="Set glob patterns to exclude while watching for files. Includes "
-    "'.*, .py[cod], .sw.*, ~*' by default, which can be overridden in reload-excludes.",
+    "'.*, .py[cod], .sw.*, ~*' by default; the defaults can be overridden "
+    "in --reload-include.",
 )
 @click.option(
     "--reload-delay",

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -85,15 +85,15 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "reload_includes",
     multiple=True,
     help="Set glob patterns to include while watching for files. Includes '*.py' "
-    "by default; these defaults can be overridden in --reload-exclude.",
+    "by default; these defaults can be overridden in `--reload-exclude`.",
 )
 @click.option(
     "--reload-exclude",
     "reload_excludes",
     multiple=True,
     help="Set glob patterns to exclude while watching for files. Includes "
-    "'.*, .py[cod], .sw.*, ~*' by default; the defaults can be overridden "
-    "in --reload-include.",
+    "'.*, .py[cod], .sw.*, ~*' by default; these defaults can be overridden "
+    "in `--reload-include`.",
 )
 @click.option(
     "--reload-delay",


### PR DESCRIPTION
I'm not sure if you meant to say reload-includes, and I didn't check the source code, but this just seemed confusing since it says to override the argument you are specifying.