### PR TITLE
Fix sys.stdin being None on windows

### DIFF
--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -32,11 +32,11 @@ def get_subprocess(
     """
     # We pass across the stdin fileno, and reopen it in the child process.
     # This is required for some debugging environments.
-    stdin_fileno: Optional[int]
+    stdin_fileno: Optional[int] = None
     try:
         stdin_fileno = sys.stdin.fileno()
-    except OSError:
-        stdin_fileno = None
+    except Exception:
+        pass
 
     kwargs = {
         "config": config,


### PR DESCRIPTION
# Summary

The sys.stdin can be None in some specific cases e.g Windows GUI application that does not have attached console.

The issue occurs in `uvicorn/subprocess.py:get_subprocess` function resulting in fatal errors further on.

This PR fixes that issue, and brings back possibility to run uvicorn as a part of windows GUI application.

# Changes

Provided solution improves reliability of `get_subprocess` function by setting `stdin_fileno` by default to `None`.

# Notes
Here is a mention about std* descriptors in python docs:
https://docs.python.org/3/library/sys.html
```
Note Under some conditions stdin, stdout and stderr as well as the original values __stdin__, __stdout__ and __stderr__ can be None. It is usually the case for Windows GUI apps that aren’t connected to a console and Python apps started with pythonw.
```
