### PR TITLE
Show warning about incorrect IP in trusted hosts

### DIFF
--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -8,6 +8,8 @@ the connecting client, rather that the connecting proxy.
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
+import ipaddress
+import logging
 from typing import List, Optional, Tuple, Union, cast
 
 from asgiref.typing import (
@@ -30,6 +32,12 @@ class ProxyHeadersMiddleware:
         else:
             self.trusted_hosts = set(trusted_hosts)
         self.always_trust = "*" in self.trusted_hosts
+
+        try:
+            list(map(ipaddress.ip_address, self.trusted_hosts))
+        except ValueError:
+            logger = logging.getLogger("uvicorn.warning")
+            logger.warning("Incorrect IP in trusted hosts")
 
     def get_trusted_client_host(
         self, x_forwarded_for_hosts: List[str]


### PR DESCRIPTION
Right now you can pass any incorrect data to `--forwarded-allow-ips` and `uvicorn` starts as expected with no warning at least.

Correct values for now:
* `--forwarded-allow-ips="1.2.3.4,777.289.357.999"`
* `--forwarded-allow-ips="1.2.3.4.5.6.7.8,foo bar"`
* `--forwarded-allow-ips="2001:db8::1X,333.333.333.333"`
* `--forwarded-allow-ips=""`

I think we should check IPs and raise up warning about existing incorrect IP in `trusted hosts`.

This **PR** implements checking IPs in `--forwarded-allow-ips` and raises warning to stdout like: 
`Incorrect IP in trusted hosts`.

Inspired by #1223 