### PR TITLE
Make use of the unused_tcp_port fixture to spawn the server on a random port

### DIFF
--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -12,55 +12,58 @@ async def app(scope, receive, send):
 
 
 @pytest.mark.asyncio
-async def test_default_default_headers():
-    config = Config(app=app, loop="asyncio", limit_max_requests=1)
+async def test_default_default_headers(unused_tcp_port):
+    config = Config(app=app, port=unused_tcp_port, loop="asyncio", limit_max_requests=1)
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert response.headers["server"] == "uvicorn" and response.headers["date"]
 
 
 @pytest.mark.asyncio
-async def test_override_server_header():
+async def test_override_server_header(unused_tcp_port):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden")],
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert (
                 response.headers["server"] == "over-ridden" and response.headers["date"]
             )
 
 
 @pytest.mark.asyncio
-async def test_disable_default_server_header():
+async def test_disable_default_server_header(unused_tcp_port):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         server_header=False,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert "server" not in response.headers
 
 
 @pytest.mark.asyncio
-async def test_override_server_header_multiple_times():
+async def test_override_server_header_multiple_times(unused_tcp_port):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden"), ("Server", "another-value")],
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert (
                 response.headers["server"] == "over-ridden, another-value"
                 and response.headers["date"]
@@ -68,16 +71,17 @@ async def test_override_server_header_multiple_times():
 
 
 @pytest.mark.asyncio
-async def test_add_additional_header():
+async def test_add_additional_header(unused_tcp_port):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("X-Additional", "new-value")],
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert (
                 response.headers["x-additional"] == "new-value"
                 and response.headers["server"] == "uvicorn"
@@ -86,14 +90,15 @@ async def test_add_additional_header():
 
 
 @pytest.mark.asyncio
-async def test_disable_default_date_header():
+async def test_disable_default_date_header(unused_tcp_port):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         date_header=False,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert "date" not in response.headers

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -17,9 +17,11 @@ async def test_run(
     tls_certificate_server_cert_path,
     tls_certificate_private_key_path,
     tls_ca_certificate_pem_path,
+    unused_tcp_port,
 ):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         ssl_keyfile=tls_certificate_private_key_path,
@@ -28,16 +30,20 @@ async def test_run(
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 
 @pytest.mark.asyncio
 async def test_run_chain(
-    tls_ca_ssl_context, tls_certificate_key_and_chain_path, tls_ca_certificate_pem_path
+    tls_ca_ssl_context,
+    tls_certificate_key_and_chain_path,
+    tls_ca_certificate_pem_path,
+    unused_tcp_port,
 ):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_key_and_chain_path,
@@ -45,21 +51,24 @@ async def test_run_chain(
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 
 @pytest.mark.asyncio
-async def test_run_chain_only(tls_ca_ssl_context, tls_certificate_key_and_chain_path):
+async def test_run_chain_only(
+    tls_ca_ssl_context, tls_certificate_key_and_chain_path, unused_tcp_port
+):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_key_and_chain_path,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 
@@ -69,9 +78,11 @@ async def test_run_password(
     tls_certificate_server_cert_path,
     tls_ca_certificate_pem_path,
     tls_certificate_private_key_encrypted_path,
+    unused_tcp_port,
 ):
     config = Config(
         app=app,
+        port=unused_tcp_port,
         loop="asyncio",
         limit_max_requests=1,
         ssl_keyfile=tls_certificate_private_key_encrypted_path,
@@ -81,5 +92,5 @@ async def test_run_password(
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204


### PR DESCRIPTION
small attempt to see if this could solve debian packaging connection issues, see https://github.com/encode/uvicorn/discussions/1231#discussioncomment-1600482
