### PR TITLE
Avoid error messages from logging when port is str

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -188,7 +188,7 @@ class Config:
         self,
         app: Union[ASGIApplication, Callable, str],
         host: str = "127.0.0.1",
-        port: int = 8000,
+        port: Union[int, str] = 8000,
         uds: Optional[str] = None,
         fd: Optional[int] = None,
         loop: LoopSetupType = "auto",
@@ -234,7 +234,7 @@ class Config:
     ):
         self.app = app
         self.host = host
-        self.port = port
+        self.port = int(port)
         self.uds = uds
         self.fd = fd
         self.loop = loop


### PR DESCRIPTION
Currently, starting uvicorn with port argument as a string would work - but the logging message at startup

> Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)

would crash because it expected an int. This fixes that.