### PR TITLE
Ensure HTTP connections are closed in case of data-less TCP pings

### DIFF
--- a/uvicorn/_handlers/http.py
+++ b/uvicorn/_handlers/http.py
@@ -81,6 +81,11 @@ async def handle_http(
     data = reader._buffer  # type: ignore
     if data:
         protocol.data_received(data)
+    else:
+        # Client already disconnected.
+        # E.g. they sent a TCP ping health check.
+        # Fine, let's disconnect too.
+        transport.close()
 
     # Let the transport run in the background. When closed, this future will complete
     # and we'll exit here.

--- a/uvicorn/_handlers/http.py
+++ b/uvicorn/_handlers/http.py
@@ -79,13 +79,7 @@ async def handle_http(
     # yet: all data that the client might have already sent since the connection has
     # been established is in the `_buffer`.
     data = reader._buffer  # type: ignore
-    if data:
-        protocol.data_received(data)
-    else:
-        # Client already disconnected.
-        # E.g. they sent a TCP ping health check.
-        # Fine, let's disconnect too.
-        transport.close()
+    protocol.data_received(data)
 
     # Let the transport run in the background. When closed, this future will complete
     # and we'll exit here.

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -223,6 +223,11 @@ class H11Protocol(asyncio.Protocol):
                 self.cycle.more_body = False
                 self.cycle.message_event.set()
 
+            elif event_type is h11.ConnectionClosed:
+                if not self.transport.is_closing():
+                    self.transport.close()
+                break
+
     def handle_upgrade(self, event):
         upgrade_value = None
         for name, value in self.headers:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -137,6 +137,9 @@ class HttpToolsProtocol(asyncio.Protocol):
         except httptools.HttpParserUpgrade:
             self.handle_upgrade()
 
+        if data == b"" and not self.transport.is_closing():
+            self.transport.close()
+
     def handle_upgrade(self):
         upgrade_value = None
         for name, value in self.headers:


### PR DESCRIPTION
Closes https://github.com/encode/uvicorn/issues/1226

Completes #869 (released in 0.14.0) with a missing branch: it _is_ possible that `data` be `b""`, e.g. if the client is a health checker that uses empty TCP pings to verify a service is up. As shown in #1226, this may be the case in k8s environments for example. In that case, we should be mindful of closing the `transport`, i.e. closing the connection (hence the connection/memory leak reported in #1226).

To reproduce before/after, consider this server:

```python
async def app(scope, receive, send):
    if scope["type"] == "lifespan":
        await lifespan(scope, receive, send)
        return

    assert scope["type"] == "http"
    await http(scope, receive, send)
    await send(
        {
            "type": "http.response.start",
            "status": 200,
            "headers": [[b"content-type", b"text/plain"]],
        }
    )
```

And this "ping as fast as you can" client:

```python
import socket

while True:
    with socket.create_connection(("localhost", 8000)) as sock:
        pass
```

0. Fire up a resource monitor, e.g. Activity Monitor on macOS.
1. Launch the server.
2. Lookup the Python process activity.
2. Launch the client.

Before the change, the Python process memory would go up indefinitely, at a pace that varies from system to system. Eg I start from 16MB and get to >20MB and up in just a few seconds.

After the change, memory remains stable. Eg I see a stable 17.1 MB despite the client hitting the server with pings.