### PR TITLE
Fix 1230; don't call ensure_open in WebSocketProtocol.asgi_receive

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import httpx
 import pytest
 
@@ -559,7 +561,6 @@ async def test_server_reject_connection(ws_protocol_cls, http_protocol_cls):
         # This doesn't raise `TypeError`:
         # See https://github.com/encode/uvicorn/issues/244
         message = await receive()
-        print("message", message)
         assert message["type"] == "websocket.disconnect"
 
     async def websocket_session(url):
@@ -572,3 +573,35 @@ async def test_server_reject_connection(ws_protocol_cls, http_protocol_cls):
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
     async with run_server(config):
         await websocket_session("ws://127.0.0.1:8000")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_can_read_messages_in_buffer_after_close(
+    ws_protocol_cls, http_protocol_cls
+):
+    frames = []
+
+    class App(WebSocketResponse):
+        async def websocket_connect(self, message):
+            await self.send({"type": "websocket.accept"})
+            # Ensure server doesn't start reading frames from read buffer until
+            # after client has sent close frame, but server is still able to
+            # read these frames
+            await asyncio.sleep(0.2)
+
+        async def websocket_receive(self, message):
+            frames.append(message.get("bytes"))
+
+    async def send_text(url):
+        async with websockets.connect(url) as websocket:
+            await websocket.send(b"abc")
+            await websocket.send(b"abc")
+            await websocket.send(b"abc")
+
+    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    async with run_server(config):
+        await send_text("ws://127.0.0.1:8000")
+
+    assert frames == [b"abc", b"abc", b"abc"]


### PR DESCRIPTION
Closes https://github.com/encode/uvicorn/issues/1230. Reverts most of https://github.com/encode/uvicorn/commit/9a3040c9cd56844631b28631acd5862b5a4eafdd

We can't call `WebSocketCommonProtocol.ensure_open` before calling `WebSocketCommonProtocol.recv`, because there may be unread frames in the server's read queue that were sent by the client **before** the client sent the close frame. [See this comment from the websockets source code](https://github.com/aaugustin/websockets/blob/ed9a7b446c7147f6f88dbeb1d86546ad754e435e/src/websockets/legacy/protocol.py#L521-L525)

`WebSocketCommonProtocol.ensure_open` raises an exception and prevents the server from reading these unread frames. Neither the client, nor application code using uvicorn, has any way of knowing that frames successfully sent by the client to the server's read queue, before any close frame was sent, will never be read by the server.

The spec is clear on this: https://datatracker.ietf.org/doc/html/rfc6455#section-1.4

> After sending a control frame indicating the connection should be closed, a peer does not send any further data; after receiving a control frame indicating the connection should be closed, a peer discards any further data received.

The current behavior in uvicorn is rather "a peer discards any further data received, and any data previously received"

Also worth noting, https://github.com/aaugustin/websockets/pull/670 was eventually closed without any changes being made; in other words, there was no bug in `websockets`, and the maintainer agrees that calling `await self.ensure_open()` in `recv` is incorrect

-----

I tested `uvicorn` after making these changes, and the behavior is as expected; the server can read frames in the read queue after a close frame is sent by the client, as long as those frames were sent before the close frame