### PR TITLE
Feature/verify flags

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -341,7 +341,7 @@ def test_ssl_config_cert_reqs(
         app=asgi_app,
         ssl_certfile=tls_ca_certificate_pem_path,
         ssl_keyfile=tls_ca_certificate_private_key_path,
-        ssl_cert_reqs=ssl.VerifyMode.CERT_REQUIRED
+        ssl_cert_reqs=ssl.VerifyMode.CERT_REQUIRED,
     )
     config.load()
 
@@ -358,16 +358,18 @@ def test_ssl_config_cert_req_flags(
         ssl_keyfile=tls_ca_certificate_private_key_path,
         ssl_cert_reqs=(
             ssl.VerifyMode.CERT_REQUIRED,
-            ssl.VerifyFlags.VERIFY_X509_STRICT | \
-                ssl.VerifyFlags.VERIFY_X509_TRUSTED_FIRST
-        )
+            ssl.VerifyFlags.VERIFY_X509_STRICT
+            | ssl.VerifyFlags.VERIFY_X509_TRUSTED_FIRST,
+        ),
     )
     config.load()
 
     assert config.ssl.verify_mode == ssl.VerifyMode.CERT_REQUIRED
-    assert config.ssl.verify_flags == \
-        ssl.VerifyFlags.VERIFY_X509_STRICT | \
-            ssl.VerifyFlags.VERIFY_X509_TRUSTED_FIRST
+    assert (
+        config.ssl.verify_flags
+        == ssl.VerifyFlags.VERIFY_X509_STRICT
+        | ssl.VerifyFlags.VERIFY_X509_TRUSTED_FIRST
+    )
 
 
 def asgi2_app(scope: Scope) -> typing.Callable:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import socket
+import ssl
 import sys
 import typing
 from copy import deepcopy
@@ -330,6 +331,43 @@ def test_ssl_config_combined(tls_certificate_key_and_chain_path: str) -> None:
     config.load()
 
     assert config.is_ssl is True
+
+
+def test_ssl_config_cert_reqs(
+    tls_ca_certificate_pem_path: str,
+    tls_ca_certificate_private_key_path: str,
+) -> None:
+    config = Config(
+        app=asgi_app,
+        ssl_certfile=tls_ca_certificate_pem_path,
+        ssl_keyfile=tls_ca_certificate_private_key_path,
+        ssl_cert_reqs=ssl.VerifyMode.CERT_REQUIRED
+    )
+    config.load()
+
+    assert config.ssl.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+
+
+def test_ssl_config_cert_req_flags(
+    tls_ca_certificate_pem_path: str,
+    tls_ca_certificate_private_key_path: str,
+) -> None:
+    config = Config(
+        app=asgi_app,
+        ssl_certfile=tls_ca_certificate_pem_path,
+        ssl_keyfile=tls_ca_certificate_private_key_path,
+        ssl_cert_reqs=(
+            ssl.VerifyMode.CERT_REQUIRED,
+            ssl.VerifyFlags.VERIFY_X509_STRICT | \
+                ssl.VerifyFlags.VERIFY_X509_TRUSTED_FIRST
+        )
+    )
+    config.load()
+
+    assert config.ssl.verify_mode == ssl.VerifyMode.CERT_REQUIRED
+    assert config.ssl.verify_flags == \
+        ssl.VerifyFlags.VERIFY_X509_STRICT | \
+            ssl.VerifyFlags.VERIFY_X509_TRUSTED_FIRST
 
 
 def asgi2_app(scope: Scope) -> typing.Callable:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -118,13 +118,16 @@ def create_ssl_context(
     keyfile: Optional[Union[str, os.PathLike]],
     password: Optional[str],
     ssl_version: int,
-    cert_reqs: int,
+    cert_reqs: Union[int, Tuple[int, int]],
     ca_certs: Optional[Union[str, os.PathLike]],
     ciphers: Optional[str],
 ) -> ssl.SSLContext:
     ctx = ssl.SSLContext(ssl_version)
     get_password = (lambda: password) if password else None
     ctx.load_cert_chain(certfile, keyfile, get_password)
+    if isinstance(cert_reqs, Tuple):
+        (cert_reqs, cert_req_flags) = cert_reqs
+        ctx.verify_flags = cert_req_flags
     ctx.verify_mode = cert_reqs
     if ca_certs:
         ctx.load_verify_locations(ca_certs)
@@ -226,7 +229,7 @@ class Config:
         ssl_certfile: Optional[Union[str, os.PathLike]] = None,
         ssl_keyfile_password: Optional[str] = None,
         ssl_version: int = SSL_PROTOCOL_VERSION,
-        ssl_cert_reqs: int = ssl.CERT_NONE,
+        ssl_cert_reqs: Union[int, Tuple[int, int]] = ssl.CERT_NONE,
         ssl_ca_certs: Optional[str] = None,
         ssl_ciphers: str = "TLSv1",
         headers: Optional[List[List[str]]] = None,


### PR DESCRIPTION
Extend `cert_reqs` to also allow setting the `SSLContext.verify_flags` in addition to the `SSLContext.verify_mode`.