### PR TITLE
Override default asyncio event loop with reload only

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -493,7 +493,7 @@ class Config:
     def setup_event_loop(self) -> None:
         loop_setup: Optional[Callable] = import_from_string(LOOP_SETUPS[self.loop])
         if loop_setup is not None:
-            loop_setup()
+            loop_setup(reload=self.reload)
 
     def bind_socket(self) -> socket.socket:
         logger_args: List[Union[str, int]]

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -1,12 +1,11 @@
 import asyncio
 import logging
 import sys
-from typing import Any
 
 logger = logging.getLogger("uvicorn.error")
 
 
-def asyncio_setup(reload: bool = False, **_: Any) -> None:  # pragma: no cover
+def asyncio_setup(reload: bool = False) -> None:  # pragma: no cover
     if sys.version_info >= (3, 8) and sys.platform == "win32" and reload:
         logger.warning("The --reload flag should not be used in production on Windows.")
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -1,11 +1,12 @@
 import asyncio
 import logging
 import sys
+from typing import Any
 
 logger = logging.getLogger("uvicorn.error")
 
 
-def asyncio_setup(reload: bool = False, **_) -> None:  # pragma: no cover
+def asyncio_setup(reload: bool = False, **_: Any) -> None:  # pragma: no cover
     if sys.version_info >= (3, 8) and sys.platform == "win32" and reload:
         logger.warning("The --reload flag should not be used in production on Windows.")
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -1,7 +1,12 @@
 import asyncio
+import logging
 import sys
 
+logger = logging.getLogger("uvicorn.error")
 
-def asyncio_setup() -> None:  # pragma: no cover
-    if sys.version_info >= (3, 8) and sys.platform == "win32":
+
+def asyncio_setup(reload: bool = False, **_) -> None:  # pragma: no cover
+    if sys.version_info >= (3, 8) and sys.platform == "win32" and reload:
+        logger.warning("Overriding default event loop due to --reload flag.")
+        logger.warning("The --reload flag should not be used in production on Windows")
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -7,6 +7,5 @@ logger = logging.getLogger("uvicorn.error")
 
 def asyncio_setup(reload: bool = False, **_) -> None:  # pragma: no cover
     if sys.version_info >= (3, 8) and sys.platform == "win32" and reload:
-        logger.warning("Overriding default event loop due to --reload flag.")
-        logger.warning("The --reload flag should not be used in production on Windows")
+        logger.warning("The --reload flag should not be used in production on Windows.")
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -1,14 +1,11 @@
-from typing import Any
-
-
-def auto_loop_setup(**kwdargs: Any) -> None:
+def auto_loop_setup(reload: bool = False) -> None:
     try:
         import uvloop  # noqa
     except ImportError:  # pragma: no cover
         from uvicorn.loops.asyncio import asyncio_setup as loop_setup
 
-        loop_setup(**kwdargs)
+        loop_setup(reload=reload)
     else:  # pragma: no cover
         from uvicorn.loops.uvloop import uvloop_setup
 
-        uvloop_setup(**kwdargs)
+        uvloop_setup(reload=reload)

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -1,4 +1,7 @@
-def auto_loop_setup(**kwdargs) -> None:
+from typing import Any
+
+
+def auto_loop_setup(**kwdargs: Any) -> None:
     try:
         import uvloop  # noqa
     except ImportError:  # pragma: no cover

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -1,11 +1,11 @@
-def auto_loop_setup() -> None:
+def auto_loop_setup(**kwdargs) -> None:
     try:
         import uvloop  # noqa
     except ImportError:  # pragma: no cover
         from uvicorn.loops.asyncio import asyncio_setup as loop_setup
 
-        loop_setup()
+        loop_setup(**kwdargs)
     else:  # pragma: no cover
         from uvicorn.loops.uvloop import uvloop_setup
 
-        uvloop_setup()
+        uvloop_setup(**kwdargs)

--- a/uvicorn/loops/uvloop.py
+++ b/uvicorn/loops/uvloop.py
@@ -1,7 +1,8 @@
 import asyncio
+from typing import Any
 
 import uvloop
 
 
-def uvloop_setup(**_) -> None:
+def uvloop_setup(**_: Any) -> None:
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())

--- a/uvicorn/loops/uvloop.py
+++ b/uvicorn/loops/uvloop.py
@@ -1,8 +1,7 @@
 import asyncio
-from typing import Any
 
 import uvloop
 
 
-def uvloop_setup(**_: Any) -> None:
+def uvloop_setup(reload: bool = False) -> None:
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())

--- a/uvicorn/loops/uvloop.py
+++ b/uvicorn/loops/uvloop.py
@@ -3,5 +3,5 @@ import asyncio
 import uvloop
 
 
-def uvloop_setup() -> None:
+def uvloop_setup(**_) -> None:
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())


### PR DESCRIPTION
#535 changed the default event loop in windows to the selector event loop to avoid an issue with the --reload flag (see #529).

This can cause the issue described in #1220 as well as make the asyncio.subprocess.create_subprocess_* calls fail.

This PR overrides the event loop only with reload configured on windows and logs a warning as suggested in this [comment](https://github.com/encode/uvicorn/issues/1220#issuecomment-974027158).