### PR TITLE
Allow WebSocket close event to receive reason being None from ASGI app

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -403,7 +403,11 @@ async def test_asgi_return_value(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 @pytest.mark.parametrize("code", [None, 1000, 1001])
-@pytest.mark.parametrize("reason", [None, "test"])
+@pytest.mark.parametrize(
+    "reason",
+    [None, "test", False],
+    ids=["none_as_reason", "normal_reason", "without_reason"],
+)
 async def test_app_close(ws_protocol_cls, http_protocol_cls, code, reason):
     async def app(scope, receive, send):
         while True:
@@ -416,7 +420,7 @@ async def test_app_close(ws_protocol_cls, http_protocol_cls, code, reason):
                 if code is not None:
                     reply["code"] = code
 
-                if reason is not None:
+                if reason is not False:
                     reply["reason"] = reason
 
                 await send(reply)

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -261,7 +261,7 @@ class WebSocketProtocol(_LoggerMixin, websockets.WebSocketServerProtocol):
 
             elif message_type == "websocket.close":
                 code = message.get("code", 1000)
-                reason = message.get("reason", "")
+                reason = message.get("reason", "") or ""
                 await self.close(code, reason)
                 self.closed_event.set()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -297,7 +297,7 @@ class WSProtocol(asyncio.Protocol):
             elif message_type == "websocket.close":
                 self.close_sent = True
                 code = message.get("code", 1000)
-                reason = message.get("reason", "")
+                reason = message.get("reason", "") or ""
                 self.queue.put_nowait({"type": "websocket.disconnect", "code": code})
                 output = self.conn.send(
                     wsproto.events.CloseConnection(code=code, reason=reason)


### PR DESCRIPTION
This is a small fix to the "reason" key on the WebSocket close event. According to the ASGI specs, the application can send `None` on the "reason" field:
 
```
`reason` (Unicode string) – A reason given for the closure, can be any string. Optional; if missing or `None` default is empty string.
```

This PR adds the possibility from the server to send `None`, and if that's the case, it will default to empty string.

Reference: https://asgi.readthedocs.io/en/latest/specs/www.html#close-send-event