### PR TITLE
Remove Python 3.6

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [windows-latest, ubuntu-latest]
     steps:
       - uses: "actions/checkout@v2"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Documentation**: [https://www.uvicorn.org](https://www.uvicorn.org)
 
-**Requirements**: Python 3.6+ (For Python 3.5 support, install version 0.8.6.)
+**Requirements**: Python 3.7+ (For Python 3.6 support, install version 0.15.0.)
 
 Uvicorn is a lightning-fast ASGI server implementation, using [uvloop][uvloop] and [httptools][httptools].
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ cryptography==3.4.8
 coverage==5.5
 httpx==1.0.0b0
 pytest-asyncio==0.15.1
-async_generator==1.10 ; python_version < '3.7'
 
 
 # Documentation

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ env_marker_cpython = (
 
 env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
-env_marker_below_37 = "python_version < '3.7'"
-env_marker_gte_37 = "python_version >= '3.7'"
 
 minimal_requirements = [
     "asgiref>=3.4.0",
@@ -54,9 +52,7 @@ minimal_requirements = [
 
 
 extra_requirements = [
-    "websockets>=9.1; " + env_marker_below_37,
-    "websockets>=10.0; " + env_marker_gte_37,
-    "httptools>=0.2.0,<0.4.0",
+    "websockets>=1" "httptools>=0.2.0,<0.4.0",
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",
@@ -87,7 +83,6 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Internet :: WWW/HTTP",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ minimal_requirements = [
 
 
 extra_requirements = [
-    "websockets>=1" "httptools>=0.2.0,<0.4.0",
+    "websockets>=10.0",
+    "httptools>=0.2.0,<0.4.0",
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,7 @@
 import asyncio
 import os
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
-
-try:
-    from contextlib import asynccontextmanager
-except ImportError:  # pragma: no cover
-    from async_generator import asynccontextmanager
 
 from uvicorn import Config, Server
 

--- a/uvicorn/_handlers/http.py
+++ b/uvicorn/_handlers/http.py
@@ -51,7 +51,8 @@ async def handle_http(
     # So we need to attach a callback to handle exceptions ourselves for that case.
     # (It's not easy to know which loop we're effectively running on, so we attach the
     # callback in all cases. In practice it won't be called on vanilla asyncio.)
-    task = _get_current_task()
+    task = asyncio.current_task()
+    assert task is not None
 
     @task.add_done_callback
     def retrieve_exception(task: asyncio.Task) -> None:
@@ -85,15 +86,3 @@ async def handle_http(
     # Let the transport run in the background. When closed, this future will complete
     # and we'll exit here.
     await connection_lost
-
-
-def _get_current_task() -> asyncio.Task:
-    try:
-        current_task = asyncio.current_task  # type: ignore
-    except AttributeError:  # pragma: no cover
-        # Python 3.6.
-        current_task = asyncio.Task.current_task  # type: ignore
-
-    task = current_task()
-    assert task is not None
-    return task

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -1,7 +1,6 @@
 import asyncio
 import http
 import logging
-import sys
 from typing import Callable
 from urllib.parse import unquote
 
@@ -25,22 +24,7 @@ class Server:
         return not self.closing
 
 
-# special case logger kwarg in websockets >=10
-if sys.version_info >= (3, 7):
-
-    class _LoggerMixin:
-        pass
-
-
-else:
-
-    class _LoggerMixin:
-        def __init__(self, *args, logger, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.logger = logging.LoggerAdapter(logger, {"websocket": self})
-
-
-class WebSocketProtocol(_LoggerMixin, websockets.WebSocketServerProtocol):
+class WebSocketProtocol(websockets.WebSocketServerProtocol):
     def __init__(
         self, config, server_state, on_connection_lost: Callable = None, _loop=None
     ):

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -64,9 +64,7 @@ class Server:
 
     def run(self, sockets: Optional[List[socket.socket]] = None) -> None:
         self.config.setup_event_loop()
-        if sys.version_info >= (3, 7):
-            return asyncio.run(self.serve(sockets=sockets))
-        return asyncio.get_event_loop().run_until_complete(self.serve(sockets=sockets))
+        return asyncio.run(self.serve(sockets=sockets))
 
     async def serve(self, sockets: Optional[List[socket.socket]] = None) -> None:
         process_id = os.getpid()

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -80,9 +80,7 @@ class UvicornWorker(Worker):
             sys.exit(Arbiter.WORKER_BOOT_ERROR)
 
     def run(self) -> None:
-        if sys.version_info >= (3, 7):
-            return asyncio.run(self._serve())
-        return asyncio.get_event_loop().run_until_complete(self._serve())
+        return asyncio.run(self._serve())
 
     async def callback_notify(self) -> None:
         self.notify()


### PR DESCRIPTION
Python 3.6 EOL is 23 Dec 2021, and this PR removes it. 

References: 
- https://endoflife.date/python
- https://pypistats.org/packages/uvicorn