### PR TITLE
Ensure non-zero exit code when startup fails

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,7 +57,7 @@ def test_cli_call_server_run() -> None:
     with mock.patch.object(Server, "run") as mock_run:
         result = runner.invoke(cli, ["tests.test_cli:App"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == 3
     mock_run.assert_called_once()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,3 +74,15 @@ def test_run_invalid_app_config_combination(caplog: pytest.LogCaptureFixture) ->
         "You must pass the application as an import string to enable "
         "'reload' or 'workers'."
     )
+
+
+def test_run_startup_failure(caplog: pytest.LogCaptureFixture) -> None:
+    async def app(scope, receive, send):
+        assert scope["type"] == "lifespan"
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            raise RuntimeError("Startup failed")
+
+    with pytest.raises(SystemExit) as exit_exception:
+        run(app, lifespan="on")
+    assert exit_exception.value.code == 3

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -451,7 +451,7 @@ def run(app: typing.Union[ASGIApplication, str], **kwargs: typing.Any) -> None:
     if config.uds:
         os.remove(config.uds)  # pragma: py-win32
 
-    if not server.started:
+    if not server.started and not config.should_reload and config.workers == 1:
         sys.exit(STARTUP_FAILED)
 
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -30,6 +30,8 @@ LIFESPAN_CHOICES = click.Choice(list(LIFESPAN.keys()))
 LOOP_CHOICES = click.Choice([key for key in LOOP_SETUPS.keys() if key != "none"])
 INTERFACE_CHOICES = click.Choice(INTERFACES)
 
+STARTUP_FAILED = 3
+
 logger = logging.getLogger("uvicorn.error")
 
 
@@ -448,6 +450,9 @@ def run(app: typing.Union[ASGIApplication, str], **kwargs: typing.Any) -> None:
         server.run()
     if config.uds:
         os.remove(config.uds)  # pragma: py-win32
+
+    if not server.started:
+        sys.exit(STARTUP_FAILED)
 
 
 if __name__ == "__main__":

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -30,7 +30,7 @@ LIFESPAN_CHOICES = click.Choice(list(LIFESPAN.keys()))
 LOOP_CHOICES = click.Choice([key for key in LOOP_SETUPS.keys() if key != "none"])
 INTERFACE_CHOICES = click.Choice(INTERFACES)
 
-STARTUP_FAILED = 3
+STARTUP_FAILURE = 3
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -452,7 +452,7 @@ def run(app: typing.Union[ASGIApplication, str], **kwargs: typing.Any) -> None:
         os.remove(config.uds)  # pragma: py-win32
 
     if not server.started and not config.should_reload and config.workers == 1:
-        sys.exit(STARTUP_FAILED)
+        sys.exit(STARTUP_FAILURE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR proposes that running uvicorn without `--workers` and `--reload` at startup failure will exit with code 3.

The reasoning for the number 3 is to differentiate from the general exit code, and to match gunicorn's decision (consensus).

*What about `--workers` and `--reload`?*

Well, using `--workers` you actually don't exit at startup failure yet. See https://github.com/encode/uvicorn/issues/1115

As for the `--reload`, what do you recommend @euri10 ? `server.started` is always `False` on the `main.run()` because `target=server.run` runs in another process. Until #1177 (not released yet), on startup failure it didn't exit as well.