### PR TITLE
Harden header decoding

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -144,7 +144,16 @@ async def test_close_connection(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_headers(ws_protocol_cls, http_protocol_cls):
+@pytest.mark.parametrize(
+    "request_headers",
+    [
+        {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5 (Ergänzendes Update))"
+        }
+    ],
+    ids=["non-ascii-byte-in-header"],
+)
+async def test_headers(ws_protocol_cls, http_protocol_cls, request_headers):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             headers = self.scope.get("headers")
@@ -153,7 +162,7 @@ async def test_headers(ws_protocol_cls, http_protocol_cls):
             await self.send({"type": "websocket.accept"})
 
     async def open_connection(url):
-        async with websockets.connect(url) as websocket:
+        async with websockets.connect(url, extra_headers=request_headers) as websocket:
             return websocket.open
 
     config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -136,7 +136,7 @@ class WebSocketProtocol(_LoggerMixin, websockets.WebSocketServerProtocol):
             subprotocols.extend([token.strip() for token in header.split(",")])
 
         asgi_headers = [
-            (name.encode("ascii"), value.encode("ascii"))
+            (name.encode("ascii"), value.encode("ascii", errors="replace"))
             for name, value in headers.raw_items()
         ]
 


### PR DESCRIPTION
### What

This PR attempts to harden the header handling in websockets_impl.py to avoid a crash if a client sends a non-ascii character in one of the headers.

### Why

We've had a few cases of receiving a header with a unicode character which seems to stem from a browser running on a recent [version of Mac OS Catalina with german locale settings](https://support.apple.com/kb/DL2071?viewlocale=de_LI&locale=de_LI).

The traceback of the error, as exposed by the red commit on this branch:

```
Traceback (most recent call last):
  File "/Users/ses/w/uvicorn/venv/lib/python3.9/site-packages/websockets/legacy/server.py", line 162, in handler
    await self.handshake(
  File "/Users/ses/w/uvicorn/venv/lib/python3.9/site-packages/websockets/legacy/server.py", line 588, in handshake
    early_response = await early_response_awaitable
  File "/Users/ses/w/uvicorn/uvicorn/protocols/websockets/websockets_impl.py", line 138, in process_request
    asgi_headers = [
  File "/Users/ses/w/uvicorn/uvicorn/protocols/websockets/websockets_impl.py", line 139, in <listcomp>
    (name.encode("ascii"), value.encode("ascii"))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 51-52: ordinal not in range(128)
```

I couldn't determine if this is in fact a standards violation or not, although there are strong indications that browser should URL encode all non-ascii characters in their request headers.  Regardless of that, I thought hardening uvicorn couldn't hurt.

### How

... I extended an existing test which had the name "headers" in it.  I think this may warrant another test which focuses on the request headers, perhaps the project maintainers can suggest a better approach and I'll be happy to take it.

After the test began failing I got it passing by adding `errors="replace"` kwarg to the string encoding call.  This should replace non-ascii characters with `?`, which I find slightly more helpful than having the character disappear, which can be achieved with `errors="ignore"`.  The latter option might however be more appropriate for the header name.