### PR TITLE
Fix logging tests that depends on each other

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ coverage==5.5
 coverage-conditional-plugin==0.4.0
 httpx==1.0.0b0
 pytest-asyncio==0.15.1
+pytest-randomly==3.11.0
 
 
 # Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ coverage==5.5
 coverage-conditional-plugin==0.4.0
 httpx==1.0.0b0
 pytest-asyncio==0.15.1
-pytest-randomly==3.11.0
 
 
 # Documentation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 import ssl
+from copy import deepcopy
 
 import pytest
 import trustme
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
+
+from uvicorn.config import LOGGING_CONFIG
 
 
 @pytest.fixture
@@ -128,3 +131,8 @@ def reload_directory_structure(tmp_path_factory: pytest.TempPathFactory):
     ext_file.touch()
 
     yield root
+
+
+@pytest.fixture(scope="function")
+def logging_config() -> dict:
+    return deepcopy(LOGGING_CONFIG)

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -56,7 +56,6 @@ async def test_trace_logging_on_http_protocol(http_protocol, caplog, logging_con
         log_level="trace",
         http=http_protocol,
         log_config=logging_config,
-        lifespan="off",
     )
     with caplog_for_logger(caplog, "uvicorn.error"):
         async with run_server(config):
@@ -68,7 +67,6 @@ async def test_trace_logging_on_http_protocol(http_protocol, caplog, logging_con
             for record in caplog.records
             if record.name == "uvicorn.error"
         ]
-        print(caplog.records)
         assert any(" - HTTP connection made" in message for message in messages)
         assert any(" - HTTP connection lost" in message for message in messages)
 
@@ -94,7 +92,6 @@ async def test_trace_logging_on_ws_protocol(ws_protocol, caplog, logging_config)
         log_level="trace",
         log_config=logging_config,
         ws=ws_protocol,
-        lifespan="off",
     )
     with caplog_for_logger(caplog, "uvicorn.error"):
         async with run_server(config):
@@ -105,7 +102,6 @@ async def test_trace_logging_on_ws_protocol(ws_protocol, caplog, logging_config)
             for record in caplog.records
             if record.name == "uvicorn.error"
         ]
-        print(caplog.records)
         assert any(" - Upgrading to WebSocket" in message for message in messages)
         assert any(" - WebSocket connection made" in message for message in messages)
         assert any(" - WebSocket connection lost" in message for message in messages)

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -29,7 +29,9 @@ async def app(scope, receive, send):
 
 @pytest.mark.asyncio
 async def test_trace_logging(caplog, logging_config):
-    config = Config(app=app, log_level="trace", log_config=logging_config, lifespan="auto")
+    config = Config(
+        app=app, log_level="trace", log_config=logging_config, lifespan="auto"
+    )
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
@@ -38,6 +40,7 @@ async def test_trace_logging(caplog, logging_config):
         messages = [
             record.message for record in caplog.records if record.name == "uvicorn.asgi"
         ]
+        print(caplog.records)
         assert "ASGI [1] Started scope=" in messages.pop(0)
         assert "ASGI [1] Raised exception" in messages.pop(0)
         assert "ASGI [2] Started scope=" in messages.pop(0)
@@ -66,6 +69,7 @@ async def test_trace_logging_on_http_protocol(http_protocol, caplog, logging_con
             for record in caplog.records
             if record.name == "uvicorn.error"
         ]
+        print(caplog.records)
         assert any(" - HTTP connection made" in message for message in messages)
         assert any(" - HTTP connection lost" in message for message in messages)
 
@@ -102,6 +106,7 @@ async def test_trace_logging_on_ws_protocol(ws_protocol, caplog, logging_config)
             for record in caplog.records
             if record.name == "uvicorn.error"
         ]
+        print(caplog.records)
         assert any(" - Upgrading to WebSocket" in message for message in messages)
         assert any(" - WebSocket connection made" in message for message in messages)
         assert any(" - WebSocket connection lost" in message for message in messages)

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -70,7 +70,6 @@ async def test_trace_logging_on_http_protocol(http_protocol, caplog, logging_con
 @pytest.mark.parametrize("ws_protocol", [("websockets"), ("wsproto")])
 async def test_trace_logging_on_ws_protocol(ws_protocol, caplog, logging_config):
     async def websocket_app(scope, receive, send):
-        print(scope)
         assert scope["type"] == "websocket"
         while True:
             message = await receive()

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -29,9 +29,7 @@ async def app(scope, receive, send):
 
 @pytest.mark.asyncio
 async def test_trace_logging(caplog, logging_config):
-    config = Config(
-        app=app, log_level="trace", log_config=logging_config, lifespan="off"
-    )
+    config = Config(app=app, log_level="trace", log_config=logging_config)
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -29,7 +29,9 @@ async def app(scope, receive, send):
 
 @pytest.mark.asyncio
 async def test_trace_logging(caplog, logging_config):
-    config = Config(app=app, log_level="trace", log_config=logging_config)
+    config = Config(
+        app=app, log_level="trace", log_config=logging_config, lifespan="off"
+    )
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
@@ -50,7 +52,11 @@ async def test_trace_logging(caplog, logging_config):
 @pytest.mark.parametrize("http_protocol", [("h11"), ("httptools")])
 async def test_trace_logging_on_http_protocol(http_protocol, caplog, logging_config):
     config = Config(
-        app=app, log_level="trace", http=http_protocol, log_config=logging_config
+        app=app,
+        log_level="trace",
+        http=http_protocol,
+        log_config=logging_config,
+        lifespan="off",
     )
     with caplog_for_logger(caplog, "uvicorn.error"):
         async with run_server(config):

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -40,7 +40,6 @@ async def test_trace_logging(caplog, logging_config):
         messages = [
             record.message for record in caplog.records if record.name == "uvicorn.asgi"
         ]
-        print(caplog.records)
         assert "ASGI [1] Started scope=" in messages.pop(0)
         assert "ASGI [1] Raised exception" in messages.pop(0)
         assert "ASGI [2] Started scope=" in messages.pop(0)

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -29,7 +29,7 @@ async def app(scope, receive, send):
 
 @pytest.mark.asyncio
 async def test_trace_logging(caplog, logging_config):
-    config = Config(app=app, log_level="trace", log_config=logging_config)
+    config = Config(app=app, log_level="trace", log_config=logging_config, lifespan="auto")
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:

--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
 
+from tests.middleware.test_logging import caplog_for_logger
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 
@@ -12,19 +13,22 @@ async def test_message_logger(caplog):
         await send({"type": "http.response.start", "status": 200, "headers": []})
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
-    caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
-    caplog.set_level(TRACE_LOG_LEVEL)
+    with caplog_for_logger(caplog, "uvicorn.asgi"):
+        caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
+        caplog.set_level(TRACE_LOG_LEVEL)
 
-    app = MessageLoggerMiddleware(app)
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
-        response = await client.get("/")
-    assert response.status_code == 200
-    messages = [record.msg % record.args for record in caplog.records]
-    assert sum(["ASGI [1] Started" in message for message in messages]) == 1
-    assert sum(["ASGI [1] Send" in message for message in messages]) == 2
-    assert sum(["ASGI [1] Receive" in message for message in messages]) == 1
-    assert sum(["ASGI [1] Completed" in message for message in messages]) == 1
-    assert sum(["ASGI [1] Raised exception" in message for message in messages]) == 0
+        app = MessageLoggerMiddleware(app)
+        async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+            response = await client.get("/")
+        assert response.status_code == 200
+        messages = [record.msg % record.args for record in caplog.records]
+        assert sum(["ASGI [1] Started" in message for message in messages]) == 1
+        assert sum(["ASGI [1] Send" in message for message in messages]) == 2
+        assert sum(["ASGI [1] Receive" in message for message in messages]) == 1
+        assert sum(["ASGI [1] Completed" in message for message in messages]) == 1
+        assert (
+            sum(["ASGI [1] Raised exception" in message for message in messages]) == 0
+        )
 
 
 @pytest.mark.asyncio
@@ -32,15 +36,18 @@ async def test_message_logger_exc(caplog):
     async def app(scope, receive, send):
         raise RuntimeError()
 
-    caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
-    caplog.set_level(TRACE_LOG_LEVEL)
-    app = MessageLoggerMiddleware(app)
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
-        with pytest.raises(RuntimeError):
-            await client.get("/")
-    messages = [record.msg % record.args for record in caplog.records]
-    assert sum(["ASGI [1] Started" in message for message in messages]) == 1
-    assert sum(["ASGI [1] Send" in message for message in messages]) == 0
-    assert sum(["ASGI [1] Receive" in message for message in messages]) == 0
-    assert sum(["ASGI [1] Completed" in message for message in messages]) == 0
-    assert sum(["ASGI [1] Raised exception" in message for message in messages]) == 1
+    with caplog_for_logger(caplog, "uvicorn.asgi"):
+        caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
+        caplog.set_level(TRACE_LOG_LEVEL)
+        app = MessageLoggerMiddleware(app)
+        async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+            with pytest.raises(RuntimeError):
+                await client.get("/")
+        messages = [record.msg % record.args for record in caplog.records]
+        assert sum(["ASGI [1] Started" in message for message in messages]) == 1
+        assert sum(["ASGI [1] Send" in message for message in messages]) == 0
+        assert sum(["ASGI [1] Receive" in message for message in messages]) == 0
+        assert sum(["ASGI [1] Completed" in message for message in messages]) == 0
+        assert (
+            sum(["ASGI [1] Raised exception" in message for message in messages]) == 1
+        )

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -332,7 +332,7 @@ class TestBaseReload:
         app_first_dir = tmp_path / "app_first"
         app_first_file = app_first_dir / "file.py"
 
-        with as_cwd(tmp_path), caplog.at_level(INFO):
+        with as_cwd(tmp_path):
             config = Config(
                 app="tests.test_config:asgi_app", reload=True, reload_includes=["app*"]
             )
@@ -360,7 +360,7 @@ class TestBaseReload:
         app_first_dir = tmp_path / "app_first"
         app_first_file = app_first_dir / "file.py"
 
-        with as_cwd(tmp_path), caplog.at_level(DEBUG):
+        with as_cwd(tmp_path):
             config = Config(
                 app="tests.test_config:asgi_app", reload=True, reload_excludes=["app*"]
             )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,6 @@ import os
 import socket
 import sys
 import typing
-from copy import deepcopy
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -20,7 +19,7 @@ from pytest_mock import MockerFixture
 
 from tests.utils import as_cwd
 from uvicorn._types import Environ, StartResponse
-from uvicorn.config import LOGGING_CONFIG, Config
+from uvicorn.config import Config
 from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
@@ -30,11 +29,6 @@ from uvicorn.protocols.http.h11_impl import H11Protocol
 @pytest.fixture
 def mocked_logging_config_module(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("logging.config")
-
-
-@pytest.fixture(scope="function")
-def logging_config() -> dict:
-    return deepcopy(LOGGING_CONFIG)
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -353,10 +353,10 @@ def test_asgi_version(
 @pytest.mark.parametrize(
     "use_colors, expected",
     [
-        pytest.param(False, False, id="use_colors_disabled"),
         pytest.param(None, None, id="use_colors_not_provided"),
-        pytest.param(True, True, id="use_colors_enabled"),
         pytest.param("invalid", None, id="use_colors_invalid_value"),
+        pytest.param(True, True, id="use_colors_enabled"),
+        pytest.param(False, False, id="use_colors_disabled"),
     ],
 )
 def test_log_config_default(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -359,10 +359,10 @@ def test_asgi_version(
 @pytest.mark.parametrize(
     "use_colors, expected",
     [
-        pytest.param(None, None, id="use_colors_not_provided"),
-        pytest.param("invalid", None, id="use_colors_invalid_value"),
-        pytest.param(True, True, id="use_colors_enabled"),
         pytest.param(False, False, id="use_colors_disabled"),
+        pytest.param(None, None, id="use_colors_not_provided"),
+        pytest.param(True, True, id="use_colors_enabled"),
+        pytest.param("invalid", None, id="use_colors_invalid_value"),
     ],
 )
 def test_log_config_default(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -369,15 +369,16 @@ def test_log_config_default(
     mocked_logging_config_module: MagicMock,
     use_colors: typing.Optional[bool],
     expected: typing.Optional[bool],
+    logging_config,
 ) -> None:
     """
     Test that one can specify the use_colors option when using the default logging
     config.
     """
-    config = Config(app=asgi_app, use_colors=use_colors)
+    config = Config(app=asgi_app, use_colors=use_colors, log_config=logging_config)
     config.load()
 
-    mocked_logging_config_module.dictConfig.assert_called_once_with(LOGGING_CONFIG)
+    mocked_logging_config_module.dictConfig.assert_called_once_with(logging_config)
 
     (provided_dict_config,), _ = mocked_logging_config_module.dictConfig.call_args
     assert provided_dict_config["formatters"]["default"]["use_colors"] == expected


### PR DESCRIPTION
Fixes #1286 or part of it, since I'm not sure yet if there are not other cases where parametrized tests are messing up with our test suite.

In this case the order of parameterized tests was important because the global `LOGGING_CONFIG` is not reset for each test : so we force it in the config using a fixture that is a deepcopy of the dict, so we use the original dict ofr each test and not the result of the previous one.