### PR TITLE
Support `extra_headers` for WS `accept` message

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -236,7 +236,7 @@ class WebSocketProtocol(_LoggerMixin, websockets.WebSocketServerProtocol):
                     self.extra_headers.extend(
                         # ASGI spec requires bytes
                         # But for compability we need to convert it to strings
-                        (name.decode(), value.decode())
+                        (name.decode("latin-1"), value.decode("latin-1"))
                         for name, value in message.get("headers")
                     )
                 self.handshake_started_event.set()

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -257,9 +257,12 @@ class WSProtocol(asyncio.Protocol):
                 )
                 self.handshake_complete = True
                 subprotocol = message.get("subprotocol")
+                extra_headers = message.get("headers", [])
                 output = self.conn.send(
                     wsproto.events.AcceptConnection(
-                        subprotocol=subprotocol, extensions=[PerMessageDeflate()]
+                        subprotocol=subprotocol,
+                        extensions=[PerMessageDeflate()],
+                        extra_headers=extra_headers,
                     )
                 )
                 self.transport.write(output)


### PR DESCRIPTION
The `extra_headers` support for WS `accept` message.
According to ASGI spec: https://asgi.readthedocs.io/en/latest/specs/www.html#accept-send-event