### PR TITLE
Remove `root_path` from logs

### DIFF
--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -46,9 +46,7 @@ def get_client_addr(scope: WWWScope) -> str:
 
 
 def get_path_with_query_string(scope: WWWScope) -> str:
-    path_with_query_string = urllib.parse.quote(
-        scope.get("root_path", "") + scope["path"]
-    )
+    path_with_query_string = urllib.parse.quote(scope["path"])
     if scope["query_string"]:
         path_with_query_string = "{}?{}".format(
             path_with_query_string, scope["query_string"].decode("ascii")

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -227,7 +227,7 @@ class WebSocketProtocol(_LoggerMixin, websockets.WebSocketServerProtocol):
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
                     self.scope["client"],
-                    self.scope["root_path"] + self.scope["path"],
+                    self.scope["path"],
                 )
                 self.initial_response = None
                 self.accepted_subprotocol = message.get("subprotocol")
@@ -237,7 +237,7 @@ class WebSocketProtocol(_LoggerMixin, websockets.WebSocketServerProtocol):
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     self.scope["client"],
-                    self.scope["root_path"] + self.scope["path"],
+                    self.scope["path"],
                 )
                 self.initial_response = (http.HTTPStatus.FORBIDDEN, [], b"")
                 self.handshake_started_event.set()

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -253,7 +253,7 @@ class WSProtocol(asyncio.Protocol):
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
                     self.scope["client"],
-                    self.scope["root_path"] + self.scope["path"],
+                    self.scope["path"],
                 )
                 self.handshake_complete = True
                 subprotocol = message.get("subprotocol")
@@ -269,7 +269,7 @@ class WSProtocol(asyncio.Protocol):
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     self.scope["client"],
-                    self.scope["root_path"] + self.scope["path"],
+                    self.scope["path"],
                 )
                 self.handshake_complete = True
                 self.close_sent = True


### PR DESCRIPTION
Closes #1290 and removes `scope["root_path"]` from logs and only logs `scope["path"]`.

I could not find any other occurrences.