### PR TITLE
Refactor/vendorize typings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
-    "asgiref>=3.3.4",
     "click>=7.0",
     "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
-    "asgiref>=3.4.0",
+    "asgiref>=3.3.4",
     "click>=7.0",
     "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -2,9 +2,9 @@ from typing import List, Union
 
 import httpx
 import pytest
-from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 from tests.response import Response
+from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -3,9 +3,8 @@ from typing import List
 
 import httpx
 import pytest
-from asgiref.typing import HTTPRequestEvent, HTTPScope
 
-from uvicorn._types import Environ, StartResponse
+from uvicorn._types import Environ, HTTPRequestEvent, HTTPScope, StartResponse
 from uvicorn.middleware.wsgi import WSGIMiddleware, build_environ
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,11 +15,17 @@ else:  # pragma: py-lt-38
 
 import pytest
 import yaml
-from asgiref.typing import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Scope
 from pytest_mock import MockerFixture
 
 from tests.utils import as_cwd
-from uvicorn._types import Environ, StartResponse
+from uvicorn._types import (
+    ASGIApplication,
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    Environ,
+    Scope,
+    StartResponse,
+)
 from uvicorn.config import LOGGING_CONFIG, Config
 from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -1,5 +1,13 @@
 import types
 import typing
+import sys
+from typing import Dict, Iterable, Optional, Tuple, Union
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal, TypedDict
+else:
+    from typing import Literal, TypedDict
+
 
 # WSGI
 Environ = typing.MutableMapping[str, typing.Any]
@@ -12,3 +20,62 @@ StartResponse = typing.Callable[
 WSGIApp = typing.Callable[
     [Environ, StartResponse], typing.Union[typing.Iterable[bytes], BaseException]
 ]
+
+
+class ASGISpecInfo(TypedDict):
+    version: str
+    spec_version: Optional[Literal["2.0", "2.1"]]
+
+
+class LifespanScope(TypedDict):
+    type: Literal["lifespan"]
+    asgi: ASGISpecInfo
+
+
+class LifespanReceiveMessage(TypedDict):
+    type: Literal["lifespan.startup", "lifespan.shutdown"]
+
+
+class LifespanSendMessage(TypedDict):
+    type: Literal[
+        "lifespan.startup.complete",
+        "lifespan.startup.failed",
+        "lifespan.shutdown.complete",
+        "lifespan.shutdown.failed",
+    ]
+    message: Optional[str]
+
+
+class HTTPScope(TypedDict):
+    type: Literal["http"]
+    asgi: ASGISpecInfo
+    http_version: str
+    method: str
+    scheme: str
+    path: str
+    raw_path: bytes
+    query_string: bytes
+    root_path: str
+    headers: Iterable[Tuple[bytes, bytes]]
+    client: Optional[Tuple[str, int]]
+    server: Optional[Tuple[str, Optional[int]]]
+    extensions: Dict[str, Dict[object, object]]
+
+
+class WebsocketScope(TypedDict):
+    type: Literal["websocket"]
+    asgi: ASGISpecInfo
+    http_version: str
+    scheme: str
+    path: str
+    raw_path: bytes
+    query_string: bytes
+    root_path: str
+    headers: Iterable[Tuple[bytes, bytes]]
+    client: Optional[Tuple[str, int]]
+    server: Optional[Tuple[str, Optional[int]]]
+    subprotocols: Iterable[str]
+    extensions: Dict[str, Dict[object, object]]
+
+
+WWWScope = Union[HTTPScope, WebsocketScope]

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -1,12 +1,12 @@
 import types
 import typing
 import sys
-from typing import Dict, Iterable, Optional, Tuple, Union
+from typing import Awaitable, Callable, Dict, Iterable, Optional, Tuple, Type, Union
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal, TypedDict
+if sys.version_info >= (3, 8):
+    from typing import Literal, Protocol, TypedDict
 else:
-    from typing import Literal, TypedDict
+    from typing_extensions import Literal, Protocol, TypedDict
 
 
 # WSGI
@@ -62,9 +62,14 @@ class HTTPScope(TypedDict):
     extensions: Dict[str, Dict[object, object]]
 
 
+class ASGIVersions(TypedDict):
+    spec_version: str
+    version: Union[Literal["2.0"], Literal["3.0"]]
+
+
 class WebsocketScope(TypedDict):
     type: Literal["websocket"]
-    asgi: ASGISpecInfo
+    asgi: ASGIVersions
     http_version: str
     scheme: str
     path: str
@@ -79,3 +84,157 @@ class WebsocketScope(TypedDict):
 
 
 WWWScope = Union[HTTPScope, WebsocketScope]
+Scope = Union[HTTPScope, WebsocketScope, LifespanScope]
+
+
+class HTTPRequestEvent(TypedDict):
+    type: Literal["http.request"]
+    body: bytes
+    more_body: bool
+
+
+class HTTPResponseStartEvent(TypedDict):
+    type: Literal["http.response.start"]
+    status: int
+    headers: Iterable[Tuple[bytes, bytes]]
+
+
+class HTTPResponseBodyEvent(TypedDict):
+    type: Literal["http.response.body"]
+    body: bytes
+    more_body: bool
+
+
+class HTTPServerPushEvent(TypedDict):
+    type: Literal["http.response.push"]
+    path: str
+    headers: Iterable[Tuple[bytes, bytes]]
+
+
+class HTTPDisconnectEvent(TypedDict):
+    type: Literal["http.disconnect"]
+
+
+class WebsocketConnectEvent(TypedDict):
+    type: Literal["websocket.connect"]
+
+
+class WebsocketAcceptEvent(TypedDict):
+    type: Literal["websocket.accept"]
+    subprotocol: Optional[str]
+    headers: Iterable[Tuple[bytes, bytes]]
+
+
+class WebsocketReceiveEvent(TypedDict):
+    type: Literal["websocket.receive"]
+    bytes: Optional[bytes]
+    text: Optional[str]
+
+
+class WebsocketSendEvent(TypedDict):
+    type: Literal["websocket.send"]
+    bytes: Optional[bytes]
+    text: Optional[str]
+
+
+class WebsocketResponseStartEvent(TypedDict):
+    type: Literal["websocket.http.response.start"]
+    status: int
+    headers: Iterable[Tuple[bytes, bytes]]
+
+
+class WebsocketResponseBodyEvent(TypedDict):
+    type: Literal["websocket.http.response.body"]
+    body: bytes
+    more_body: bool
+
+
+class WebsocketDisconnectEvent(TypedDict):
+    type: Literal["websocket.disconnect"]
+    code: int
+
+
+class WebsocketCloseEvent(TypedDict):
+    type: Literal["websocket.close"]
+    code: int
+    reason: Optional[str]
+
+
+class LifespanStartupEvent(TypedDict):
+    type: Literal["lifespan.startup"]
+
+
+class LifespanShutdownEvent(TypedDict):
+    type: Literal["lifespan.shutdown"]
+
+
+class LifespanStartupCompleteEvent(TypedDict):
+    type: Literal["lifespan.startup.complete"]
+
+
+class LifespanStartupFailedEvent(TypedDict):
+    type: Literal["lifespan.startup.failed"]
+    message: str
+
+
+class LifespanShutdownCompleteEvent(TypedDict):
+    type: Literal["lifespan.shutdown.complete"]
+
+
+class LifespanShutdownFailedEvent(TypedDict):
+    type: Literal["lifespan.shutdown.failed"]
+    message: str
+
+
+ASGIReceiveEvent = Union[
+    HTTPRequestEvent,
+    HTTPDisconnectEvent,
+    WebsocketConnectEvent,
+    WebsocketReceiveEvent,
+    WebsocketDisconnectEvent,
+    LifespanStartupEvent,
+    LifespanShutdownEvent,
+]
+
+
+ASGISendEvent = Union[
+    HTTPResponseStartEvent,
+    HTTPResponseBodyEvent,
+    HTTPServerPushEvent,
+    HTTPDisconnectEvent,
+    WebsocketAcceptEvent,
+    WebsocketSendEvent,
+    WebsocketResponseStartEvent,
+    WebsocketResponseBodyEvent,
+    WebsocketCloseEvent,
+    LifespanStartupCompleteEvent,
+    LifespanStartupFailedEvent,
+    LifespanShutdownCompleteEvent,
+    LifespanShutdownFailedEvent,
+]
+
+
+ASGIReceiveCallable = Callable[[], Awaitable[ASGIReceiveEvent]]
+ASGISendCallable = Callable[[ASGISendEvent], Awaitable[None]]
+
+
+class ASGI2Protocol(Protocol):
+    def __init__(self, scope: Scope) -> None:
+        ...
+
+    async def __call__(
+        self, receive: ASGIReceiveCallable, send: ASGISendCallable
+    ) -> None:
+        ...
+
+
+ASGI2Application = Type[ASGI2Protocol]
+ASGI3Application = Callable[
+    [
+        Scope,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+    ],
+    Awaitable[None],
+]
+ASGIApplication = Union[ASGI2Application, ASGI3Application]

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -1,10 +1,8 @@
+import re
+import sys
 import types
 import typing
-import sys
-import re
-
 from typing import Awaitable, Callable, Dict, Iterable, Optional, Tuple, Type, Union
-
 
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol, TypedDict
@@ -30,6 +28,30 @@ def split_version(version):
             split_version[3] = "final"
         split_version = list(map(int, split_version[:3])) + split_version[3:]
         return tuple(split_version)
+
+
+ASGIREF_VERSION_TUPLE = None
+ASGIREF_33 = False
+ASGIREF_34 = False
+
+try:
+    import asgiref
+
+    ASGIREF_VERSION_TUPLE = split_version(asgiref.__version__)
+except ImportError:
+    pass
+
+if ASGIREF_VERSION_TUPLE is not None:
+    ASGIREF_33 = ASGIREF_VERSION_TUPLE > (3, 3, 2,) and ASGIREF_VERSION_TUPLE < (
+        3,
+        4,
+        0,
+    )
+    ASGIREF_34 = ASGIREF_VERSION_TUPLE >= (3, 4, 0,) and ASGIREF_VERSION_TUPLE < (
+        3,
+        5,
+        0,
+    )
 
 
 # WSGI

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -1,12 +1,35 @@
 import types
 import typing
 import sys
+import re
+
 from typing import Awaitable, Callable, Dict, Iterable, Optional, Tuple, Type, Union
+
 
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol, TypedDict
 else:
     from typing_extensions import Literal, Protocol, TypedDict
+
+
+_version_re = re.compile(r"^(\d+)\.(\d+)\.(\d+)(\..*)?$", re.VERBOSE)
+
+
+def split_version(version):
+    """Return VERSION tuple for given string representation of version
+
+    Credit: sindresorhus/editorconfig-sublime, editorconfig/versiontools.py @ 19f3532
+    License: MIT
+    """
+    match = _version_re.search(version)
+    if not match:
+        return None
+    else:
+        split_version = list(match.groups())
+        if split_version[3] is None:
+            split_version[3] = "final"
+        split_version = list(map(int, split_version[:3])) + split_version[3:]
+        return tuple(split_version)
 
 
 # WSGI

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -18,7 +18,6 @@ else:  # pragma: py-lt-38
     from typing import Literal
 
 import click
-from asgiref.typing import ASGIApplication
 
 try:
     import yaml
@@ -28,6 +27,7 @@ except ImportError:  # pragma: no cover
     # enable this functionality.
     pass
 
+from uvicorn._types import ASGIApplication
 from uvicorn.importer import ImportFromStringError, import_from_string
 from uvicorn.middleware.asgi2 import ASGI2Middleware
 from uvicorn.middleware.debug import DebugMiddleware

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -361,13 +361,8 @@ class Config:
             self.forwarded_allow_ips = forwarded_allow_ips
 
     @property
-    def asgi_version(self) -> Literal["2.0", "3.0"]:
-        mapping: Dict[str, Literal["2.0", "3.0"]] = {
-            "asgi2": "2.0",
-            "asgi3": "3.0",
-            "wsgi": "3.0",
-        }
-        return mapping[self.interface]
+    def asgi_version(self) -> str:
+        return {"asgi2": "2.0", "asgi3": "3.0", "wsgi": "3.0"}[self.interface]
 
     @property
     def is_ssl(self) -> bool:

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -1,27 +1,9 @@
 import asyncio
 import logging
 from asyncio import Queue
-from typing import Union
-
-from asgiref.typing import (
-    LifespanScope,
-    LifespanShutdownCompleteEvent,
-    LifespanShutdownEvent,
-    LifespanShutdownFailedEvent,
-    LifespanStartupCompleteEvent,
-    LifespanStartupEvent,
-    LifespanStartupFailedEvent,
-)
 
 from uvicorn import Config
-
-LifespanReceiveMessage = Union[LifespanStartupEvent, LifespanShutdownEvent]
-LifespanSendMessage = Union[
-    LifespanStartupFailedEvent,
-    LifespanShutdownFailedEvent,
-    LifespanStartupCompleteEvent,
-    LifespanShutdownCompleteEvent,
-]
+from uvicorn._types import LifespanReceiveMessage, LifespanScope, LifespanSendMessage
 
 STATE_TRANSITION_ERROR = "Got invalid state transition on lifespan protocol."
 
@@ -48,8 +30,8 @@ class LifespanOn:
         main_lifespan_task = loop.create_task(self.main())  # noqa: F841
         # Keep a hard reference to prevent garbage collection
         # See https://github.com/encode/uvicorn/pull/972
-        startup_event: LifespanStartupEvent = {"type": "lifespan.startup"}
-        await self.receive_queue.put(startup_event)
+
+        await self.receive_queue.put({"type": "lifespan.startup"})
         await self.startup_event.wait()
 
         if self.startup_failed or (self.error_occured and self.config.lifespan == "on"):
@@ -62,8 +44,7 @@ class LifespanOn:
         if self.error_occured:
             return
         self.logger.info("Waiting for application shutdown.")
-        shutdown_event: LifespanShutdownEvent = {"type": "lifespan.shutdown"}
-        await self.receive_queue.put(shutdown_event)
+        await self.receive_queue.put({"type": "lifespan.shutdown"})
         await self.shutdown_event.wait()
 
         if self.shutdown_failed or (

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -6,9 +6,9 @@ import sys
 import typing
 
 import click
-from asgiref.typing import ASGIApplication
 
 import uvicorn
+from uvicorn._types import ASGIApplication
 from uvicorn.config import (
     HTTP_PROTOCOLS,
     INTERFACES,

--- a/uvicorn/middleware/asgi2.py
+++ b/uvicorn/middleware/asgi2.py
@@ -1,4 +1,4 @@
-from asgiref.typing import (
+from uvicorn._types import (
     ASGI2Application,
     ASGIReceiveCallable,
     ASGISendCallable,

--- a/uvicorn/middleware/debug.py
+++ b/uvicorn/middleware/debug.py
@@ -2,7 +2,7 @@ import html
 import traceback
 from typing import Union
 
-from asgiref.typing import (
+from uvicorn._types import (
     ASGI3Application,
     ASGIReceiveCallable,
     ASGISendCallable,

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from asgiref.typing import (
+from uvicorn._types import (
     ASGI3Application,
     ASGIReceiveCallable,
     ASGIReceiveEvent,
@@ -9,7 +9,6 @@ from asgiref.typing import (
     ASGISendEvent,
     WWWScope,
 )
-
 from uvicorn.logging import TRACE_LOG_LEVEL
 
 PLACEHOLDER_FORMAT = {

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -16,7 +16,7 @@ from asgiref.typing import (
     ASGISendCallable,
     HTTPScope,
     Scope,
-    WebSocketScope,
+    WebsocketScope,
 )
 
 
@@ -47,7 +47,7 @@ class ProxyHeadersMiddleware:
         self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:
         if scope["type"] in ("http", "websocket"):
-            scope = cast(Union[HTTPScope, WebSocketScope], scope)
+            scope = cast(Union[HTTPScope, WebsocketScope], scope)
             client_addr: Optional[Tuple[str, int]] = scope.get("client")
             client_host = client_addr[0] if client_addr else None
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -10,7 +10,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
 from typing import List, Optional, Tuple, Union, cast
 
-from asgiref.typing import (
+from uvicorn._types import (
     ASGI3Application,
     ASGIReceiveCallable,
     ASGISendCallable,

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -5,18 +5,20 @@ import sys
 from collections import deque
 from typing import Deque, Iterable, Optional, Tuple
 
-from asgiref.typing import (
+from uvicorn._types import (
     ASGIReceiveCallable,
     ASGIReceiveEvent,
     ASGISendCallable,
     ASGISendEvent,
+    Environ,
+    ExcInfo,
     HTTPRequestEvent,
     HTTPResponseBodyEvent,
     HTTPResponseStartEvent,
     HTTPScope,
+    StartResponse,
+    WSGIApp,
 )
-
-from uvicorn._types import Environ, ExcInfo, StartResponse, WSGIApp
 
 
 def build_environ(scope: HTTPScope, message: ASGIReceiveEvent, body: bytes) -> Environ:

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from asgiref.typing import (
+from uvicorn._types import (
     ASGIReceiveCallable,
     ASGISendCallable,
     HTTPResponseBodyEvent,

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -2,7 +2,7 @@ import asyncio
 import urllib.parse
 from typing import Optional, Tuple
 
-from asgiref.typing import WWWScope
+from uvicorn._types import WWWScope
 
 
 def get_remote_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:


### PR DESCRIPTION
In re: #1305

I'm having difficulty with if making switches that work between `ASGIREF_33`/`ASGIREF_34`. Apparently type annotations can't handle that since it's more of a runtime thing?

@Kludex Is this possible to do without watering the typings down too much? 

- What's done `_types.py` being backported to 3.3.2 and removed `asgiref` as a dependency
- version checking without needing `distutils`/`packaging`

It can do branching like a `_compat.py` module would, but mypy considers things like:

```python
if ASGIREF_33:

    class HTTPScope(TypedDict):
        type: Literal["http"]
        asgi: ASGISpecInfo
        http_version: str
        method: str
        scheme: str
        path: str
        raw_path: bytes
        query_string: bytes
        root_path: str
        headers: Iterable[Tuple[bytes, bytes]]
        client: Optional[Tuple[str, int]]
        server: Optional[Tuple[str, Optional[int]]]
        extensions: Dict[str, Dict[object, object]]


elif ASGIREF_34:

    class HTTPScope(TypedDict):
        type: Literal["http"]
        asgi: ASGISpecInfo
        http_version: str
        method: str
        scheme: str
        path: str
        raw_path: bytes
        query_string: bytes
        root_path: str
        headers: Iterable[Tuple[bytes, bytes]]
        client: Optional[Tuple[str, int]]
        server: Optional[Tuple[str, Optional[int]]]
        extensions: Optional[Dict[str, Dict[object, object]]]
```

to be duplication.

And it's also not possible to override or extend:

```python

  class HTTPScope(TypedDict):
      type: Literal["http"]
      asgi: ASGISpecInfo
      http_version: str
      method: str
      scheme: str
      path: str
      raw_path: bytes
      query_string: bytes
      root_path: str
      headers: Iterable[Tuple[bytes, bytes]]
      client: Optional[Tuple[str, int]]
      server: Optional[Tuple[str, Optional[int]]]
      extensions: Dict[str, Dict[object, object]]

if ASGIREF_34:

    class HTTPScope(HTTPScope):
        extensions: Optional[Dict[str, Dict[object, object]]]

```

I suppose it's because that requires runtime that `mypy` isn't meant to analyze

Thoughts on this? I've allowed edits and you're welcome to fork [my branch `refactor/vendorize-typings`](https://github.com/tony/uvicorn/tree/refactor/vendorize-typings)