### PR TITLE
Fix reload process behavior when exception is raised

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,21 +122,6 @@ def test_cli_incomplete_app_parameter() -> None:
     assert result.exit_code == 1
 
 
-def test_cli_reloader_incomplete_app_parameter(
-    capfd: pytest.CaptureFixture[str],
-) -> None:
-    runner = CliRunner()
-
-    runner.invoke(cli, ["tests.test_cli", "--reload"])
-
-    captured = capfd.readouterr()
-
-    assert (
-        'Error loading ASGI app. Import string "tests.test_cli" '
-        'must be in format "<module>:<attribute>".'
-    ) in captured.err
-
-
 @pytest.fixture()
 def load_env_h11_protocol():
     old_environ = dict(os.environ)

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -45,9 +45,6 @@ class BaseReload:
             if self.should_restart():
                 self.restart()
 
-            if self.process.exitcode is not None:
-                break
-
         self.shutdown()
 
     def startup(self) -> None:


### PR DESCRIPTION
Current master (and latest version [0.16.0]) makes the `--reload` command to not work as expected. 

Considering a simple application:
```python
from fastapi import FastAPI

app = FastAPI()

@app.on_event("startup")
async def startup():
    ...


@app.get("/")
def home():
    ...
```
When running `uvicorn main:app --reload` when the code above, and removing one of the lines with `...`, the reload process will exit. We don't want that. #1115 was not true for `--reload`.

The output for it can be seen below (after that, the process exits):
```python
~/Development via 🐍 v3.9.7 via 🅒 uvicorn3.9 on ☁️  marcelotryle@gmail.com took 9s 
❯ uvicorn main:app --reload
INFO:     Will watch for changes in these directories: ['/home/marcelo/Development']
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     Started reloader process [328680] using watchgod
INFO:     Started server process [328682]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
WARNING:  WatchGodReload detected file change in '['/home/marcelo/Development/main.py']'. Reloading...
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [328682]
Process SpawnProcess-2:
Traceback (most recent call last):
  File "/home/marcelo/anaconda3/envs/uvicorn3.9/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/home/marcelo/anaconda3/envs/uvicorn3.9/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/subprocess.py", line 76, in subprocess_started
    target(sockets=sockets)
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/server.py", line 67, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/home/marcelo/anaconda3/envs/uvicorn3.9/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1501, in uvloop.loop.Loop.run_until_complete
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/server.py", line 74, in serve
    config.load()
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/config.py", line 458, in load
    self.loaded_app = import_from_string(self.app)
  File "/home/marcelo/Development/encode/uvicorn/uvicorn/importer.py", line 21, in import_from_string
    module = importlib.import_module(module_str)
  File "/home/marcelo/anaconda3/envs/uvicorn3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 846, in exec_module
  File "<frozen importlib._bootstrap_external>", line 983, in get_code
  File "<frozen importlib._bootstrap_external>", line 913, in source_to_code
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/marcelo/Development/./main.py", line 11
    def home():
               ^
IndentationError: expected an indented block
INFO:     Stopping reloader process [328680]
```

The changes proposed here makes the reload process to work as expected i.e. reload the uvicorn server, and not exit when modifications that are not able to run are made.