### PR TITLE
Update black target version

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -8,7 +8,7 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}black --check --diff --target-version=py36 $SOURCE_FILES
+${PREFIX}black --check --diff --target-version=py37 $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
 ${PREFIX}mypy --show-error-codes
 ${PREFIX}isort --check --diff --project=uvicorn $SOURCE_FILES

--- a/scripts/lint
+++ b/scripts/lint
@@ -10,5 +10,5 @@ set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
 ${PREFIX}isort --project=uvicorn $SOURCE_FILES
-${PREFIX}black --target-version=py36 $SOURCE_FILES
+${PREFIX}black --target-version=py37 $SOURCE_FILES
 ${PREFIX}python -m tools.cli_usage


### PR DESCRIPTION
Since Python 3.6 was deprecated in #1261, this seemed like an oversight 🙂  I could be wrong though