### PR TITLE
Guard imports not needed at runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ wheel==0.37.0
 autoflake==1.4
 black==21.9b0
 flake8==3.9.2
+flake8-type-checking==1.2.0
 isort==5.9.3
 pytest==6.2.5
 pytest-mock==3.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 ignore = W503, E203, B305
 max-line-length = 88
+enable-extensions = TC,TC1
 
 [mypy]
 disallow_untyped_defs = True

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -1,11 +1,17 @@
-from typing import List, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
-from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 from tests.response import Response
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+if TYPE_CHECKING:
+    from typing import List, Union
+
+    from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 
 async def app(

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
 import sys
-from typing import List
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
-from asgiref.typing import HTTPRequestEvent, HTTPScope
 
-from uvicorn._types import Environ, StartResponse
 from uvicorn.middleware.wsgi import WSGIMiddleware, build_environ
+
+if TYPE_CHECKING:
+    from typing import List
+
+    from asgiref.typing import HTTPRequestEvent, HTTPScope
+
+    from uvicorn._types import Environ, StartResponse
 
 
 def hello_world(environ: Environ, start_response: StartResponse) -> List[bytes]:

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 import signal
 from logging import DEBUG, INFO, WARNING
-from pathlib import Path
 from time import sleep
+from typing import TYPE_CHECKING
 
 import pytest
 
 from tests.utils import as_cwd
 from uvicorn.config import Config
-from uvicorn.supervisors.basereload import BaseReload
 from uvicorn.supervisors.statreload import StatReload
 from uvicorn.supervisors.watchgodreload import WatchGodReload
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from uvicorn.supervisors.basereload import BaseReload
 
 
 class TestBaseReload:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import importlib
 import os
 import platform
 import sys
-from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
@@ -14,6 +16,10 @@ from uvicorn.config import Config
 from uvicorn.main import main as cli
 from uvicorn.server import Server
 from uvicorn.supervisors import ChangeReload, Multiprocess
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 HEADERS = "Content-Security-Policy:default-src 'self'; script-src https://example.com"
 main = importlib.import_module("uvicorn.main")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,30 +1,42 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
 import socket
 import sys
-import typing
 from copy import deepcopy
-from pathlib import Path
-from unittest.mock import MagicMock
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal
+from typing import TYPE_CHECKING
 
 import pytest
 import yaml
-from asgiref.typing import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Scope
-from pytest_mock import MockerFixture
 
 from tests.utils import as_cwd
-from uvicorn._types import Environ, StartResponse
 from uvicorn.config import LOGGING_CONFIG, Config
 from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Callable, Iterator, Optional
+    from unittest.mock import MagicMock
+
+    from asgiref.typing import (
+        ASGIApplication,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
+    from pytest_mock import MockerFixture
+
+    from uvicorn._types import Environ, StartResponse
+
+    if sys.version_info < (3, 8):
+        from typing_extensions import Literal
+    else:
+        from typing import Literal
 
 
 @pytest.fixture
@@ -336,7 +348,7 @@ def test_ssl_config_combined(tls_certificate_key_and_chain_path: str) -> None:
     assert config.is_ssl is True
 
 
-def asgi2_app(scope: Scope) -> typing.Callable:
+def asgi2_app(scope: Scope) -> Callable:
     async def asgi(
         receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:  # pragma: nocover
@@ -367,8 +379,8 @@ def test_asgi_version(
 )
 def test_log_config_default(
     mocked_logging_config_module: MagicMock,
-    use_colors: typing.Optional[bool],
-    expected: typing.Optional[bool],
+    use_colors: Optional[bool],
+    expected: Optional[bool],
 ) -> None:
     """
     Test that one can specify the use_colors option when using the default logging
@@ -438,14 +450,14 @@ def test_log_config_file(mocked_logging_config_module: MagicMock) -> None:
 
 
 @pytest.fixture(params=[0, 1])
-def web_concurrency(request: pytest.FixtureRequest) -> typing.Iterator[int]:
+def web_concurrency(request: pytest.FixtureRequest) -> Iterator[int]:
     yield getattr(request, "param")
     if os.getenv("WEB_CONCURRENCY"):
         del os.environ["WEB_CONCURRENCY"]
 
 
 @pytest.fixture(params=["127.0.0.1", "127.0.0.2"])
-def forwarded_allow_ips(request: pytest.FixtureRequest) -> typing.Iterator[str]:
+def forwarded_allow_ips(request: pytest.FixtureRequest) -> Iterator[str]:
     yield getattr(request, "param")
     if os.getenv("FORWARDED_ALLOW_IPS"):
         del os.environ["FORWARDED_ALLOW_IPS"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 import asyncio
 import os
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from uvicorn import Config, Server
+from uvicorn import Server
+
+if TYPE_CHECKING:
+    from uvicorn import Config
 
 
 @asynccontextmanager

--- a/uvicorn/_handlers/http.py
+++ b/uvicorn/_handlers/http.py
@@ -1,16 +1,17 @@
+from __future__ import annotations
+
 import asyncio
 from typing import TYPE_CHECKING
 
-from uvicorn.config import Config
-
 if TYPE_CHECKING:  # pragma: no cover
+    from uvicorn.config import Config
     from uvicorn.server import ServerState
 
 
 async def handle_http(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
-    server_state: "ServerState",
+    server_state: ServerState,
     config: Config,
 ) -> None:
     # Run transport/protocol session from streams.

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import inspect
 import json
@@ -8,7 +10,6 @@ import socket
 import ssl
 import sys
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from uvicorn.logging import TRACE_LOG_LEVEL
 
@@ -17,8 +18,14 @@ if sys.version_info < (3, 8):
 else:
     from typing import Literal
 
+from typing import TYPE_CHECKING
+
 import click
-from asgiref.typing import ASGIApplication
+
+if TYPE_CHECKING:
+    from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
+
+    from asgiref.typing import ASGIApplication
 
 try:
     import yaml

--- a/uvicorn/importer.py
+++ b/uvicorn/importer.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import importlib
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class ImportFromStringError(Exception):

--- a/uvicorn/lifespan/off.py
+++ b/uvicorn/lifespan/off.py
@@ -1,4 +1,9 @@
-from uvicorn import Config
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from uvicorn import Config
 
 
 class LifespanOff:

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -1,27 +1,32 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from asyncio import Queue
-from typing import Union
+from typing import TYPE_CHECKING
 
-from asgiref.typing import (
-    LifespanScope,
-    LifespanShutdownCompleteEvent,
-    LifespanShutdownEvent,
-    LifespanShutdownFailedEvent,
-    LifespanStartupCompleteEvent,
-    LifespanStartupEvent,
-    LifespanStartupFailedEvent,
-)
+if TYPE_CHECKING:
+    from typing import Union
 
-from uvicorn import Config
+    from asgiref.typing import (
+        LifespanScope,
+        LifespanShutdownCompleteEvent,
+        LifespanShutdownEvent,
+        LifespanShutdownFailedEvent,
+        LifespanStartupCompleteEvent,
+        LifespanStartupEvent,
+        LifespanStartupFailedEvent,
+    )
 
-LifespanReceiveMessage = Union[LifespanStartupEvent, LifespanShutdownEvent]
-LifespanSendMessage = Union[
-    LifespanStartupFailedEvent,
-    LifespanShutdownFailedEvent,
-    LifespanStartupCompleteEvent,
-    LifespanShutdownCompleteEvent,
-]
+    from uvicorn import Config
+
+    LifespanReceiveMessage = Union[LifespanStartupEvent, LifespanShutdownEvent]
+    LifespanSendMessage = Union[
+        LifespanStartupFailedEvent,
+        LifespanShutdownFailedEvent,
+        LifespanStartupCompleteEvent,
+        LifespanShutdownCompleteEvent,
+    ]
 
 STATE_TRANSITION_ERROR = "Got invalid state transition on lifespan protocol."
 
@@ -35,7 +40,7 @@ class LifespanOn:
         self.logger = logging.getLogger("uvicorn.error")
         self.startup_event = asyncio.Event()
         self.shutdown_event = asyncio.Event()
-        self.receive_queue: "Queue[LifespanReceiveMessage]" = asyncio.Queue()
+        self.receive_queue: Queue[LifespanReceiveMessage] = asyncio.Queue()
         self.error_occured = False
         self.startup_failed = False
         self.shutdown_failed = False

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import http
 import logging
 import sys
 from copy import copy
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 TRACE_LOG_LEVEL = 5
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform
 import ssl
 import sys
-import typing
+from typing import TYPE_CHECKING
 
 import click
-from asgiref.typing import ASGIApplication
 
 import uvicorn
 from uvicorn.config import (
@@ -20,8 +21,16 @@ from uvicorn.config import (
     WS_PROTOCOLS,
     Config,
 )
-from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
+from uvicorn.server import (  # noqa: F401,TC002  # Used to be defined here.
+    Server,
+    ServerState,
+)
 from uvicorn.supervisors import ChangeReload, Multiprocess
+
+if TYPE_CHECKING:
+    from typing import Any, List, Union
+
+    from asgiref.typing import ASGIApplication
 
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))
@@ -356,9 +365,9 @@ def main(
     interface: str,
     debug: bool,
     reload: bool,
-    reload_dirs: typing.List[str],
-    reload_includes: typing.List[str],
-    reload_excludes: typing.List[str],
+    reload_dirs: List[str],
+    reload_includes: List[str],
+    reload_excludes: List[str],
     reload_delay: float,
     workers: int,
     env_file: str,
@@ -381,7 +390,7 @@ def main(
     ssl_cert_reqs: int,
     ssl_ca_certs: str,
     ssl_ciphers: str,
-    headers: typing.List[str],
+    headers: List[str],
     use_colors: bool,
     app_dir: str,
     factory: bool,
@@ -435,7 +444,7 @@ def main(
     run(app, **kwargs)
 
 
-def run(app: typing.Union[ASGIApplication, str], **kwargs: typing.Any) -> None:
+def run(app: Union[ASGIApplication, str], **kwargs: Any) -> None:
     app_dir = kwargs.pop("app_dir", None)
     if app_dir is not None:
         sys.path.insert(0, app_dir)

--- a/uvicorn/middleware/asgi2.py
+++ b/uvicorn/middleware/asgi2.py
@@ -1,9 +1,14 @@
-from asgiref.typing import (
-    ASGI2Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    Scope,
-)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI2Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
 
 
 class ASGI2Middleware:

--- a/uvicorn/middleware/debug.py
+++ b/uvicorn/middleware/debug.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
 import html
 import traceback
-from typing import Union
+from typing import TYPE_CHECKING
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    ASGISendEvent,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    WWWScope,
-)
+if TYPE_CHECKING:
+    from typing import Union
+
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        ASGISendEvent,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        WWWScope,
+    )
 
 
 class HTMLResponse:

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -1,16 +1,21 @@
-import logging
-from typing import Any
+from __future__ import annotations
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGIReceiveEvent,
-    ASGISendCallable,
-    ASGISendEvent,
-    WWWScope,
-)
+import logging
+from typing import TYPE_CHECKING
 
 from uvicorn.logging import TRACE_LOG_LEVEL
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGIReceiveEvent,
+        ASGISendCallable,
+        ASGISendEvent,
+        WWWScope,
+    )
 
 PLACEHOLDER_FORMAT = {
     "body": "<{length} bytes>",

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -8,16 +8,21 @@ the connecting client, rather that the connecting proxy.
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
-from typing import List, Optional, Tuple, Union, cast
+from __future__ import annotations
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    HTTPScope,
-    Scope,
-    WebSocketScope,
-)
+from typing import TYPE_CHECKING, Union, cast
+
+from asgiref.typing import HTTPScope, WebSocketScope
+
+if TYPE_CHECKING:
+    from typing import List, Optional, Tuple
+
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
 
 
 class ProxyHeadersMiddleware:

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -1,22 +1,27 @@
+from __future__ import annotations
+
 import asyncio
 import concurrent.futures
 import io
 import sys
 from collections import deque
-from typing import Deque, Iterable, Optional, Tuple
+from typing import TYPE_CHECKING
 
-from asgiref.typing import (
-    ASGIReceiveCallable,
-    ASGIReceiveEvent,
-    ASGISendCallable,
-    ASGISendEvent,
-    HTTPRequestEvent,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    HTTPScope,
-)
+if TYPE_CHECKING:
+    from typing import Deque, Iterable, Optional, Tuple
 
-from uvicorn._types import Environ, ExcInfo, StartResponse, WSGIApp
+    from asgiref.typing import (
+        ASGIReceiveCallable,
+        ASGIReceiveEvent,
+        ASGISendCallable,
+        ASGISendEvent,
+        HTTPRequestEvent,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        HTTPScope,
+    )
+
+    from uvicorn._types import Environ, ExcInfo, StartResponse, WSGIApp
 
 
 def build_environ(scope: HTTPScope, message: ASGIReceiveEvent, body: bytes) -> Environ:

--- a/uvicorn/protocols/http/auto.py
+++ b/uvicorn/protocols/http/auto.py
@@ -1,7 +1,12 @@
-import asyncio
-from typing import Type
+from __future__ import annotations
 
-AutoHTTPProtocol: Type[asyncio.Protocol]
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from asyncio import Protocol
+    from typing import Type
+
+AutoHTTPProtocol: Type[Protocol]
 try:
     import httptools  # noqa
 except ImportError:  # pragma: no cover

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
 import asyncio
+from typing import TYPE_CHECKING
 
-from asgiref.typing import (
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    Scope,
-)
-
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        Scope,
+    )
 CLOSE_HEADER = (b"connection", b"close")
 
 HIGH_WATER_LIMIT = 65536

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import http
 import logging
-from typing import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import unquote
 
 import h11
@@ -20,6 +22,9 @@ from uvicorn.protocols.utils import (
     get_remote_addr,
     is_ssl,
 )
+
+if TYPE_CHECKING:
+    from typing import Callable
 
 
 def _get_status_phrase(status_code):

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import asyncio
 import http
 import logging
 import re
 import urllib
 from collections import deque
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import httptools
 
@@ -22,6 +24,9 @@ from uvicorn.protocols.utils import (
     get_remote_addr,
     is_ssl,
 )
+
+if TYPE_CHECKING:
+    from typing import Callable
 
 HEADER_RE = re.compile(b'[\x00-\x1F\x7F()<>@,;:[]={} \t\\"]')
 HEADER_VALUE_RE = re.compile(b"[\x00-\x1F\x7F]")

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,11 +1,16 @@
-import asyncio
+from __future__ import annotations
+
 import urllib.parse
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING
 
-from asgiref.typing import WWWScope
+if TYPE_CHECKING:
+    from asyncio import Transport
+    from typing import Optional, Tuple
+
+    from asgiref.typing import WWWScope
 
 
-def get_remote_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:
+def get_remote_addr(transport: Transport) -> Optional[Tuple[str, int]]:
     socket_info = transport.get_extra_info("socket")
     if socket_info is not None:
         try:
@@ -22,7 +27,7 @@ def get_remote_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:
     return None
 
 
-def get_local_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:
+def get_local_addr(transport: Transport) -> Optional[Tuple[str, int]]:
     socket_info = transport.get_extra_info("socket")
     if socket_info is not None:
         info = socket_info.getsockname()
@@ -34,7 +39,7 @@ def get_local_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:
     return None
 
 
-def is_ssl(transport: asyncio.Transport) -> bool:
+def is_ssl(transport: Transport) -> bool:
     return bool(transport.get_extra_info("sslcontext"))
 
 

--- a/uvicorn/protocols/websockets/auto.py
+++ b/uvicorn/protocols/websockets/auto.py
@@ -1,7 +1,12 @@
-import asyncio
-import typing
+from __future__ import annotations
 
-AutoWebSocketsProtocol: typing.Optional[typing.Type[asyncio.Protocol]]
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from asyncio import Protocol
+    from typing import Optional
+
+AutoWebSocketsProtocol: Optional[type[Protocol]]
 try:
     import websockets  # noqa
 except ImportError:  # pragma: no cover

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import http
 import logging
-from typing import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import unquote
 
 import websockets
@@ -9,6 +11,9 @@ from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFact
 
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.utils import get_local_addr, get_remote_addr, is_ssl
+
+if TYPE_CHECKING:
+    from typing import Callable
 
 
 class Server:

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import asyncio
 import logging
-from typing import Callable
+from typing import TYPE_CHECKING
 from urllib.parse import unquote
 
 import h11
@@ -12,6 +14,9 @@ from wsproto.utilities import RemoteProtocolError
 
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.utils import get_local_addr, get_remote_addr, is_ssl
+
+if TYPE_CHECKING:
+    from typing import Callable
 
 # Check wsproto version. We've build against 0.13. We don't know about 0.14 yet.
 assert wsproto.__version__ > "0.13", "Need wsproto version 0.13"

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -8,15 +10,17 @@ import sys
 import threading
 import time
 from email.utils import formatdate
-from types import FrameType
-from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING
 
 import click
 
 from uvicorn._handlers.http import handle_http
-from uvicorn.config import Config
 
 if TYPE_CHECKING:
+    from types import FrameType
+    from typing import Any, List, Optional, Set, Tuple, Union
+
+    from uvicorn.config import Config
     from uvicorn.protocols.http.h11_impl import H11Protocol
     from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
     from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
@@ -47,7 +51,7 @@ class ServerState:
 
     def __init__(self) -> None:
         self.total_requests = 0
-        self.connections: Set["Protocols"] = set()
+        self.connections: Set[Protocols] = set()
         self.tasks: Set[asyncio.Task] = set()
         self.default_headers: List[Tuple[bytes, bytes]] = []
 

--- a/uvicorn/subprocess.py
+++ b/uvicorn/subprocess.py
@@ -2,14 +2,19 @@
 Some light wrappers around Python's multiprocessing, to deal with cleanly
 starting child processes.
 """
+from __future__ import annotations
+
 import multiprocessing
 import os
 import sys
-from multiprocessing.context import SpawnProcess
-from socket import socket
-from typing import Callable, List, Optional
+from typing import TYPE_CHECKING
 
-from uvicorn.config import Config
+if TYPE_CHECKING:
+    from multiprocessing.context import SpawnProcess
+    from socket import socket
+    from typing import Callable, List, Optional
+
+    from uvicorn.config import Config
 
 multiprocessing.allow_connection_pickling()
 spawn = multiprocessing.get_context("spawn")

--- a/uvicorn/supervisors/__init__.py
+++ b/uvicorn/supervisors/__init__.py
@@ -1,10 +1,15 @@
-import typing
+from __future__ import annotations
 
-from uvicorn.supervisors.basereload import BaseReload
+from typing import TYPE_CHECKING
+
 from uvicorn.supervisors.multiprocess import Multiprocess
 
-if typing.TYPE_CHECKING:
-    ChangeReload: typing.Type[BaseReload]  # pragma: no cover
+if TYPE_CHECKING:
+    from typing import Type
+
+    from uvicorn.supervisors.basereload import BaseReload
+
+    ChangeReload: Type[BaseReload]  # pragma: no cover
 else:
     try:
         from uvicorn.supervisors.watchgodreload import WatchGodReload as ChangeReload

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 import logging
 import os
 import signal
 import threading
-from socket import socket
-from types import FrameType
-from typing import Callable, List, Optional
+from typing import TYPE_CHECKING
 
 import click
 
-from uvicorn.config import Config
 from uvicorn.subprocess import get_subprocess
+
+if TYPE_CHECKING:
+    from socket import socket
+    from types import FrameType
+    from typing import Callable, List, Optional
+
+    from uvicorn.config import Config
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -1,16 +1,22 @@
+from __future__ import annotations
+
 import logging
 import os
 import signal
 import threading
-from multiprocessing.context import SpawnProcess
-from socket import socket
-from types import FrameType
-from typing import Callable, List, Optional
+from typing import TYPE_CHECKING
 
 import click
 
-from uvicorn.config import Config
 from uvicorn.subprocess import get_subprocess
+
+if TYPE_CHECKING:
+    from multiprocessing.context import SpawnProcess
+    from socket import socket
+    from types import FrameType
+    from typing import Callable, List, Optional
+
+    from uvicorn.config import Config
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from socket import socket
-from typing import Callable, Dict, Iterator, List, Optional
+from typing import TYPE_CHECKING
 
-from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
+
+if TYPE_CHECKING:
+    from socket import socket
+    from typing import Callable, Dict, Iterator, List, Optional
+
+    from uvicorn.config import Config
 
 logger = logging.getLogger("uvicorn.error")
 

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -1,17 +1,21 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from socket import socket
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING
 
 from watchgod import DefaultWatcher
 
-from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
 
 logger = logging.getLogger("uvicorn.error")
 
 if TYPE_CHECKING:  # pragma: no cover
     import os
+    from socket import socket
+    from typing import Callable, Dict, List, Optional
+
+    from uvicorn.config import Config
 
     DirEntry = os.DirEntry[str]
 
@@ -43,7 +47,7 @@ class CustomWatcher(DefaultWatcher):
         self.resolved_root = root_path
         super().__init__(str(root_path))
 
-    def should_watch_file(self, entry: "DirEntry") -> bool:
+    def should_watch_file(self, entry: DirEntry) -> bool:
         cached_result = self.watched_files.get(entry.path)
         if cached_result is not None:
             return cached_result
@@ -65,7 +69,7 @@ class CustomWatcher(DefaultWatcher):
         self.watched_files[entry.path] = False
         return False
 
-    def should_watch_dir(self, entry: "DirEntry") -> bool:
+    def should_watch_dir(self, entry: DirEntry) -> bool:
         cached_result = self.watched_dirs.get(entry.path)
         if cached_result is not None:
             return cached_result

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import signal
 import sys
-from typing import Any
+from typing import TYPE_CHECKING
 
 from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
 
 from uvicorn.config import Config
 from uvicorn.main import Server
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class UvicornWorker(Worker):


### PR DESCRIPTION
Please ignore. This is just a proof-of-concept to discuss in the gitter chat.

## Motivation

Imports that are used for annotations are not required at runtime (assuming you don't evaluate the annotations yourself, or use a library that does - see pydantic). We don't want to remove them, as they're used by type checkers, but we can remove them from the runtime of the application by guarding them with `if TYPE_CHECKING:` which equates to `if False:`.

As far as I can tell, there are two primary benefits to doing this:

- Organisation: it's simpler to reason about your code, when you have a clear separation of runtime and non-runtime imports
- Efficiency: only importing things we need creates less of an overhead at runtime

And a secondary benefit that's more relevant in larger projects is that guarding imports will remove a lot of import circularity issues for you.

## Changes

This PR moves all imports that satisfy this condition into type-checking blocks.

It also adds a flake8-plugin to tell you:
- When an import can be moved **into* a type-checking block (it is unused, except for type hinting), and perhaps more importantly
- When an import need to be moved **out** of a type-checking block, because the remaining file might have changed in a way that no longer satisfies the above
 
But I can remove the addition of the flake8-hook if you prefer. I should say that it's my plugin, but I don't mind if you use it or not 👍 

### Guarding imports - Our options

We have two ways of managing forwards references:

1. Stringified references

```python
if TYPE_CHECKING:
    from typing import Any

x: "Any"
```


2. [PEP 563](https://www.python.org/dev/peps/pep-0563/) - Postponed evaluation of annotations

```python
from __futures__ import annotations

if TYPE_CHECKING:
    from typing import Any

x: Any
```

I've gone with number two here, but I could revert to number 1 if that is preferred. As a quick disclaimer, the `annotations` futures import also enables other back-ported language features, which you may not want.

