### PR TITLE
Add the `python_requires` version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
     author="Tom Christie",
     author_email="tom@tomchristie.com",
     packages=get_packages("uvicorn"),
+    python_requires=">=3.7",
     install_requires=minimal_requirements,
     extras_require={"standard": extra_requirements},
     include_package_data=True,


### PR DESCRIPTION
(Specifying Python 3.7 as the minimum requirement.)

Fixes #1327 