### PR TITLE
Fix ensure http connection is closed

### DIFF
--- a/uvicorn/_handlers/http.py
+++ b/uvicorn/_handlers/http.py
@@ -7,6 +7,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from uvicorn.server import ServerState
 
 
+MAX_RECV = 2 ** 16
+
+
 async def handle_http(
     reader: asyncio.StreamReader,
     writer: asyncio.StreamWriter,
@@ -33,13 +36,13 @@ async def handle_http(
     # Use a future to coordinate between the protocol and this handler task.
     # https://docs.python.org/3/library/asyncio-protocol.html#connecting-existing-sockets
     loop = asyncio.get_event_loop()
-    connection_lost = loop.create_future()
+    reader_read = asyncio.create_task(reader.read(MAX_RECV))
 
     # Switch the protocol from the stream reader to our own HTTP protocol class.
     protocol = config.http_protocol_class(  # type: ignore[call-arg, operator]
         config=config,
         server_state=server_state,
-        on_connection_lost=lambda: connection_lost.set_result(True),
+        on_connection_lost=reader_read.cancel,
     )
     transport = writer.transport
     transport.set_protocol(protocol)
@@ -56,7 +59,7 @@ async def handle_http(
 
     @task.add_done_callback
     def retrieve_exception(task: asyncio.Task) -> None:
-        exc = task.exception()
+        exc = task.exception() if not task.cancelled() else None
 
         if exc is None:
             return
@@ -74,15 +77,5 @@ async def handle_http(
 
     # Kick off the HTTP protocol.
     protocol.connection_made(transport)
-
-    # Pass any data already in the read buffer.
-    # The assumption here is that we haven't read any data off the stream reader
-    # yet: all data that the client might have already sent since the connection has
-    # been established is in the `_buffer`.
-    data = reader._buffer  # type: ignore
-    if data:
-        protocol.data_received(data)
-
-    # Let the transport run in the background. When closed, this future will complete
-    # and we'll exit here.
-    await connection_lost
+    data = await reader_read
+    protocol.data_received(data)

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -222,6 +222,10 @@ class H11Protocol(asyncio.Protocol):
                     continue
                 self.cycle.more_body = False
                 self.cycle.message_event.set()
+            elif event_type is h11.ConnectionClosed:
+                break
+        if self.conn.our_state is h11.MUST_CLOSE and not self.transport.is_closing():
+            self.transport.close()
 
     def handle_upgrade(self, event):
         upgrade_value = None

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -136,6 +136,8 @@ class HttpToolsProtocol(asyncio.Protocol):
             self.transport.close()
         except httptools.HttpParserUpgrade:
             self.handle_upgrade()
+        if data == b"" and not self.transport.is_closing():
+            self.transport.close()
 
     def handle_upgrade(self):
         upgrade_value = None


### PR DESCRIPTION
Ref Issues: #1199 #1226
Ref PRs: #1192 #1244 #1307
## Description
As #869 (released in 0.14.0) is missing handle the scenario of `b""`, it is possible to make the HTTP connection not close correctly.
Here is the memory usage plot with the current main branch, running a single `tcping` process for 5 minutes.
![p1](https://user-images.githubusercontent.com/8675900/149714875-cc79367c-b9b0-4878-abdc-af65ad2e43ac.png)

The memory usage is increasing, and the `netstat` shows many `CLOSE_WAIT` connections.

![p2](https://user-images.githubusercontent.com/8675900/149715049-34b28258-e4f5-4cb2-bf52-45851cab07bd.png)

I read the code in #869 , I have found two issues:
1. As we handle the connection close or not in the protocol, I think we should pass the scenario of `b""`  to [protocol.data_received](https://github.com/encode/uvicorn/blob/master/uvicorn/_handlers/http.py#L84) too. It is up to the protocol to determine if the connection should be closed or not.
2. Reading the data from [`_buffer`](https://github.com/encode/uvicorn/blob/master/uvicorn/_handlers/http.py#L82) seems not a good way. In some scenarios, the client will initially send empty TCP pings, then  `_buffer` will receive `b""`, determine if the connections should be closed or not through the `_buffer` data is confusing (refs from the [read](https://github.com/python/cpython/blob/main/Lib/asyncio/streams.py#L669) function).

Here is current PR code running a single `tcping` process for 5 minutes in the same testing environment:
![p3](https://user-images.githubusercontent.com/8675900/149715482-24310042-3f98-486b-ab61-fbbe5261fb69.png)

Test codes:
```python
import uvicorn

async def app(scope, receive, send):
    assert scope["type"] == "http"
    await send(
        {
            "type": "http.response.start",
            "status": 200,
            "headers": [
                [b"content-type", b"text/plain"],
            ],
        }
    )
    await send(
        {
            "type": "http.response.body",
            "body": b"Hello, world!",
        }
    )


if __name__ == "__main__":
    uvicorn.run(app, host="0.0.0.0", reload=False, log_level=5)

``` 