### PR TITLE
Fix `TypeError: __init__() got an unexpected keyword argument 'logger…

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -70,7 +70,6 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             ping_interval=self.config.ws_ping_interval,
             ping_timeout=self.config.ws_ping_timeout,
             extensions=extensions,
-            logger=logging.getLogger("uvicorn.error"),
             extra_headers=[],
         )
 


### PR DESCRIPTION
…'` error.

I got a TypeError: __init__() got an unexpected keyword argument 'logger' error when i made a websocket and made a request, i came here to fix it.