### PR TITLE
Fix `spec_version` value from WebSocket and HTTP connection scopes

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -710,8 +710,8 @@ def asgi2app(scope):
 
 
 asgi_scope_data = [
-    (asgi3app, {"version": "3.0", "spec_version": "2.1"}),
-    (asgi2app, {"version": "2.0", "spec_version": "2.1"}),
+    (asgi3app, {"version": "3.0", "spec_version": "2.3"}),
+    (asgi2app, {"version": "2.0", "spec_version": "2.3"}),
 ]
 
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -159,7 +159,7 @@ class H11Protocol(asyncio.Protocol):
                     "type": "http",
                     "asgi": {
                         "version": self.config.asgi_version,
-                        "spec_version": "2.1",
+                        "spec_version": "2.3",
                     },
                     "http_version": event.http_version.decode("ascii"),
                     "server": self.server,

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -201,7 +201,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.headers = []
         self.scope = {
             "type": "http",
-            "asgi": {"version": self.config.asgi_version, "spec_version": "2.1"},
+            "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
             "http_version": "1.1",
             "server": self.server,
             "client": self.client,

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -132,7 +132,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
 
         self.scope = {
             "type": "websocket",
-            "asgi": {"version": self.config.asgi_version, "spec_version": "2.1"},
+            "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -146,7 +146,7 @@ class WSProtocol(asyncio.Protocol):
         raw_path, _, query_string = event.target.partition("?")
         self.scope = {
             "type": "websocket",
-            "asgi": {"version": self.config.asgi_version, "spec_version": "2.1"},
+            "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,


### PR DESCRIPTION
Let's wait for https://github.com/django/asgiref/pull/312 to be merged before accepting this. We now are compliant with spec version 2.3:

![image](https://user-images.githubusercontent.com/7353520/150790747-54d3f5e0-9100-4843-8221-44cf873e097c.png)
