### PR TITLE
Require operations approval for package deploys.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,3 @@
----
 name: Publish
 
 on:
@@ -10,6 +9,9 @@ jobs:
   publish:
     name: "Publish release"
     runs-on: "ubuntu-latest"
+
+    environment:
+        name: deploy
 
     steps:
       - uses: "actions/checkout@v2"


### PR DESCRIPTION
Switch the "publish" workflow to run on the "deploy" environment, so that we can require reviews from @encode/operations  before deploying to PyPI.

I've also:

* Setup a deploy environment in this repo's settings.
* Configured it to have "required reviews" from the @encode/operations team
* Created a new PyPI API token for `uvicorn`.
* Saved that token in the deploy environment's secrets as PYPI_TOKEN.
