### PR TITLE
Check extra requirement versions at runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ minimal_requirements = [
 
 extra_requirements = [
     "websockets>=10.0",
-    "httptools>=0.2.0,<0.4.0",
+    "httptools>=0.2.0",
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -22,6 +22,8 @@ from asgiref.typing import ASGIApplication
 
 try:
     import yaml
+
+    assert yaml.__version__ >= "5.1", "Uvicorn requires PyYAML version 5.1 or higher"
 except ImportError:
     # If the code below that depends on yaml is exercised, it will raise a NameError.
     # Install the PyYAML package or the uvicorn[standard] optional dependencies to

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -1,6 +1,10 @@
 def auto_loop_setup(reload: bool = False) -> None:
     try:
         import uvloop  # noqa
+
+        assert (
+            uvloop.__version__ >= "0.14.0"
+        ), "Uvicorn requires uvloop version 0.14.0 or higher"
     except ImportError:  # pragma: no cover
         from uvicorn.loops.asyncio import asyncio_setup as loop_setup
 

--- a/uvicorn/protocols/http/auto.py
+++ b/uvicorn/protocols/http/auto.py
@@ -4,6 +4,10 @@ from typing import Type
 AutoHTTPProtocol: Type[asyncio.Protocol]
 try:
     import httptools  # noqa
+
+    assert (
+        httptools.__version__ >= "0.2.0"
+    ), "Uvicorn requires httptools version 0.2.0 or higher"
 except ImportError:  # pragma: no cover
     from uvicorn.protocols.http.h11_impl import H11Protocol
 

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -10,6 +10,10 @@ from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFact
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.utils import get_local_addr, get_remote_addr, is_ssl
 
+assert (
+    websockets.__version__ >= "10.0"
+), "Uvicorn requires websockets version 10.0 or higher"
+
 
 class Server:
     closing = False

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -3,10 +3,13 @@ from pathlib import Path
 from socket import socket
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional
 
+import watchgod
 from watchgod import DefaultWatcher
 
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
+
+assert watchgod.VERSION >= "0.6", "Uvicorn requires watchgod version 0.6 or higher"
 
 logger = logging.getLogger("uvicorn.error")
 


### PR DESCRIPTION
Currently, if a user installs `uvicorn` without the `[standard]` extra requirements, the user is able to install packages with incompatible versions. Like, they can do `pip install uvicorn websockets==0.9.0`, and this will break at runtime, because `uvicorn` only works with `websockets>=10.0`.

Alternatives, and discussion, are more than welcome.

 We can also not act here, but the error pointed out is completely misleading.