### PR TITLE
Ignore coverage on `MockLoop.is_running` method

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -131,7 +131,7 @@ class MockLoop(asyncio.AbstractEventLoop):
         self.loop = event_loop
 
     def is_running(self):
-        return True
+        return True  # pragma: no cover
 
     def create_task(self, coroutine):
         self.tasks.insert(0, coroutine)


### PR DESCRIPTION
Coverage before:
```bash
+ venv/bin/coverage report --show-missing --skip-covered --fail-under=97
Name                                              Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------
tests/protocols/test_http.py                        473      1    99%   134
tests/protocols/test_websocket.py                   451      1    99%   622
tests/test_config.py                                260      1    99%   12
uvicorn/_handlers/http.py                            22      3    86%   67-76, 81
uvicorn/config.py                                   304     18    94%   16, 25-29, 141-142, 177, 326-327, 331, 361, 517-519, 545-546, 552-554
uvicorn/middleware/proxy_headers.py                  33      1    97%   44
uvicorn/protocols/http/flow_control.py               34      6    82%   25, 38-40, 44-45
uvicorn/protocols/http/h11_impl.py                  304     14    95%   124-125, 225-226, 228, 243-244, 264-265, 317, 323, 421, 424, 439
uvicorn/protocols/http/httptools_impl.py            324     12    96%   125-126, 140, 155-156, 160, 318, 324, 422, 425, 457, 459
uvicorn/protocols/utils.py                           37      2    95%   14-17
uvicorn/protocols/websockets/websockets_impl.py     166      2    99%   105-106
uvicorn/protocols/websockets/wsproto_impl.py        222     27    88%   27, 77, 90, 100, 113, 115, 125, 131, 134-137, 169-180, 218-225
uvicorn/server.py                                   186     55    70%   20-25, 31-32, 90-92, 113-129, 133-139, 143-152, 164-167, 186-187, 193, 206, 249-251, 255, 267, 278-281, 297, 311-314
uvicorn/subprocess.py                                21      4    81%   69-76
uvicorn/supervisors/basereload.py                    51      7    86%   43-48, 81, 90
-------------------------------------------------------------------------------
TOTAL                                              4744    154    97%
```
After this, the following line disappears:
```bash
tests/protocols/test_http.py                        473      1    99%   134
```

Alternative solution: remove `is_running` method.