### PR TITLE
Add py-gte-38 coverage rule on import statements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,3 +74,4 @@ plugins =
 [coverage:coverage_conditional_plugin]
 rules =
   "sys_platform == 'win32'": py-win32
+  "sys_version_info >= (3, 8)": py-gte-38

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from pathlib import Path
 from unittest.mock import MagicMock
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 8):  # pragma: py-gte-38
     from typing_extensions import Literal
 else:
     from typing import Literal

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -12,7 +12,7 @@ from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from uvicorn.logging import TRACE_LOG_LEVEL
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 8):  # pragma: py-gte-38
     from typing_extensions import Literal
 else:
     from typing import Literal


### PR DESCRIPTION
We agreed on only taking care of the coverage on Python 3.8. See [this](https://github.com/encode/uvicorn/issues/102#issuecomment-797365601) and [this](https://github.com/encode/uvicorn/issues/102#issuecomment-797395437).

Before:
```bash
+ venv/bin/coverage report --show-missing --skip-covered --fail-under=97
Name                                              Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------
tests/protocols/test_http.py                        473      1    99%   134
tests/protocols/test_websocket.py                   451      1    99%   622
tests/test_config.py                                260      1    99%   12
uvicorn/_handlers/http.py                            22      3    86%   67-76, 81
uvicorn/config.py                                   304     17    94%   16, 25-29, 141-142, 326-327, 331, 361, 517-519, 545-546, 552-554
uvicorn/middleware/proxy_headers.py                  33      1    97%   44
uvicorn/protocols/http/flow_control.py               34      6    82%   25, 38-40, 44-45
uvicorn/protocols/http/h11_impl.py                  304     14    95%   124-125, 225-226, 228, 243-244, 264-265, 317, 323, 421, 424, 439
uvicorn/protocols/http/httptools_impl.py            324     12    96%   125-126, 140, 155-156, 160, 318, 324, 422, 425, 457, 459
uvicorn/protocols/utils.py                           37      2    95%   14-17
uvicorn/protocols/websockets/websockets_impl.py     166      2    99%   105-106
uvicorn/protocols/websockets/wsproto_impl.py        222     27    88%   27, 77, 90, 100, 113, 115, 125, 131, 134-137, 169-180, 218-225
uvicorn/server.py                                   186     55    70%   20-25, 31-32, 90-92, 113-129, 133-139, 143-152, 164-167, 186-187, 193, 206, 249-251, 255, 267, 278-281, 297, 311-314
uvicorn/subprocess.py                                21      4    81%   69-76
uvicorn/supervisors/basereload.py                    51      7    86%   43-48, 81, 90
-------------------------------------------------------------------------------
TOTAL                                              4744    153    97%
```
After this PR, the following line is erased:
```bash
tests/test_config.py                                260      1    99%   12
```