### PR TITLE
Fix coverage precision to 96.77%

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=97
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=96.83

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=96.83
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=96.77

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,9 @@ include = uvicorn/*, tests/*
 plugins =
   coverage_conditional_plugin
 
+[coverage:report]
+precision = 2
+
 [coverage:coverage_conditional_plugin]
 rules =
   "sys_platform == 'win32'": py-win32

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,3 +78,4 @@ precision = 2
 rules =
   "sys_platform == 'win32'": py-win32
   "sys_version_info >= (3, 8)": py-gte-38
+  "sys_version_info < (3, 8)": py-lt-38

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 if sys.version_info < (3, 8):  # pragma: py-gte-38
     from typing_extensions import Literal
-else:
+else:  # pragma: py-lt-38
     from typing import Literal
 
 import pytest

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -14,7 +14,7 @@ from uvicorn.logging import TRACE_LOG_LEVEL
 
 if sys.version_info < (3, 8):  # pragma: py-gte-38
     from typing_extensions import Literal
-else:
+else:  # pragma: py-lt-38
     from typing import Literal
 
 import click


### PR DESCRIPTION
"Aren't you being too pedantic?"

Not really... It's really bothersome having to regain the same coverage over and over again because PRs get merged without covering all of it. The idea here is to not regress anymore.

`coverage` doesn't support the precision argument on the CLI. I've created a PR to fix it: https://github.com/nedbat/coveragepy/pull/1317. Until then, we should use the `setup.cfg`.