### PR TITLE
Send HTTP 400 response for invalid request

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -742,5 +742,5 @@ def test_invalid_http_request(request_line, protocol_cls, caplog, event_loop):
 
     with get_connected_protocol(app, protocol_cls, event_loop) as protocol:
         protocol.data_received(request)
-        assert not protocol.transport.buffer
-        assert "Invalid HTTP request received." in caplog.messages
+        assert b"HTTP/1.1 400 Bad Request" in protocol.transport.buffer
+        assert b"Invalid HTTP request received." in protocol.transport.buffer

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -135,9 +135,9 @@ class H11Protocol(asyncio.Protocol):
             try:
                 event = self.conn.next_event()
             except h11.RemoteProtocolError as exc:
-                msg = "Invalid HTTP request received."
+                msg = b"Invalid HTTP request received."
                 self.logger.warning(msg, exc_info=exc)
-                self.transport.close()
+                self.send_400_response(msg)
                 return
             event_type = type(event)
 
@@ -234,30 +234,9 @@ class H11Protocol(asyncio.Protocol):
                 upgrade_value = value.lower()
 
         if upgrade_value != b"websocket" or self.ws_protocol_class is None:
-            msg = "Unsupported upgrade request."
+            msg = b"Unsupported upgrade request."
             self.logger.warning(msg)
-
-            from uvicorn.protocols.websockets.auto import AutoWebSocketsProtocol
-
-            if AutoWebSocketsProtocol is None:
-                msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
-                self.logger.warning(msg)
-
-            reason = STATUS_PHRASES[400]
-            headers = [
-                (b"content-type", b"text/plain; charset=utf-8"),
-                (b"connection", b"close"),
-            ]
-            event = h11.Response(status_code=400, headers=headers, reason=reason)
-            output = self.conn.send(event)
-            self.transport.write(output)
-            event = h11.Data(data=b"Unsupported upgrade request.")
-            output = self.conn.send(event)
-            self.transport.write(output)
-            event = h11.EndOfMessage()
-            output = self.conn.send(event)
-            self.transport.write(output)
-            self.transport.close()
+            self.send_400_response(msg)
             return
 
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -277,6 +256,30 @@ class H11Protocol(asyncio.Protocol):
         protocol.connection_made(self.transport)
         protocol.data_received(b"".join(output))
         self.transport.set_protocol(protocol)
+
+    def send_400_response(self, msg: bytes):
+
+        from uvicorn.protocols.websockets.auto import AutoWebSocketsProtocol
+
+        if AutoWebSocketsProtocol is None:
+            msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
+            self.logger.warning(msg)
+
+        reason = STATUS_PHRASES[400]
+        headers = [
+            (b"content-type", b"text/plain; charset=utf-8"),
+            (b"connection", b"close"),
+        ]
+        event = h11.Response(status_code=400, headers=headers, reason=reason)
+        output = self.conn.send(event)
+        self.transport.write(output)
+        event = h11.Data(data=msg)
+        output = self.conn.send(event)
+        self.transport.write(output)
+        event = h11.EndOfMessage()
+        output = self.conn.send(event)
+        self.transport.write(output)
+        self.transport.close()
 
     def on_response_complete(self):
         self.server_state.total_requests += 1

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -135,7 +135,7 @@ class H11Protocol(asyncio.Protocol):
             try:
                 event = self.conn.next_event()
             except h11.RemoteProtocolError as exc:
-                msg = b"Invalid HTTP request received."
+                msg = "Invalid HTTP request received."
                 self.logger.warning(msg, exc_info=exc)
                 self.send_400_response(msg)
                 return
@@ -234,7 +234,7 @@ class H11Protocol(asyncio.Protocol):
                 upgrade_value = value.lower()
 
         if upgrade_value != b"websocket" or self.ws_protocol_class is None:
-            msg = b"Unsupported upgrade request."
+            msg = "Unsupported upgrade request."
             self.logger.warning(msg)
             self.send_400_response(msg)
             return
@@ -257,7 +257,7 @@ class H11Protocol(asyncio.Protocol):
         protocol.data_received(b"".join(output))
         self.transport.set_protocol(protocol)
 
-    def send_400_response(self, msg: bytes):
+    def send_400_response(self, msg: str):
 
         from uvicorn.protocols.websockets.auto import AutoWebSocketsProtocol
 
@@ -273,7 +273,7 @@ class H11Protocol(asyncio.Protocol):
         event = h11.Response(status_code=400, headers=headers, reason=reason)
         output = self.conn.send(event)
         self.transport.write(output)
-        event = h11.Data(data=msg)
+        event = h11.Data(data=msg.encode("ascii"))
         output = self.conn.send(event)
         self.transport.write(output)
         event = h11.EndOfMessage()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -133,7 +133,8 @@ class HttpToolsProtocol(asyncio.Protocol):
         except httptools.HttpParserError as exc:
             msg = "Invalid HTTP request received."
             self.logger.warning(msg, exc_info=exc)
-            self.transport.close()
+            self.send_400_response(msg)
+            return
         except httptools.HttpParserUpgrade:
             self.handle_upgrade()
         if data == b"" and not self.transport.is_closing():
@@ -148,27 +149,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         if upgrade_value != b"websocket" or self.ws_protocol_class is None:
             msg = "Unsupported upgrade request."
             self.logger.warning(msg)
-
-            from uvicorn.protocols.websockets.auto import AutoWebSocketsProtocol
-
-            if AutoWebSocketsProtocol is None:
-                msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
-                self.logger.warning(msg)
-
-            content = [STATUS_LINE[400]]
-            for name, value in self.default_headers:
-                content.extend([name, b": ", value, b"\r\n"])
-            content.extend(
-                [
-                    b"content-type: text/plain; charset=utf-8\r\n",
-                    b"content-length: " + str(len(msg)).encode("ascii") + b"\r\n",
-                    b"connection: close\r\n",
-                    b"\r\n",
-                    msg.encode("ascii"),
-                ]
-            )
-            self.transport.write(b"".join(content))
-            self.transport.close()
+            self.send_400_response(msg)
             return
 
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -189,6 +170,29 @@ class HttpToolsProtocol(asyncio.Protocol):
         protocol.connection_made(self.transport)
         protocol.data_received(b"".join(output))
         self.transport.set_protocol(protocol)
+
+    def send_400_response(self, msg: str):
+
+        from uvicorn.protocols.websockets.auto import AutoWebSocketsProtocol
+
+        if AutoWebSocketsProtocol is None:
+            msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
+            self.logger.warning(msg)
+
+        content = [STATUS_LINE[400]]
+        for name, value in self.default_headers:
+            content.extend([name, b": ", value, b"\r\n"])
+        content.extend(
+            [
+                b"content-type: text/plain; charset=utf-8\r\n",
+                b"content-length: " + str(len(msg)).encode("ascii") + b"\r\n",
+                b"connection: close\r\n",
+                b"\r\n",
+                msg.encode("ascii"),
+            ]
+        )
+        self.transport.write(b"".join(content))
+        self.transport.close()
 
     # Parser callbacks
     def on_url(self, url):


### PR DESCRIPTION
Given an invalid request, respond with an HTTP 400 error instead of
closing the connection without a response.

Please find here a rebased version of #205