### PR TITLE
Drop wsproto version checking

### DIFF
--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -4,7 +4,6 @@ from urllib.parse import unquote
 
 import h11
 import wsproto
-from packaging import version
 from wsproto import ConnectionType, events
 from wsproto.connection import ConnectionState
 from wsproto.extensions import PerMessageDeflate
@@ -12,10 +11,6 @@ from wsproto.utilities import RemoteProtocolError
 
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.utils import get_local_addr, get_remote_addr, is_ssl
-
-assert version.parse(wsproto.__version__) >= version.parse(
-    "0.13"
-), "Uvicorn requires wsproto version 0.13 or higher"
 
 
 class WSProtocol(asyncio.Protocol):


### PR DESCRIPTION
Refs. https://github.com/encode/uvicorn/issues/1358

I'm okay with us considering if we want to enforce strict version checking, but for right now *let's just drop this*. 

(Because #1358 is a much worse thing for users to be bumping into than... "If you switch to wsproto, *and* you install an older version *then* websockets won't work properly.)