### PR TITLE
Version 0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.17.3 - 2022-02-03
+
+### Fixed
+
+- Drop wsproto version checking. (#1359) 03/02/22
+
 ## 0.17.2 - 2022-02-03
 
 ### Fixed

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Draft release: https://github.com/encode/uvicorn/releases/edit/untagged-415f6a57cdf5f1153288

## 0.17.3 - 2022-02-03

 ### Fixed

 - Drop wsproto version checking. (#1359) 03/02/22
