### PR TITLE
Replace `create_server` by `create_unix_server`

### DIFF
--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,4 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage report --show-missing --skip-covered --fail-under=96.96
+${PREFIX}coverage report --show-missing --skip-covered --fail-under=96.93

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -134,7 +134,7 @@ class Server:
             uds_perms = 0o666
             if os.path.exists(config.uds):
                 uds_perms = os.stat(config.uds).st_mode
-            server = await loop.create_server(  # type: ignore[call-overload]
+            server = await loop.create_unix_server(
                 create_protocol, path=config.uds, ssl=config.ssl, backlog=config.backlog
             )
             os.chmod(config.uds, uds_perms)


### PR DESCRIPTION
When reverting the "stream interface" there was a mistake on the functions used. Thanks for the report @wlaub