### PR TITLE
Uvicorn logging error when port is a string although the server is running, see issue #1368

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -192,7 +192,7 @@ class Server:
                 # It's an IPv6 address.
                 addr_format = "%s://[%s]:%d"
 
-            port = config.port
+            port = int(config.port)
             if port == 0:
                 port = listeners[0].getsockname()[1]
 


### PR DESCRIPTION
See issue https://github.com/encode/uvicorn/issues/1368