### PR TITLE
Add note on 'UVICORN_' prefixed settings and '--env-file'

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -13,9 +13,7 @@ For example, in case you want to run the app on port `5000`, just set the enviro
 !!! note
     CLI options and the arguments for `uvicorn.run()` take precedence over environment variables.
 
-    Also note that `UVICORN_*` prefixed settings cannot be used from within an environment configuration file.
-    Using an environment configuration file with the `--env-file` flag is intended for configuring the ASGI application
-    that uvicorn runs, rather than configuring uvicorn itself.
+    Also note that `UVICORN_*` prefixed settings cannot be used from within an environment configuration file. Using an environment configuration file with the `--env-file` flag is intended for configuring the ASGI application that uvicorn runs, rather than configuring uvicorn itself.
 
 ## Application
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -14,8 +14,8 @@ For example, in case you want to run the app on port `5000`, just set the enviro
     CLI options and the arguments for `uvicorn.run()` take precedence over environment variables.
 
     Also note that `UVICORN_*` prefixed settings cannot be used from within an environment configuration file.
-    Using an environment configuration file is intended for configuring the ASGI application that uvicorn
-    runs, rather than configuring uvicorn itself.
+    Using an environment configuration file with the `--env-file` flag is intended for configuring the ASGI application
+    that uvicorn runs, rather than configuring uvicorn itself.
 
 ## Application
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -13,6 +13,9 @@ For example, in case you want to run the app on port `5000`, just set the enviro
 !!! note
     CLI options and the arguments for `uvicorn.run()` take precedence over environment variables.
 
+    Also note that `UVICORN_*` prefixed settings cannot be used from within an environment configuration file.
+    Using an environment configuration file is intended for configuring the ASGI application that uvicorn
+    runs, rather than configuring uvicorn itself.
 
 ## Application
 


### PR DESCRIPTION
Closes https://github.com/encode/uvicorn/issues/1319

Rendered docs now look like...

<img width="783" alt="Screenshot 2022-02-11 at 12 07 49" src="https://user-images.githubusercontent.com/647359/153588931-1d01297e-f956-4e49-a709-58cefa24aad5.png">

