### PR TITLE
Add macOS to the pipeline

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,
 addopts = -rxXs
   --strict-config
   --strict-markers
-  --basetemp=/tmp/pytest
 xfail_strict=True
 filterwarnings=
     # Turn warnings that aren't filtered into exceptions

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,
 addopts = -rxXs
   --strict-config
   --strict-markers
+  --basetemp=/tmp/pytest
 xfail_strict=True
 filterwarnings=
     # Turn warnings that aren't filtered into exceptions

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -511,9 +511,9 @@ def test_ws_max_size() -> None:
     ],
     ids=["--reload=True --workers=1", "--reload=False --workers=2"],
 )
-@pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="require linux")
 def test_bind_unix_socket_works_with_reload_or_workers(
-    tmp_path, reload, workers
+    tmp_path: Path, reload: bool, workers: int
 ):  # pragma: py-win32
     uds_file = tmp_path / "uvicorn.sock"
     config = Config(


### PR DESCRIPTION
- Related to https://github.com/encode/uvicorn/pull/1170

As mentioned on the PR above:
> The path we use to bind to the socket is 127 bytes length. [AF_UNIX](https://man7.org/linux/man-pages/man7/unix.7.html) has only 108 bytes allocated for it, so we keep receiving `OSError: AF_UNIX path too long`. 

Solutions that I've tried:
- Use [`basetemp`](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-default-base-temporary-directory), but it doesn't work as expected on Windows.
- Use [`tmp_path_factory`](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmp-path-factory-fixture), but still doesn't work on some systems. It passes on the GitHub CI, because the path is short, but locally the name is still long.
- Enable test only for Linux systems (I've used the recommended way of checking the system, [given the docs](https://docs.python.org/3/library/sys.html#sys.platform).

I've used the last solution, but if you guys have an alternative, feel free to suggest.

EDIT: The goal of the PR evolved due to discussion. Now it's meant to add the macOS machine to the pipeline.