### PR TITLE
Bump `httptools` to `>=0.4.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ minimal_requirements = [
 
 extra_requirements = [
     "websockets>=10.0",
-    "httptools>=0.2.0,<0.4.0",
+    "httptools>=0.4.0",
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
     "watchgod>=0.6",


### PR DESCRIPTION
As there are 2 CVE that affects `httptools`, they've bumped the package to 0.4.0.

Do we remove the previous versions to force users to bump `httptools` or do we just increase the range (i.e. `<0.5.0`)?

Reference: https://github.com/MagicStack/httptools/issues/76