### PR TITLE
adding Muffin framework to the list of ASGI web frameworks in documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -509,6 +509,10 @@ Its most distinctive features are built-in support for dependency injection, aut
 
 [Falcon](https://falconframework.org) is a minimalist REST and app backend framework for Python, with a focus on reliability, correctness, and performance at scale.
 
+### Muffin
+
+[Muffin](https://github.com/klen/muffin) is a fast, lightweight and asyncronous ASGI web-framework for Python 3.
+
 
 [uvloop]: https://github.com/MagicStack/uvloop
 [httptools]: https://github.com/MagicStack/httptools

--- a/docs/index.md
+++ b/docs/index.md
@@ -511,7 +511,7 @@ Its most distinctive features are built-in support for dependency injection, aut
 
 ### Muffin
 
-[Muffin](https://github.com/klen/muffin) is a fast, lightweight and asyncronous ASGI web-framework for Python 3.
+[Muffin](https://github.com/klen/muffin) is a fast, lightweight and asynchronous ASGI web-framework for Python 3.
 
 
 [uvloop]: https://github.com/MagicStack/uvloop


### PR DESCRIPTION
Hello,
Please consider this pull request to add [Muffin](https://github.com/klen/muffin) to the list of ASGI web frameworks. It is an extremely fast ASGI framework, as can be observed from the [benchmark tests](https://github.com/klen/py-frameworks-bench) 
The framework runs on top of uvicorn and well [documented](https://klen.github.io/muffin/). Works on Python 3.7, 3.8, 3.9, 3.10.