### PR TITLE
Add macos to the CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: "actions/checkout@v2"
       - uses: "actions/setup-python@v2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
+import os
 import ssl
 from copy import deepcopy
+from hashlib import md5
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from uuid import uuid4
 
 import pytest
 import trustme
@@ -136,3 +141,38 @@ def reload_directory_structure(tmp_path_factory: pytest.TempPathFactory):
 @pytest.fixture(scope="function")
 def logging_config() -> dict:
     return deepcopy(LOGGING_CONFIG)
+
+
+@pytest.fixture
+def short_socket_name(tmp_path, tmp_path_factory):  # pragma: py-win32
+    max_sock_len = 100
+    socket_filename = "my.sock"
+    identifier = f"{uuid4()}-"
+    identifier_len = len(identifier.encode())
+    tmp_dir = Path("/tmp").resolve()
+    os_tmp_dir = Path(os.getenv("TMPDIR", "/tmp")).resolve()
+    basetemp = Path(
+        str(tmp_path_factory.getbasetemp()),
+    ).resolve()
+    hash_basetemp = md5(
+        str(basetemp).encode(),
+    ).hexdigest()
+
+    def make_tmp_dir(base_dir):
+        return TemporaryDirectory(
+            dir=str(base_dir),
+            prefix="p-",
+            suffix=f"-{hash_basetemp}",
+        )
+
+    paths = basetemp, os_tmp_dir, tmp_dir
+    for num, tmp_dir_path in enumerate(paths, 1):
+        with make_tmp_dir(tmp_dir_path) as tmpd:
+            tmpd = Path(tmpd).resolve()
+            sock_path = str(tmpd / socket_filename)
+            sock_path_len = len(sock_path.encode())
+            if sock_path_len <= max_sock_len:
+                if max_sock_len - sock_path_len >= identifier_len:
+                    sock_path = str(tmpd / "".join((identifier, socket_filename)))
+                yield sock_path
+                return

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -774,7 +774,12 @@ def test_fragmentation():
         time.sleep(0.01)
         sock.sendall(d[split:])
         resp = receive_all(sock)
-        sock.shutdown(socket.SHUT_RDWR)
+        # see https://github.com/kmonsoor/py-amqplib/issues/45
+        # we skip the error on bsd systems if python is too slow
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except Exception:
+            pass
         sock.close()
         return resp
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -513,17 +513,14 @@ def test_ws_max_size() -> None:
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
 def test_bind_unix_socket_works_with_reload_or_workers(
-    tmp_path, reload, workers
+    tmp_path, reload, workers, short_socket_name
 ):  # pragma: py-win32
-    uds_file = tmp_path / "uvicorn.sock"
-    config = Config(
-        app=asgi_app, uds=uds_file.as_posix(), reload=reload, workers=workers
-    )
+    config = Config(app=asgi_app, uds=short_socket_name, reload=reload, workers=workers)
     config.load()
     sock = config.bind_socket()
     assert isinstance(sock, socket.socket)
     assert sock.family == socket.AF_UNIX
-    assert sock.getsockname() == uds_file.as_posix()
+    assert sock.getsockname() == short_socket_name
     sock.close()
 
 


### PR DESCRIPTION
Slighlty different than https://github.com/encode/uvicorn/pull/1395 @Kludex , let me know what you think.
In particular it shrink the socket name in macos CI and solves the issues you had on the `test_fragmentation` for macos