### PR TITLE
Bump mkdocs from 1.2.3 to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ pytest-asyncio==0.15.1
 
 
 # Documentation
-mkdocs==1.2.3
+mkdocs==1.3.0
 mkdocs-material==8.2.5


### PR DESCRIPTION
Our pipeline is broken. jinja2 broke mkdocs some days ago.