### PR TITLE
enable apps receiving command line arguments

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -341,7 +341,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     help="Treat APP as an application factory, i.e. a () -> <ASGI app> callable.",
     show_default=True,
 )
-def main(
+def main_command(
     app: str,
     host: str,
     port: int,
@@ -435,6 +435,12 @@ def main(
         "app_dir": app_dir,
     }
     run(app, **kwargs)
+
+
+def main() -> None:
+    argument_separator_index = sys.argv.index("--")
+    own_arguments = sys.argv[1:argument_separator_index]
+    main_command(own_arguments)
 
 
 def run(app: typing.Union[ASGIApplication, str], **kwargs: typing.Any) -> None:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -438,8 +438,11 @@ def main_command(
 
 
 def main() -> None:
-    argument_separator_index = sys.argv.index("--")
-    own_arguments = sys.argv[1:argument_separator_index]
+    try:
+        argument_separator_index = sys.argv.index("--")
+        own_arguments = sys.argv[1:argument_separator_index]
+    except ValueError:
+        own_arguments = sys.argv[1:]
     main_command(own_arguments)
 
 


### PR DESCRIPTION
Enables additional arguments and additional options, so that uvicorn apps can parse their own arguments.

```shell
uvicorn myproject:app --debug --reload -- --myarg=value -a -r -g ./config.ini
```

```shell
python -m uvicorn myproject:app --debug --reload -- --myarg=value -a -r -g ./config.ini
```

Apps can now parse their own additional arguments:

```python
try:
  args = sys.argv[sys.argv.index("--") + 1:]
except ValueError:
  args = []
```

It might be worth considering providing the separated additional arguments via environment variable? But I wasn't sure how this needed to be named and implemented.

