### PR TITLE
Bump black to 22.3.0

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,6 +26,7 @@ jobs:
       - name: "Run linting checks"
         run: "scripts/check"
         shell: bash
+        if: "${{ matrix.os == 'ubuntu-latest'}}"
       - name: "Build package & docs"
         run: "scripts/build"
         shell: bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,7 +119,7 @@ Options:
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
   --factory                       Treat APP as an application factory, i.e. a
-                                  () -> <ASGI app> callable.  [default: False]
+                                  () -> <ASGI app> callable.
   --help                          Show this message and exit.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -188,7 +188,7 @@ Options:
                                   adding this to the PYTHONPATH. Defaults to
                                   the current working directory.  [default: .]
   --factory                       Treat APP as an application factory, i.e. a
-                                  () -> <ASGI app> callable.  [default: False]
+                                  () -> <ASGI app> callable.
   --help                          Show this message and exit.
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ wheel==0.37.0
 
 # Testing
 autoflake==1.4
-black==21.9b0
+black==22.3.0
 flake8==3.9.2
 isort==5.10.1
 pytest==6.2.5


### PR DESCRIPTION
Replaces #1427

Changes:
- Bump `black` to 22.3.0
- Ignore `scripts/check` script on the pipeline for Windows. There's no need for running this on multiple OS anyway.