### PR TITLE
Add default code for `websocket.close`

### DIFF
--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -65,7 +65,7 @@ class WSProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc):
         if exc is not None:
-            self.queue.put_nowait({"type": "websocket.disconnect"})
+            self.queue.put_nowait({"type": "websocket.disconnect", "code": exc.code})
         self.connections.remove(self)
 
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -262,7 +262,7 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.write(output)
 
             elif message_type == "websocket.close":
-                self.queue.put_nowait({"type": "websocket.disconnect", "code": None})
+                self.queue.put_nowait({"type": "websocket.disconnect", "code": message.get("code", 1000)})
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     self.scope["client"],

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -262,7 +262,9 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.write(output)
 
             elif message_type == "websocket.close":
-                self.queue.put_nowait({"type": "websocket.disconnect", "code": message.get("code", 1000)})
+                self.queue.put_nowait(
+                    {"type": "websocket.disconnect", "code": message.get("code", 1000)}
+                )
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     self.scope["client"],

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -65,7 +65,7 @@ class WSProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc):
         if exc is not None:
-            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1000})
+            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1005})
         self.connections.remove(self)
 
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -263,7 +263,7 @@ class WSProtocol(asyncio.Protocol):
 
             elif message_type == "websocket.close":
                 self.queue.put_nowait(
-                    {"type": "websocket.disconnect", "code": message.get("code", 1000)}
+                    {"type": "websocket.disconnect", "code": message.get("code", 1005)}
                 )
                 self.logger.info(
                     '%s - "WebSocket %s" 403',

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -65,7 +65,7 @@ class WSProtocol(asyncio.Protocol):
 
     def connection_lost(self, exc):
         if exc is not None:
-            self.queue.put_nowait({"type": "websocket.disconnect", "code": exc.code})
+            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1000})
         self.connections.remove(self)
 
         if self.logger.level <= TRACE_LOG_LEVEL:


### PR DESCRIPTION
I need to add tests for it.

Inspired by https://github.com/encode/starlette/issues/1560#issuecomment-1086855500

- [x] ~tests~ this is actually being tested... against none and 1000... maybe we should be more restrictive on the test...