### PR TITLE
Remove `asgiref` from minimal requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
-    "asgiref>=3.4.0",
     "click>=7.0",
     "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,
@@ -52,6 +51,7 @@ minimal_requirements = [
 
 
 extra_requirements = [
+    "asgiref>=3.4.0",
     "websockets>=10.0",
     "httptools>=0.4.0",
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -1,11 +1,15 @@
-from typing import List, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Union
 
 import httpx
 import pytest
-from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 from tests.response import Response
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+if TYPE_CHECKING:
+    from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 
 async def app(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -7,14 +9,8 @@ import typing
 from pathlib import Path
 from unittest.mock import MagicMock
 
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
-
 import pytest
 import yaml
-from asgiref.typing import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Scope
 from pytest_mock import MockerFixture
 
 from tests.utils import as_cwd
@@ -24,6 +20,19 @@ from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
+
+if sys.version_info < (3, 8):  # pragma: py-gte-38
+    from typing_extensions import Literal
+else:  # pragma: py-lt-38
+    from typing import Literal
+
+if typing.TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIApplication,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
 
 
 @pytest.fixture

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import inspect
 import json
@@ -8,7 +10,19 @@ import socket
 import ssl
 import sys
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+
+import click
 
 from uvicorn._logging import TRACE_LOG_LEVEL
 
@@ -17,8 +31,8 @@ if sys.version_info < (3, 8):  # pragma: py-gte-38
 else:  # pragma: py-lt-38
     from typing import Literal
 
-import click
-from asgiref.typing import ASGIApplication
+if TYPE_CHECKING:
+    from asgiref.typing import ASGIApplication
 
 try:
     import yaml

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import platform
@@ -6,7 +8,6 @@ import sys
 import typing
 
 import click
-from asgiref.typing import ASGIApplication
 
 import uvicorn
 from uvicorn.config import (
@@ -22,6 +23,9 @@ from uvicorn.config import (
 )
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
+
+if typing.TYPE_CHECKING:
+    from asgiref.typing import ASGIApplication
 
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))

--- a/uvicorn/middleware/asgi2.py
+++ b/uvicorn/middleware/asgi2.py
@@ -1,9 +1,14 @@
-from asgiref.typing import (
-    ASGI2Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    Scope,
-)
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI2Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
 
 
 class ASGI2Middleware:

--- a/uvicorn/middleware/debug.py
+++ b/uvicorn/middleware/debug.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
 import html
 import traceback
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    ASGISendEvent,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    WWWScope,
-)
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        ASGISendEvent,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        WWWScope,
+    )
 
 
 class HTMLResponse:

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -1,16 +1,19 @@
-import logging
-from typing import Any
+from __future__ import annotations
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGIReceiveEvent,
-    ASGISendCallable,
-    ASGISendEvent,
-    WWWScope,
-)
+import logging
+from typing import TYPE_CHECKING, Any
 
 from uvicorn._logging import TRACE_LOG_LEVEL
+
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGIReceiveEvent,
+        ASGISendCallable,
+        ASGISendEvent,
+        WWWScope,
+    )
 
 PLACEHOLDER_FORMAT = {
     "body": "<{length} bytes>",

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -8,16 +8,19 @@ the connecting client, rather that the connecting proxy.
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
-from typing import List, Optional, Tuple, Union, cast
+from __future__ import annotations
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    HTTPScope,
-    Scope,
-    WebSocketScope,
-)
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
+
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPScope,
+        Scope,
+        WebSocketScope,
+    )
 
 
 class ProxyHeadersMiddleware:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -50,7 +50,7 @@ class ProxyHeadersMiddleware:
         self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     ) -> None:
         if scope["type"] in ("http", "websocket"):
-            scope = cast(Union[HTTPScope, WebSocketScope], scope)
+            scope = cast(Union["HTTPScope", "WebSocketScope"], scope)
             client_addr: Optional[Tuple[str, int]] = scope.get("client")
             client_host = client_addr[0] if client_addr else None
 

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -1,22 +1,25 @@
+from __future__ import annotations
+
 import asyncio
 import concurrent.futures
 import io
 import sys
 from collections import deque
-from typing import Deque, Iterable, Optional, Tuple
-
-from asgiref.typing import (
-    ASGIReceiveCallable,
-    ASGIReceiveEvent,
-    ASGISendCallable,
-    ASGISendEvent,
-    HTTPRequestEvent,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    HTTPScope,
-)
+from typing import TYPE_CHECKING, Deque, Iterable, Optional, Tuple
 
 from uvicorn._types import Environ, ExcInfo, StartResponse, WSGIApp
+
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIReceiveCallable,
+        ASGIReceiveEvent,
+        ASGISendCallable,
+        ASGISendEvent,
+        HTTPRequestEvent,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        HTTPScope,
+    )
 
 
 def build_environ(

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,12 +1,16 @@
-import asyncio
+from __future__ import annotations
 
-from asgiref.typing import (
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    Scope,
-)
+import asyncio
+import typing
+
+if typing.TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        Scope,
+    )
 
 CLOSE_HEADER = (b"connection", b"close")
 


### PR DESCRIPTION
This PR removes `asgiref` from the minimal requirements.

Changes:
- Leverage `from __future__ import annotations` to get a small diff - besides the [_collateral benefits_](https://lukasz.langa.pl/61df599c-d9d8-4938-868b-36b67fdb4448/).
- Move `asgiref` from `minimal_requirements` to `extra_requirements`.