### PR TITLE
Only apply coverage on Ubuntu 3.8

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -36,4 +36,4 @@ jobs:
       - name: "Enforce coverage"
         run: "scripts/coverage"
         shell: bash
-        if: "${{ matrix.python-version == '3.8' and matrix.os == 'ubuntu-latest'}}"
+        if: "${{ matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'}}"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -36,3 +36,4 @@ jobs:
       - name: "Enforce coverage"
         run: "scripts/coverage"
         shell: bash
+        if: "${{ matrix.python-version == '3.8' and matrix.os == 'ubuntu-latest'}}"


### PR DESCRIPTION
As discussed on https://github.com/encode/uvicorn/issues/102, we agreed to only care about the coverage on Python 3.8.

This PR implements this idea.

The point here is that it's painful to care about the coverage on many systems/python versions.

Alternative idea:
- https://github.com/encode/uvicorn/pull/1478