### PR TITLE
Remove conditional on `RemoteProtocolError.event_hint`

### DIFF
--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -91,7 +91,7 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.write(self.conn.send(err.event_hint))
                 self.transport.close()
             else:
-                self.handle_no_connect(events.CloseConnection())
+                self.handle_no_connect(events.CloseConnection(code=1007))
         else:
             self.handle_events()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -87,13 +87,8 @@ class WSProtocol(asyncio.Protocol):
         try:
             self.conn.receive_data(data)
         except RemoteProtocolError as err:
-            if err.event_hint is not None:
-                self.transport.write(self.conn.send(err.event_hint))
-                self.transport.close()
-            else:
-                # Response with the "1002 Protocol Error" code.
-                # See https://www.iana.org/assignments/websocket/websocket.xhtml#close-code-number
-                self.handle_no_connect(events.CloseConnection(code=1002))
+            self.transport.write(self.conn.send(err.event_hint))
+            self.transport.close()
         else:
             self.handle_events()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -91,7 +91,9 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.write(self.conn.send(err.event_hint))
                 self.transport.close()
             else:
-                self.handle_no_connect(events.CloseConnection(code=1007))
+                # Response with the "1002 Protocol Error" code.
+                # See https://www.iana.org/assignments/websocket/websocket.xhtml#close-code-number
+                self.handle_no_connect(events.CloseConnection(code=1002))
         else:
             self.handle_events()
 


### PR DESCRIPTION
I'm not sure if this is the right `code`, but `events.CloseConnection` receives `code` as a mandatory field, so without it, you'll have an exception on missing parameters. 

List of codes: https://www.iana.org/assignments/websocket/websocket.xhtml
RFC: https://www.rfc-editor.org/rfc/rfc6455.html

I've noticed this issue while annotating `wsproto_impl`.

*EDIT*: Quite funny... `wsproto` doesn't raise a `RemoteProtocolError` without an `event_hint`. Check their source code: https://github.com/python-hyper/wsproto/.