### PR TITLE
Turn `raw_path` into bytes on both websockets implementations

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -220,7 +220,7 @@ async def test_path_and_raw_path(ws_protocol_cls, http_protocol_cls):
             path = self.scope.get("path")
             raw_path = self.scope.get("raw_path")
             assert path == "/one/two"
-            assert raw_path == "/one%2Ftwo"
+            assert raw_path == b"/one%2Ftwo"
             await self.send({"type": "websocket.accept"})
 
     async def open_connection(url):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -133,7 +133,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
             "client": self.client,
             "root_path": self.root_path,
             "path": unquote(path_portion),
-            "raw_path": path_portion,
+            "raw_path": path_portion.encode("ascii"),
             "query_string": query_string.encode("ascii"),
             "headers": asgi_headers,
             "subprotocols": subprotocols,

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -144,7 +144,7 @@ class WSProtocol(asyncio.Protocol):
             "client": self.client,
             "root_path": self.root_path,
             "path": unquote(raw_path),
-            "raw_path": raw_path,
+            "raw_path": raw_path.encode("ascii"),
             "query_string": query_string.encode("ascii"),
             "headers": headers,
             "subprotocols": event.subprotocols,


### PR DESCRIPTION
`raw_path` should be `bytes`, not `string`.

See: https://asgi.readthedocs.io/en/latest/specs/www.html#websocket-connection-scope