### PR TITLE
Refactor uvicorn logger setup

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -205,8 +205,7 @@ There are several ways to run uvicorn directly from your application.
 
 If you're looking for a programmatic equivalent of the `uvicorn` command line interface, use `uvicorn.run()`:
 
-```python
-# main.py
+```py title="main.py"
 import uvicorn
 
 async def app(scope, receive, send):
@@ -275,9 +274,7 @@ For more information, see the [deployment documentation](deployment.md).
 
 The `--factory` flag allows loading the application from a factory function, rather than an application instance directly. The factory will be called with no arguments and should return an ASGI application.
 
-**example.py**:
-
-```python
+```py title="example.py"
 def create_app():
     app = ...
     return app

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,1 @@
+# Logging

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,1 +1,40 @@
 # Logging
+
+Logging in Python is pretty complex, and there are many different ways to do it.
+This document is intended to provide an overview about the logger objects available in **Uvicorn**.
+
+### Loggers
+
+**Uvicorn** has many loggers available, each one with a different purpose.
+
+It contains an ancestor logger called `uvicorn`, and then multiple children loggers.
+
+#### Server Logger (`uvicorn.server`)
+
+This logger is used to log information about the core server functionality, such as startup and shutdown.
+
+#### WebSocket Logger (`uvicorn.websocket`)
+
+This logger is used to log server-side information about WebSocket protocol messages.
+
+#### HTTP Logger (`uvicorn.http`)
+
+This logger is used to log server-side information about HTTP protocol messages.
+
+#### Access Logger (`uvicorn.access`)
+
+This logger is used to log client-side information about each request/response cycle.
+
+#### ASGI Logger (`uvicorn.asgi`)
+
+This logger is used to log low-level server-side ASGI messages. Only available when `--log-level` is set to `trace`.
+
+### Configuration
+
+**Uvicorn** uses the standard Python `logging` module to handle logging.
+
+This section will be used to teach people how to configure uvicorn loggers.
+
+### Tutorials
+
+This section will be used to link tutorials.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,12 +24,18 @@ edit_uri: ""
 nav:
   - Introduction: "index.md"
   - Settings: "settings.md"
+  - Logging: "logging.md"
   - Deployment: "deployment.md"
   - Server Behavior: "server-behavior.md"
   - Contributing: "contributing.md"
 
 markdown_extensions:
   - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
   - codehilite:
       css_class: highlight
   - toc:

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -808,8 +808,8 @@ async def test_invalid_http_request(request_line, protocol_cls, caplog):
     app = Response("Hello, world", media_type="text/plain")
     request = INVALID_REQUEST_TEMPLATE % request_line
 
-    caplog.set_level(logging.INFO, logger="uvicorn.error")
-    logging.getLogger("uvicorn.error").propagate = True
+    caplog.set_level(logging.INFO, logger="uvicorn.http")
+    logging.getLogger("uvicorn.http").propagate = True
 
     protocol = get_connected_protocol(app, protocol_cls)
     protocol.data_received(request)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -254,7 +254,7 @@ def test_app_unimportable_other(caplog: pytest.LogCaptureFixture) -> None:
     error_messages = [
         record.message
         for record in caplog.records
-        if record.name == "uvicorn.error" and record.levelname == "ERROR"
+        if record.name == "uvicorn.server" and record.levelname == "ERROR"
     ]
     assert (
         'Error loading ASGI app. Attribute "app" not found in module "tests.test_config".'  # noqa: E501
@@ -485,8 +485,10 @@ def test_config_log_level(log_level: int) -> None:
     config = Config(app=asgi_app, log_level=log_level)
     config.load()
 
-    assert logging.getLogger("uvicorn.error").level == log_level
+    assert logging.getLogger("uvicorn.server").level == log_level
     assert logging.getLogger("uvicorn.access").level == log_level
+    assert logging.getLogger("uvicorn.http").level == log_level
+    assert logging.getLogger("uvicorn.websockets").level == log_level
     assert logging.getLogger("uvicorn.asgi").level == log_level
     assert config.log_level == log_level
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -155,7 +155,7 @@ def test_lifespan_with_failed_startup(mode, raise_exception, caplog):
     error_messages = [
         record.message
         for record in caplog.records
-        if record.name == "uvicorn.error" and record.levelname == "ERROR"
+        if record.name == "uvicorn.server" and record.levelname == "ERROR"
     ]
     assert "the lifespan event failed" in error_messages.pop(0)
     assert "Application startup failed. Exiting." in error_messages.pop(0)
@@ -240,7 +240,7 @@ def test_lifespan_with_failed_shutdown(mode, raise_exception, caplog):
     error_messages = [
         record.message
         for record in caplog.records
-        if record.name == "uvicorn.error" and record.levelname == "ERROR"
+        if record.name == "uvicorn.server" and record.levelname == "ERROR"
     ]
     assert "the lifespan event failed" in error_messages.pop(0)
     assert "Application shutdown failed. Exiting." in error_messages.pop(0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -90,7 +90,7 @@ def test_run_invalid_app_config_combination(caplog: pytest.LogCaptureFixture) ->
     with pytest.raises(SystemExit) as exit_exception:
         run(app, reload=True)
     assert exit_exception.value.code == 1
-    assert caplog.records[-1].name == "uvicorn.error"
+    assert caplog.records[-1].name == "uvicorn.server"
     assert caplog.records[-1].levelno == WARNING
     assert caplog.records[-1].message == (
         "You must pass the application as an import string to enable "

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -117,12 +117,14 @@ LOGGING_CONFIG: Dict[str, Any] = {
     },
     "loggers": {
         "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.server": {"level": "INFO"},
+        "uvicorn.websockets": {"level": "INFO"},
+        "uvicorn.http": {"level": "INFO"},
         "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
     },
 }
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 def create_ssl_context(
@@ -422,8 +424,10 @@ class Config:
                 log_level = LOG_LEVELS[self.log_level]
             else:
                 log_level = self.log_level
-            logging.getLogger("uvicorn.error").setLevel(log_level)
+            logging.getLogger("uvicorn.server").setLevel(log_level)
             logging.getLogger("uvicorn.access").setLevel(log_level)
+            logging.getLogger("uvicorn.http").setLevel(log_level)
+            logging.getLogger("uvicorn.websockets").setLevel(log_level)
             logging.getLogger("uvicorn.asgi").setLevel(log_level)
         if self.access_log is False:
             logging.getLogger("uvicorn.access").handlers = []

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -34,7 +34,7 @@ class LifespanOn:
             config.load()
 
         self.config = config
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.server")
         self.startup_event = asyncio.Event()
         self.shutdown_event = asyncio.Event()
         self.receive_queue: "Queue[LifespanReceiveMessage]" = asyncio.Queue()

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import sys
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 def asyncio_setup(use_subprocess: bool = False) -> None:  # pragma: no cover

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -41,7 +41,7 @@ INTERFACE_CHOICES = click.Choice(INTERFACES)
 
 STARTUP_FAILURE = 3
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> None:
@@ -552,7 +552,7 @@ def run(
     server = Server(config=config)
 
     if (config.reload or config.workers > 1) and not isinstance(app, str):
-        logger = logging.getLogger("uvicorn.error")
+        logger = logging.getLogger("uvicorn.server")
         logger.warning(
             "You must pass the application as an import string to enable 'reload' or "
             "'workers'."

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -76,7 +76,7 @@ class H11Protocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.http")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
         self.conn = h11.Connection(h11.SERVER, config.h11_max_incomplete_event_size)

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -74,7 +74,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.http")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
         self.parser = httptools.HttpRequestParser(self)

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -104,7 +104,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             ping_interval=self.config.ws_ping_interval,
             ping_timeout=self.config.ws_ping_timeout,
             extensions=extensions,
-            logger=logging.getLogger("uvicorn.error"),
+            logger=logging.getLogger("uvicorn.websockets"),
             extra_headers=[],
         )
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -26,7 +26,7 @@ class WSProtocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.websockets")
         self.root_path = config.root_path
 
         # Shared server state

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -30,7 +30,7 @@ HANDLED_SIGNALS = (
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class ServerState:

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -17,7 +17,7 @@ HANDLED_SIGNALS = (
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class BaseReload:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -17,7 +17,7 @@ HANDLED_SIGNALS = (
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class Multiprocess:

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, Iterator, List, Optional
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class StatReload(BaseReload):

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
 
     DirEntry = os.DirEntry[str]
 
-logger = logging.getLogger("uvicorn.error")
+
+logger = logging.getLogger("uvicorn.server")
 
 
 class CustomWatcher(DefaultWatcher):

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -22,7 +22,7 @@ class UvicornWorker(Worker):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(UvicornWorker, self).__init__(*args, **kwargs)
 
-        logger = logging.getLogger("uvicorn.error")
+        logger = logging.getLogger("uvicorn.server")
         logger.handlers = self.log.error_log.handlers
         logger.setLevel(self.log.error_log.level)
         logger.propagate = False


### PR DESCRIPTION
- Closes #562

## Changes

- Add `uvicorn.http` and `uvicorn.websockets` loggers.
- Replace `uvicorn.error` by `uvicorn.server` logger.

## Missing

- [ ] Docs update.
- [ ] Check  with `UvicornWorker`.