### PR TITLE
Replaced watchgod with watchfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.17.7 - 2022-05-18
+- Replaced watchgod with watchfiles
+
 ## 0.17.6 - 2022-03-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In this context, "Cython-based" means the following:
 Moreover, "optional extras" means that:
 
 - the websocket protocol will be handled by `websockets` (should you want to use `wsproto` you'd need to install it manually) if possible.
-- the `--reload` flag in development mode will use `watchgod`.
+- the `--reload` flag in development mode will use `watchfiles`.
 - windows users will have `colorama` installed for the colored logs.
 - `python-dotenv` will be installed should you want to use the `--env-file` option.
 - `PyYAML` will be installed to allow you to provide a `.yaml` file to `--log-config`, if desired.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,12 +43,12 @@ Options:
                                   for files. Includes '*.py' by default; these
                                   defaults can be overridden with `--reload-
                                   exclude`. This option has no effect unless
-                                  watchgod is installed.
+                                  watchfiles is installed.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files. Includes '.*, .py[cod], .sw.*,
                                   ~*' by default; these defaults can be
                                   overridden with `--reload-include`. This
-                                  option has no effect unless watchgod is
+                                  option has no effect unless watchfiles is
                                   installed.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ In this context, "Cython-based" means the following:
 Moreover, "optional extras" means that:
 
 - the websocket protocol will be handled by `websockets` (should you want to use `wsproto` you'd need to install it manually) if possible.
-- the `--reload` flag in development mode will use `watchgod`.
+- the `--reload` flag in development mode will use `watchfiles`.
 - windows users will have `colorama` installed for the colored logs.
 - `python-dotenv` will be installed should you want to use the `--env-file` option.
 - `PyYAML` will be installed to allow you to provide a `.yaml` file to `--log-config`, if desired.
@@ -110,12 +110,12 @@ Options:
                                   for files. Includes '*.py' by default; these
                                   defaults can be overridden with `--reload-
                                   exclude`. This option has no effect unless
-                                  watchgod is installed.
+                                  watchfiles is installed.
   --reload-exclude TEXT           Set glob patterns to exclude while watching
                                   for files. Includes '.*, .py[cod], .sw.*,
                                   ~*' by default; these defaults can be
                                   overridden with `--reload-include`. This
-                                  option has no effect unless watchgod is
+                                  option has no effect unless watchfiles is
                                   installed.
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -32,13 +32,13 @@ For example, in case you want to run the app on port `5000`, just set the enviro
 * `--reload` - Enable auto-reload. Uvicorn supports two versions of auto-reloading behavior enabled by this option. There are important differences between them.
 * `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default the whole current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.
 
-### Reloading without watchgod
+### Reloading without watchfiles
 
-If Uvicorn _cannot_ load [watchgod](https://pypi.org/project/watchgod/) at runtime, it will periodically look for changes in modification times to all `*.py` files (and only `*.py` files) inside of its monitored directories. See the `--reload-dir` option. Specifying other file extensions is not supported unless watchgod is installed. See the `--reload-include` and `--reload-exclude` options for details.
+If Uvicorn _cannot_ load [watchfiles](https://pypi.org/project/watchfiles/) at runtime, it will periodically look for changes in modification times to all `*.py` files (and only `*.py` files) inside of its monitored directories. See the `--reload-dir` option. Specifying other file extensions is not supported unless watchfiles is installed. See the `--reload-include` and `--reload-exclude` options for details.
 
-### Reloading with watchgod
+### Reloading with watchfiles
 
-For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchgod as a dependency. Alternatively, install [watchgod](https://pypi.org/project/watchgod/) where Unvicorn can see it. This will enable the following options (which are otherwise ignored).
+For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Unvicorn can see it. This will enable the following options (which are otherwise ignored).
 
 * `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in `--reload-exclude`.
 * `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These defaults can be overwritten by including them in `--reload-include`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ files =
     uvicorn/supervisors/__init__.py,
     uvicorn/middleware/debug.py,
     uvicorn/middleware/wsgi.py,
-    uvicorn/supervisors/watchgodreload.py,
+    uvicorn/supervisors/watchfilesreload.py,
     uvicorn/_logging.py,
     uvicorn/middleware/asgi2.py,
     uvicorn/server.py,
@@ -60,7 +60,7 @@ check_untyped_defs = True
 profile = black
 combine_as_imports = True
 known_first_party = uvicorn,tests
-known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,setuptools,urllib3,uvloop,watchgod,websockets,wsproto,yaml
+known_third_party = click,does_not_exist,gunicorn,h11,httptools,pytest,requests,setuptools,urllib3,uvloop,watchfiles,websockets,wsproto,yaml
 
 [tool:pytest]
 addopts = -rxXs

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ extra_requirements = [
     "httptools>=0.4.0",
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; " + env_marker_cpython,
     "colorama>=0.4;" + env_marker_win,
-    "watchgod>=0.6",
-    "python-dotenv>=0.13",
+    "watchfiles>=0.13",
+    "python-dotenv>=0.14",
     "PyYAML>=5.1",
 ]
 

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -9,7 +9,7 @@ from tests.utils import as_cwd
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
 from uvicorn.supervisors.statreload import StatReload
-from uvicorn.supervisors.watchgodreload import WatchGodReload
+from uvicorn.supervisors.watchfilesreload import WatchFilesReload
 
 
 class TestBaseReload:
@@ -39,7 +39,7 @@ class TestBaseReload:
         file.touch()
         return reloader.should_restart()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [StatReload, watchfilesReload])
     def test_reloader_should_initialize(self) -> None:
         """
         A basic sanity check.
@@ -52,7 +52,7 @@ class TestBaseReload:
             reloader = self._setup_reloader(config)
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [StatReload, watchfilesReload])
     def test_reload_when_python_file_is_changed(self) -> None:
         file = self.reload_path / "main.py"
 
@@ -64,7 +64,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [StatReload, watchfilesReload])
     def test_should_reload_when_python_file_in_subdir_is_changed(self) -> None:
         file = self.reload_path / "app" / "sub" / "sub.py"
 
@@ -76,7 +76,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [watchfilesReload])
     def test_should_not_reload_when_python_file_in_excluded_subdir_is_changed(
         self,
     ) -> None:
@@ -96,7 +96,7 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize(
-        "reloader_class, result", [(StatReload, False), (WatchGodReload, True)]
+        "reloader_class, result", [(StatReload, False), (watchfilesReload, True)]
     )
     def test_reload_when_pattern_matched_file_is_changed(self, result: bool) -> None:
         file = self.reload_path / "app" / "js" / "main.js"
@@ -111,7 +111,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [watchfilesReload])
     def test_should_not_reload_when_exclude_pattern_match_file_is_changed(self) -> None:
         python_file = self.reload_path / "app" / "src" / "main.py"
         css_file = self.reload_path / "app" / "css" / "main.css"
@@ -132,7 +132,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [StatReload, watchfilesReload])
     def test_should_not_reload_when_dot_file_is_changed(self) -> None:
         file = self.reload_path / ".dotted"
 
@@ -144,7 +144,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [StatReload, watchfilesReload])
     def test_should_reload_when_directories_have_same_prefix(self) -> None:
         app_dir = self.reload_path / "app"
         app_file = app_dir / "src" / "main.py"
@@ -164,7 +164,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [StatReload, watchfilesReload])
     def test_should_not_reload_when_only_subdirectory_is_watched(self) -> None:
         app_dir = self.reload_path / "app"
         app_dir_file = self.reload_path / "app" / "src" / "main.py"
@@ -183,7 +183,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [StatReload, WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [StatReload, watchfilesReload])
     def test_should_parse_dir_from_includes(self) -> None:
         app_dir = self.reload_path / "app"
         app_file = app_dir / "src" / "main.py"
@@ -203,7 +203,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [watchfilesReload])
     def test_override_defaults(self) -> None:
         dotted_file = self.reload_path / ".dotted"
         dotted_dir_file = self.reload_path / ".dotted_dir" / "file.txt"
@@ -225,7 +225,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [watchfilesReload])
     def test_should_start_one_watcher_for_dirs_inside_cwd(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -244,21 +244,21 @@ class TestBaseReload:
             assert self._reload_tester(reloader, app_file)
             assert (
                 caplog.records[-1].message
-                == f"WatchGodReload detected file change in '{[str(app_file)]}'."
+                == f"watchfilesReload detected file change in '{[str(app_file)]}'."
                 " Reloading..."
             )
             assert caplog.records[-1].levelno == WARNING
             assert self._reload_tester(reloader, app_first_file)
-            assert "WatchGodReload detected file change" in caplog.records[-1].message
+            assert "watchfilesReload detected file change" in caplog.records[-1].message
             assert (
-                caplog.records[-1].message == "WatchGodReload detected file change in "
+                caplog.records[-1].message == "watchfilesReload detected file change in "
                 f"'{[str(app_first_file)]}'. Reloading..."
             )
             assert caplog.records[-1].levelno == WARNING
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [watchfilesReload])
     def test_should_start_separate_watchers_for_dirs_outside_cwd(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -283,13 +283,13 @@ class TestBaseReload:
             assert self._reload_tester(reloader, app_file)
             assert caplog.records[-1].levelno == WARNING
             assert (
-                caplog.records[-1].message == "WatchGodReload detected file change in "
+                caplog.records[-1].message == "watchfilesReload detected file change in "
                 f"'{[str(app_file)]}'. Reloading..."
             )
             assert self._reload_tester(reloader, app_first_file)
             assert caplog.records[-1].levelno == WARNING
             assert (
-                caplog.records[-1].message == "WatchGodReload detected file change in "
+                caplog.records[-1].message == "watchfilesReload detected file change in "
                 f"'{[str(app_first_file)]}'. Reloading..."
             )
 
@@ -321,7 +321,7 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [watchfilesReload])
     def test_should_detect_new_reload_dirs(
         self, caplog: pytest.LogCaptureFixture, tmp_path: Path
     ) -> None:
@@ -343,13 +343,13 @@ class TestBaseReload:
             assert self._reload_tester(reloader, app_first_file)
             assert caplog.records[-2].levelno == INFO
             assert (
-                caplog.records[-2].message == "WatchGodReload detected a new reload "
+                caplog.records[-2].message == "watchfilesReload detected a new reload "
                 f"dir '{app_first_dir.name}' in '{tmp_path}'; Adding to watch list."
             )
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchGodReload])
+    @pytest.mark.parametrize("reloader_class", [watchfilesReload])
     def test_should_detect_new_exclude_dirs(
         self, caplog: pytest.LogCaptureFixture, tmp_path: Path
     ) -> None:
@@ -373,7 +373,7 @@ class TestBaseReload:
             assert not self._reload_tester(reloader, app_first_file)
             assert caplog.records[-1].levelno == DEBUG
             assert (
-                caplog.records[-1].message == "WatchGodReload detected a new excluded "
+                caplog.records[-1].message == "watchfilesReload detected a new excluded "
                 f"dir '{app_first_dir.name}' in '{tmp_path}'; Adding to exclude list."
             )
 

--- a/uvicorn/supervisors/__init__.py
+++ b/uvicorn/supervisors/__init__.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     ChangeReload: Type[BaseReload]
 else:
     try:
-        from uvicorn.supervisors.watchgodreload import WatchGodReload as ChangeReload
+        from uvicorn.supervisors.watchfilesreload import WatchFilesReload as ChangeReload
     except ImportError:  # pragma: no cover
         from uvicorn.supervisors.statreload import StatReload as ChangeReload
 

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -22,7 +22,7 @@ class StatReload(BaseReload):
 
         if config.reload_excludes or config.reload_includes:
             logger.warning(
-                "--reload-include and --reload-exclude have no effect unless watchgod "
+                "--reload-include and --reload-exclude have no effect unless watchfiles "
                 "is installed."
             )
 

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -122,7 +122,7 @@ class CustomWatcher(DefaultWatcher):
         return False
 
 
-class WatchGodReload(BaseReload):
+class WatchFilesReload(BaseReload):
     def __init__(
         self,
         config: Config,


### PR DESCRIPTION
As it's [deprecated](https://pypi.org/project/watchgod/).

> The package under the name watchgod will not be further developed and will only receive critical security fixes.