### PR TITLE
Server lifecycle

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
@@ -8,14 +7,12 @@ from uvicorn import Config, Server
 
 @asynccontextmanager
 async def run_server(config: Config, sockets=None):
-    server = Server(config=config)
-    cancel_handle = asyncio.ensure_future(server.serve(sockets=sockets))
-    await asyncio.sleep(0.1)
+    server = Server(config=config, sockets=sockets)
+    await server.start_serving()
     try:
         yield server
     finally:
         await server.shutdown()
-        cancel_handle.cancel()
 
 
 @contextmanager

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -120,10 +120,10 @@ class Server:
         if self._main_task is not None:
             raise RuntimeError("cannot call serve on running server")
 
-        if sockets is not None and self._sockets is not None:
-            raise RuntimeError("cannot override already provided sockets list")
-
-        self._sockets = sockets
+        if sockets is not None:
+            if self._sockets is not None:
+                raise RuntimeError("cannot override already provided sockets list")
+            self._sockets = sockets
 
         self.install_signal_handlers()
         try:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -46,7 +46,9 @@ class ServerState:
 
 
 class Server:
-    def __init__(self, config: Config) -> None:
+    def __init__(
+        self, config: Config, *, sockets: Optional[List[socket.socket]] = None
+    ) -> None:
         self.config = config
         self.server_state = ServerState()
 
@@ -55,7 +57,7 @@ class Server:
         self.force_exit = False
         self.last_notified = 0.0
 
-        self._sockets: Optional[List[socket.socket]] = None
+        self._sockets: Optional[List[socket.socket]] = sockets
 
         self._main_task: Optional[asyncio.Task] = None
 


### PR DESCRIPTION
Adds `close`, `wait_closed` and `start_serving` methods that match the semantics of `asyncio.Server`.
Adds `sockets` argument constructor in order to enable new methods to be used with existing bindings.

This makes it easier to use uvicorn as part of a larger application, by making it possible to block until a service has started, and easier to shut down cleanly.



For background, we use `uvicorn` extensively and are very happy with its behaviour in production, but have had a lot of difficulty with server lifecycle when trying to use it as part of our test suite.  In particular:
 1. It's not currently possible to block until the service has started without polling.
 2. Shutting a background server down and blocking until completion requires keeping a reference to both the server and an `asyncio.Task` wrapping `serve`.
 3. Waiting for the main loop to poll while shutting down currently dominates our test run time.
 4. Signal handler installation interferes with signal handlers from other instances, and with test shutdown.

It also took a fair bit of digging in the source code to figure out that calling `Server.shutdown` from outside does not do what one might expect.

I'd like to propose a few changes, the first of which I have attempted in this PR, which I think will resolve the issues we've encountered:

 1. Add `close`, `wait_closed` and `start_serving` methods that match the semantics of `asyncio.Server` (resolves issues 1 and 2).
 2. Use an `asyncio.Event` to make it so that `close` can pre-empt the polling loops (resolves issue 3).
 3. Add a `register_event_handlers` keyword argument to `serve` which can be used to disable registering of event handlers (resolves issue 4).
 4. Make any methods which would result in breakage if called from outside the class private.

If you are happy with this approach then I would be glad to work on 2, 3 and 4 as follow ups.

Resolves:
  - https://github.com/encode/uvicorn/issues/1301, with behaviour matching what @tomchristie suggests.
  - https://github.com/encode/uvicorn/issues/1375, although with a different API.
  - https://github.com/encode/uvicorn/issues/742