### PR TITLE
Revert log exception traceback in case of invalid HTTP request

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -162,9 +162,9 @@ class H11Protocol(asyncio.Protocol):
         while True:
             try:
                 event = self.conn.next_event()
-            except h11.RemoteProtocolError as exc:
+            except h11.RemoteProtocolError:
                 msg = "Invalid HTTP request received."
-                self.logger.warning(msg, exc_info=exc)
+                self.logger.warning(msg)
                 self.send_400_response(msg)
                 return
             event_type = type(event)

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -149,9 +149,9 @@ class HttpToolsProtocol(asyncio.Protocol):
 
         try:
             self.parser.feed_data(data)
-        except httptools.HttpParserError as exc:
+        except httptools.HttpParserError:
             msg = "Invalid HTTP request received."
-            self.logger.warning(msg, exc_info=exc)
+            self.logger.warning(msg)
             self.send_400_response(msg)
             return
         except httptools.HttpParserUpgrade:


### PR DESCRIPTION
Fixes https://github.com/encode/uvicorn/issues/1296
Since https://github.com/encode/uvicorn/issues/344#issuecomment-1142391856 seems to be fixed (we should close it) there's no reason anymore for having those