### PR TITLE
make test_http.get_connected_protocol a plain function and other post #1155 cleanups

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -131,9 +131,6 @@ class MockLoop:
         self._tasks = []
         self._later = []
 
-    def is_running(self):
-        return True  # pragma: no cover
-
     def create_task(self, coroutine):
         self._tasks.insert(0, coroutine)
         return MockTask()


### PR DESCRIPTION
follow up cleanup to https://github.com/encode/uvicorn/pull/1155

* make test_http.get_connected_protocol a plain function
  - I delayed this refactor because it would have been a bunch of whitespace change noise on #1155 
* remove MockLoop.is_running method
  - I just forgot to remove this method in #1155  