### PR TITLE
Remove `asgiref` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 -e .[standard]
 
+# Type annotation
+asgiref==3.5.2
+
 # Explicit optionals
 wsproto==1.1.0
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ env_marker_win = "sys_platform == 'win32'"
 env_marker_below_38 = "python_version < '3.8'"
 
 minimal_requirements = [
-    "asgiref>=3.4.0",
     "click>=7.0",
     "h11>=0.8",
     "typing-extensions;" + env_marker_below_38,

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -1,13 +1,15 @@
 import io
 import sys
-from typing import AsyncGenerator, List
+from typing import TYPE_CHECKING, AsyncGenerator, List
 
 import httpx
 import pytest
-from asgiref.typing import HTTPRequestEvent, HTTPScope
 
 from uvicorn._types import Environ, StartResponse
 from uvicorn.middleware.wsgi import WSGIMiddleware, build_environ
+
+if TYPE_CHECKING:
+    from asgiref.typing import HTTPRequestEvent, HTTPScope
 
 
 def hello_world(environ: Environ, start_response: StartResponse) -> List[bytes]:
@@ -114,7 +116,7 @@ async def test_wsgi_exc_info() -> None:
 
 
 def test_build_environ_encoding() -> None:
-    scope: HTTPScope = {
+    scope: "HTTPScope" = {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "scheme": "http",
         "raw_path": b"/\xe6\x96\x87",
@@ -129,7 +131,7 @@ def test_build_environ_encoding() -> None:
         "headers": [(b"key", b"value1"), (b"key", b"value2")],
         "extensions": {},
     }
-    message: HTTPRequestEvent = {
+    message: "HTTPRequestEvent" = {
         "type": "http.request",
         "body": b"",
         "more_body": False,

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,14 +1,17 @@
 import signal
 import socket
-from typing import List, Optional
-
-from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
+from typing import TYPE_CHECKING, List, Optional
 
 from uvicorn import Config
 from uvicorn.supervisors import Multiprocess
 
+if TYPE_CHECKING:
+    from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
-def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+
+def app(
+    scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+) -> None:
     pass  # pragma: no cover
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,14 +7,8 @@ import typing
 from pathlib import Path
 from unittest.mock import MagicMock
 
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
-
 import pytest
 import yaml
-from asgiref.typing import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Scope
 from pytest_mock import MockerFixture
 
 from tests.utils import as_cwd
@@ -24,6 +18,19 @@ from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
+
+if sys.version_info < (3, 8):  # pragma: py-gte-38
+    from typing_extensions import Literal
+else:  # pragma: py-lt-38
+    from typing import Literal
+
+if typing.TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIApplication,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
 
 
 @pytest.fixture
@@ -42,7 +49,7 @@ def yaml_logging_config(logging_config: dict) -> str:
 
 
 async def asgi_app(
-    scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+    scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
 ) -> None:
     pass  # pragma: nocover
 
@@ -64,7 +71,7 @@ def test_debug_app() -> None:
     [(asgi_app, False), ("tests.test_config:asgi_app", True)],
 )
 def test_config_should_reload_is_set(
-    app: ASGIApplication, expected_should_reload: bool
+    app: "ASGIApplication", expected_should_reload: bool
 ) -> None:
     config_debug = Config(app=app, debug=True)
     assert config_debug.debug is True
@@ -269,7 +276,7 @@ def test_app_unimportable_other(caplog: pytest.LogCaptureFixture) -> None:
 
 
 def test_app_factory(caplog: pytest.LogCaptureFixture) -> None:
-    def create_app() -> ASGIApplication:
+    def create_app() -> "ASGIApplication":
         return asgi_app
 
     config = Config(app=create_app, factory=True, proxy_headers=False)
@@ -330,9 +337,9 @@ def test_ssl_config_combined(tls_certificate_key_and_chain_path: str) -> None:
     assert config.is_ssl is True
 
 
-def asgi2_app(scope: Scope) -> typing.Callable:
+def asgi2_app(scope: "Scope") -> typing.Callable:
     async def asgi(
-        receive: ASGIReceiveCallable, send: ASGISendCallable
+        receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:  # pragma: nocover
         pass
 
@@ -343,7 +350,7 @@ def asgi2_app(scope: Scope) -> typing.Callable:
     "app, expected_interface", [(asgi_app, "3.0"), (asgi2_app, "2.0")]
 )
 def test_asgi_version(
-    app: ASGIApplication, expected_interface: Literal["2.0", "3.0"]
+    app: "ASGIApplication", expected_interface: Literal["2.0", "3.0"]
 ) -> None:
     config = Config(app=app)
     config.load()

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,13 +1,15 @@
 import socket
 import sys
-from typing import List
+from typing import TYPE_CHECKING, List
 from unittest.mock import patch
 
 import pytest
-from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 from uvicorn._subprocess import SpawnProcess, get_subprocess, subprocess_started
 from uvicorn.config import Config
+
+if TYPE_CHECKING:
+    from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 
 def server_run(sockets: List[socket.socket]):  # pragma: no cover
@@ -15,7 +17,7 @@ def server_run(sockets: List[socket.socket]):  # pragma: no cover
 
 
 async def app(
-    scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+    scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
 ) -> None:  # pragma: no cover
     ...
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -8,7 +8,17 @@ import socket
 import ssl
 import sys
 from pathlib import Path
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 from uvicorn._logging import TRACE_LOG_LEVEL
 
@@ -18,7 +28,6 @@ else:  # pragma: py-lt-38
     from typing import Literal
 
 import click
-from asgiref.typing import ASGIApplication
 
 try:
     import yaml
@@ -34,6 +43,9 @@ from uvicorn.middleware.debug import DebugMiddleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
+
+if TYPE_CHECKING:
+    from asgiref.typing import ASGIApplication
 
 HTTPProtocolType = Literal["auto", "h11", "httptools"]
 WSProtocolType = Literal["auto", "none", "websockets", "wsproto"]
@@ -194,7 +206,7 @@ def _normalize_dirs(dirs: Union[List[str], str, None]) -> List[str]:
 class Config:
     def __init__(
         self,
-        app: Union[ASGIApplication, Callable, str],
+        app: Union["ASGIApplication", Callable, str],
         host: str = "127.0.0.1",
         port: int = 8000,
         uds: Optional[str] = None,

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -1,27 +1,29 @@
 import asyncio
 import logging
 from asyncio import Queue
-from typing import Union
-
-from asgiref.typing import (
-    LifespanScope,
-    LifespanShutdownCompleteEvent,
-    LifespanShutdownEvent,
-    LifespanShutdownFailedEvent,
-    LifespanStartupCompleteEvent,
-    LifespanStartupEvent,
-    LifespanStartupFailedEvent,
-)
+from typing import TYPE_CHECKING, Union
 
 from uvicorn import Config
 
-LifespanReceiveMessage = Union[LifespanStartupEvent, LifespanShutdownEvent]
-LifespanSendMessage = Union[
-    LifespanStartupFailedEvent,
-    LifespanShutdownFailedEvent,
-    LifespanStartupCompleteEvent,
-    LifespanShutdownCompleteEvent,
-]
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        LifespanScope,
+        LifespanShutdownCompleteEvent,
+        LifespanShutdownEvent,
+        LifespanShutdownFailedEvent,
+        LifespanStartupCompleteEvent,
+        LifespanStartupEvent,
+        LifespanStartupFailedEvent,
+    )
+
+    LifespanReceiveMessage = Union[LifespanStartupEvent, LifespanShutdownEvent]
+    LifespanSendMessage = Union[
+        LifespanStartupFailedEvent,
+        LifespanShutdownFailedEvent,
+        LifespanStartupCompleteEvent,
+        LifespanShutdownCompleteEvent,
+    ]
+
 
 STATE_TRANSITION_ERROR = "Got invalid state transition on lifespan protocol."
 
@@ -97,7 +99,7 @@ class LifespanOn:
             self.startup_event.set()
             self.shutdown_event.set()
 
-    async def send(self, message: LifespanSendMessage) -> None:
+    async def send(self, message: "LifespanSendMessage") -> None:
         assert message["type"] in (
             "lifespan.startup.complete",
             "lifespan.startup.failed",
@@ -131,5 +133,5 @@ class LifespanOn:
             if message.get("message"):
                 self.logger.error(message["message"])
 
-    async def receive(self) -> LifespanReceiveMessage:
+    async def receive(self) -> "LifespanReceiveMessage":
         return await self.receive_queue.get()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -6,7 +6,6 @@ import sys
 import typing
 
 import click
-from asgiref.typing import ASGIApplication
 
 import uvicorn
 from uvicorn.config import (
@@ -27,6 +26,9 @@ from uvicorn.config import (
 )
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
+
+if typing.TYPE_CHECKING:
+    from asgiref.typing import ASGIApplication
 
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))
@@ -443,7 +445,7 @@ def main(
 
 
 def run(
-    app: typing.Union[ASGIApplication, str],
+    app: typing.Union["ASGIApplication", str],
     *,
     host: str = "127.0.0.1",
     port: int = 8000,

--- a/uvicorn/middleware/asgi2.py
+++ b/uvicorn/middleware/asgi2.py
@@ -1,17 +1,20 @@
-from asgiref.typing import (
-    ASGI2Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    Scope,
-)
+import typing
+
+if typing.TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI2Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
 
 
 class ASGI2Middleware:
-    def __init__(self, app: ASGI2Application):
+    def __init__(self, app: "ASGI2Application"):
         self.app = app
 
     async def __call__(
-        self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
         instance = self.app(scope)
         await instance(receive, send)

--- a/uvicorn/middleware/debug.py
+++ b/uvicorn/middleware/debug.py
@@ -20,7 +20,10 @@ class HTMLResponse:
         self.status_code = status_code
 
     async def __call__(
-        self, scope: "WWWScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+        self,
+        scope: "WWWScope",
+        receive: "ASGIReceiveCallable",
+        send: "ASGISendCallable",
     ) -> None:
         response_start: "HTTPResponseStartEvent" = {
             "type": "http.response.start",
@@ -43,7 +46,10 @@ class PlainTextResponse:
         self.status_code = status_code
 
     async def __call__(
-        self, scope: "WWWScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+        self,
+        scope: "WWWScope",
+        receive: "ASGIReceiveCallable",
+        send: "ASGISendCallable",
     ) -> None:
         response_start: "HTTPResponseStartEvent" = {
             "type": "http.response.start",
@@ -76,7 +82,10 @@ class DebugMiddleware:
         self.app = app
 
     async def __call__(
-        self, scope: "WWWScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+        self,
+        scope: "WWWScope",
+        receive: "ASGIReceiveCallable",
+        send: "ASGISendCallable",
     ) -> None:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)

--- a/uvicorn/middleware/debug.py
+++ b/uvicorn/middleware/debug.py
@@ -1,16 +1,17 @@
 import html
 import traceback
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    ASGISendEvent,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    WWWScope,
-)
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        ASGISendEvent,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        WWWScope,
+    )
 
 
 class HTMLResponse:
@@ -19,16 +20,16 @@ class HTMLResponse:
         self.status_code = status_code
 
     async def __call__(
-        self, scope: WWWScope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self, scope: "WWWScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
-        response_start: HTTPResponseStartEvent = {
+        response_start: "HTTPResponseStartEvent" = {
             "type": "http.response.start",
             "status": self.status_code,
             "headers": [(b"content-type", b"text/html; charset=utf-8")],
         }
         await send(response_start)
 
-        response_body: HTTPResponseBodyEvent = {
+        response_body: "HTTPResponseBodyEvent" = {
             "type": "http.response.body",
             "body": self.content.encode("utf-8"),
             "more_body": False,
@@ -42,16 +43,16 @@ class PlainTextResponse:
         self.status_code = status_code
 
     async def __call__(
-        self, scope: WWWScope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self, scope: "WWWScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
-        response_start: HTTPResponseStartEvent = {
+        response_start: "HTTPResponseStartEvent" = {
             "type": "http.response.start",
             "status": self.status_code,
             "headers": [(b"content-type", b"text/plain; charset=utf-8")],
         }
         await send(response_start)
 
-        response_body: HTTPResponseBodyEvent = {
+        response_body: "HTTPResponseBodyEvent" = {
             "type": "http.response.body",
             "body": self.content.encode("utf-8"),
             "more_body": False,
@@ -59,7 +60,7 @@ class PlainTextResponse:
         await send(response_body)
 
 
-def get_accept_header(scope: WWWScope) -> str:
+def get_accept_header(scope: "WWWScope") -> str:
     accept = "*/*"
 
     for key, value in scope.get("headers", []):
@@ -71,18 +72,18 @@ def get_accept_header(scope: WWWScope) -> str:
 
 
 class DebugMiddleware:
-    def __init__(self, app: ASGI3Application):
+    def __init__(self, app: "ASGI3Application"):
         self.app = app
 
     async def __call__(
-        self, scope: WWWScope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self, scope: "WWWScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
 
         response_started = False
 
-        async def inner_send(message: ASGISendEvent) -> None:
+        async def inner_send(message: "ASGISendEvent") -> None:
             nonlocal response_started, send
 
             if message["type"] == "http.response.start":

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -58,7 +58,7 @@ class MessageLoggerMiddleware:
         client = scope.get("client")
         prefix = "%s:%d - ASGI" % (client[0], client[1]) if client else "ASGI"
 
-        async def inner_receive() -> ASGIReceiveEvent:
+        async def inner_receive() -> "ASGIReceiveEvent":
             message = await receive()
             logged_message = message_with_placeholders(message)
             log_text = "%s [%d] Receive %s"

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -1,14 +1,15 @@
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGIReceiveEvent,
-    ASGISendCallable,
-    ASGISendEvent,
-    WWWScope,
-)
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGIReceiveEvent,
+        ASGISendCallable,
+        ASGISendEvent,
+        WWWScope,
+    )
 
 from uvicorn._logging import TRACE_LOG_LEVEL
 
@@ -35,7 +36,7 @@ def message_with_placeholders(message: Any) -> Any:
 
 
 class MessageLoggerMiddleware:
-    def __init__(self, app: ASGI3Application):
+    def __init__(self, app: "ASGI3Application"):
         self.task_counter = 0
         self.app = app
         self.logger = logging.getLogger("uvicorn.asgi")
@@ -46,7 +47,10 @@ class MessageLoggerMiddleware:
         self.logger.trace = trace  # type: ignore
 
     async def __call__(
-        self, scope: WWWScope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self,
+        scope: "WWWScope",
+        receive: "ASGIReceiveCallable",
+        send: "ASGISendCallable",
     ) -> None:
         self.task_counter += 1
 
@@ -63,7 +67,7 @@ class MessageLoggerMiddleware:
             )
             return message
 
-        async def inner_send(message: ASGISendEvent) -> None:
+        async def inner_send(message: "ASGISendEvent") -> None:
             logged_message = message_with_placeholders(message)
             log_text = "%s [%d] Send %s"
             self.logger.trace(  # type: ignore

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -8,21 +8,24 @@ the connecting client, rather that the connecting proxy.
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
-from typing import List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
 
-from asgiref.typing import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    HTTPScope,
-    Scope,
-    WebSocketScope,
-)
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPScope,
+        Scope,
+        WebSocketScope,
+    )
 
 
 class ProxyHeadersMiddleware:
     def __init__(
-        self, app: ASGI3Application, trusted_hosts: Union[List[str], str] = "127.0.0.1"
+        self,
+        app: "ASGI3Application",
+        trusted_hosts: Union[List[str], str] = "127.0.0.1",
     ) -> None:
         self.app = app
         if isinstance(trusted_hosts, str):
@@ -44,7 +47,7 @@ class ProxyHeadersMiddleware:
         return None
 
     async def __call__(
-        self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
         if scope["type"] in ("http", "websocket"):
             scope = cast(Union[HTTPScope, WebSocketScope], scope)

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -50,7 +50,7 @@ class ProxyHeadersMiddleware:
         self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
         if scope["type"] in ("http", "websocket"):
-            scope = cast(Union[HTTPScope, WebSocketScope], scope)
+            scope = cast(Union["HTTPScope", "WebSocketScope"], scope)
             client_addr: Optional[Tuple[str, int]] = scope.get("client")
             client_host = client_addr[0] if client_addr else None
 

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -79,7 +79,10 @@ class WSGIMiddleware:
         self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
 
     async def __call__(
-        self, scope: HTTPScope, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self,
+        scope: "HTTPScope",
+        receive: "ASGIReceiveCallable",
+        send: "ASGISendCallable",
     ) -> None:
         assert scope["type"] == "http"
         instance = WSGIResponder(self.app, self.executor, scope)

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -3,24 +3,25 @@ import concurrent.futures
 import io
 import sys
 from collections import deque
-from typing import Deque, Iterable, Optional, Tuple
+from typing import TYPE_CHECKING, Deque, Iterable, Optional, Tuple
 
-from asgiref.typing import (
-    ASGIReceiveCallable,
-    ASGIReceiveEvent,
-    ASGISendCallable,
-    ASGISendEvent,
-    HTTPRequestEvent,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    HTTPScope,
-)
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIReceiveCallable,
+        ASGIReceiveEvent,
+        ASGISendCallable,
+        ASGISendEvent,
+        HTTPRequestEvent,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        HTTPScope,
+    )
 
 from uvicorn._types import Environ, ExcInfo, StartResponse, WSGIApp
 
 
 def build_environ(
-    scope: HTTPScope, message: ASGIReceiveEvent, body: io.BytesIO
+    scope: "HTTPScope", message: "ASGIReceiveEvent", body: io.BytesIO
 ) -> Environ:
     """
     Builds a scope and request message into a WSGI environ object.
@@ -90,7 +91,7 @@ class WSGIResponder:
         self,
         app: WSGIApp,
         executor: concurrent.futures.ThreadPoolExecutor,
-        scope: HTTPScope,
+        scope: "HTTPScope",
     ):
         self.app = app
         self.executor = executor
@@ -98,13 +99,13 @@ class WSGIResponder:
         self.status = None
         self.response_headers = None
         self.send_event = asyncio.Event()
-        self.send_queue: Deque[Optional[ASGISendEvent]] = deque()
+        self.send_queue: Deque[Optional["ASGISendEvent"]] = deque()
         self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
         self.response_started = False
         self.exc_info: Optional[ExcInfo] = None
 
     async def __call__(
-        self, receive: ASGIReceiveCallable, send: ASGISendCallable
+        self, receive: "ASGIReceiveCallable", send: "ASGISendCallable"
     ) -> None:
         message: HTTPRequestEvent = await receive()  # type: ignore[assignment]
         body = io.BytesIO(message.get("body", b""))
@@ -112,7 +113,7 @@ class WSGIResponder:
         if more_body:
             body.seek(0, io.SEEK_END)
             while more_body:
-                body_message: HTTPRequestEvent = (
+                body_message: "HTTPRequestEvent" = (
                     await receive()  # type: ignore[assignment]
                 )
                 body.write(body_message.get("body", b""))
@@ -133,7 +134,7 @@ class WSGIResponder:
         if self.exc_info is not None:
             raise self.exc_info[0].with_traceback(self.exc_info[1], self.exc_info[2])
 
-    async def sender(self, send: ASGISendCallable) -> None:
+    async def sender(self, send: "ASGISendCallable") -> None:
         while True:
             if self.send_queue:
                 message = self.send_queue.popleft()

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,12 +1,14 @@
 import asyncio
+import typing
 
-from asgiref.typing import (
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    HTTPResponseBodyEvent,
-    HTTPResponseStartEvent,
-    Scope,
-)
+if typing.TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        Scope,
+    )
 
 CLOSE_HEADER = (b"connection", b"close")
 
@@ -46,9 +48,9 @@ class FlowControl:
 
 
 async def service_unavailable(
-    scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
+    scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
 ) -> None:
-    response_start: HTTPResponseStartEvent = {
+    response_start: "HTTPResponseStartEvent" = {
         "type": "http.response.start",
         "status": 503,
         "headers": [
@@ -58,7 +60,7 @@ async def service_unavailable(
     }
     await send(response_start)
 
-    response_body: HTTPResponseBodyEvent = {
+    response_body: "HTTPResponseBodyEvent" = {
         "type": "http.response.body",
         "body": b"Service Unavailable",
         "more_body": False,

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -493,7 +493,7 @@ class RequestResponseCycle:
             if message_type != "http.response.body":
                 msg = "Expected ASGI message 'http.response.body', but got '%s'."
                 raise RuntimeError(msg % message_type)
-            message = cast(HTTPResponseBodyEvent, message)
+            message = cast("HTTPResponseBodyEvent", message)
 
             body = message.get("body", b"")
             more_body = message.get("more_body", False)

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,8 +1,9 @@
 import asyncio
 import urllib.parse
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
-from asgiref.typing import WWWScope
+if TYPE_CHECKING:
+    from asgiref.typing import WWWScope
 
 
 def get_remote_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:
@@ -38,14 +39,14 @@ def is_ssl(transport: asyncio.Transport) -> bool:
     return bool(transport.get_extra_info("sslcontext"))
 
 
-def get_client_addr(scope: WWWScope) -> str:
+def get_client_addr(scope: "WWWScope") -> str:
     client = scope.get("client")
     if not client:
         return ""
     return "%s:%d" % client
 
 
-def get_path_with_query_string(scope: WWWScope) -> str:
+def get_path_with_query_string(scope: "WWWScope") -> str:
     path_with_query_string = urllib.parse.quote(scope["path"])
     if scope["query_string"]:
         path_with_query_string = "{}?{}".format(


### PR DESCRIPTION
- Closes #1305

This PR is a followup to the discussion on https://github.com/encode/uvicorn/discussions/1527.

`__future__.annotations` is in a position that we don't know if it will be removed, so I didn't add it here. That caused the diff to be huge tho...

This PR removes `asgiref` as dependency, and adds it to the `requirements.txt`.