### PR TITLE
Use `DEFAULT_MAX_INCOMPLETE_EVENT_SIZE` as default to `h11_max_incomplete_event_size` on the CLI

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -346,7 +346,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--h11-max-incomplete-event-size",
     "h11_max_incomplete_event_size",
     type=int,
-    default=None,
+    default=DEFAULT_MAX_INCOMPLETE_EVENT_SIZE,
     help="For h11, the maximum number of bytes to buffer of an incomplete event.",
 )
 @click.option(


### PR DESCRIPTION
- Closes #1533

Either this or verifying if is `None` before `h11.Connection`. @euri10 