### PR TITLE
Fix type hints for `log_config`

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Awaitable,
     Callable,
     Dict,
@@ -91,7 +92,7 @@ INTERFACES: List[InterfaceType] = ["auto", "asgi3", "asgi2", "wsgi"]
 SSL_PROTOCOL_VERSION: int = ssl.PROTOCOL_TLS_SERVER
 
 
-LOGGING_CONFIG: dict = {
+LOGGING_CONFIG: Dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
@@ -222,7 +223,7 @@ class Config:
         ws_per_message_deflate: Optional[bool] = True,
         lifespan: LifespanType = "auto",
         env_file: Optional[Union[str, os.PathLike]] = None,
-        log_config: Optional[Union[dict, str]] = LOGGING_CONFIG,
+        log_config: Optional[Union[Dict[str, Any], str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
         use_colors: Optional[bool] = None,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -478,7 +478,7 @@ def run(
     reload_delay: float = 0.25,
     workers: typing.Optional[int] = None,
     env_file: typing.Optional[str] = None,
-    log_config: typing.Optional[typing.Union[dict, str]] = None,
+    log_config: typing.Optional[typing.Union[typing.Dict[str, typing.Any], str]] = None,
     log_level: typing.Optional[str] = None,
     access_log: bool = True,
     proxy_headers: bool = True,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -478,7 +478,9 @@ def run(
     reload_delay: float = 0.25,
     workers: typing.Optional[int] = None,
     env_file: typing.Optional[str] = None,
-    log_config: typing.Optional[typing.Union[typing.Dict[str, typing.Any], str]] = LOGGING_CONFIG,
+    log_config: typing.Optional[
+        typing.Union[typing.Dict[str, typing.Any], str]
+    ] = LOGGING_CONFIG,
     log_level: typing.Optional[str] = None,
     access_log: bool = True,
     proxy_headers: bool = True,


### PR DESCRIPTION
This is a fix for the issue reported here: https://github.com/encode/uvicorn/discussions/1536

Previously, if external code called `uvicorn.run()` and was type-checked with pyright, it reported `error: Type of "run" is partially unknown`. This is because it wants the generic type `dict` to have parameters specifying the type, as in `dict[str, Any]`.

I'm actually a bit surprised that mypy doesn't also report this as a problem, since all the examples I saw in the mypy docs provide a parameter for generics like `list` and `dict`.