### PR TITLE
Add default `log_config` on `uvicorn.run()`

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -478,7 +478,7 @@ def run(
     reload_delay: float = 0.25,
     workers: typing.Optional[int] = None,
     env_file: typing.Optional[str] = None,
-    log_config: typing.Optional[typing.Union[dict, str]] = None,
+    log_config: typing.Optional[typing.Union[dict, str]] = LOGGING_CONFIG,
     log_level: typing.Optional[str] = None,
     access_log: bool = True,
     proxy_headers: bool = True,


### PR DESCRIPTION
I broke the logs because of this. 😞

I don't know how I didn't catch this... It's too simple...

Anyway, moment of shame here. This application doesn't show any logs:

```python
import uvicorn
from fastapi import FastAPI

app = FastAPI() 
@app.get("/")
def index(): 
    return {"home": "index"}

if __name__==  "__main__": 
    uvicorn.run("main:app", port=8100)
```

The reason is that I've set the default of `log_config` to `None`, instead of `LOGGING_CONFIG`.

EDIT: The funny thing is that I noticed this behavior, and I thought the problem was the computer (mac)... 🤦