### PR TITLE
Add test to check if `run()` matches `Config.__init__()`

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import inspect
 import socket
 from logging import WARNING
 
@@ -107,3 +108,17 @@ def test_run_startup_failure(caplog: pytest.LogCaptureFixture) -> None:
     with pytest.raises(SystemExit) as exit_exception:
         run(app, lifespan="on")
     assert exit_exception.value.code == 3
+
+
+def test_run_match_config_params() -> None:
+    config_params = {
+        key: repr(value)
+        for key, value in inspect.signature(Config.__init__).parameters.items()
+        if key not in ("self", "timeout_notify", "callback_notify")
+    }
+    run_params = {
+        key: repr(value)
+        for key, value in inspect.signature(run).parameters.items()
+        if key not in ("app_dir",)
+    }
+    assert config_params == run_params

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -218,9 +218,9 @@ class Config:
         http: Union[Type[asyncio.Protocol], HTTPProtocolType] = "auto",
         ws: Union[Type[asyncio.Protocol], WSProtocolType] = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
-        ws_ping_interval: Optional[float] = 20,
-        ws_ping_timeout: Optional[float] = 20,
-        ws_per_message_deflate: Optional[bool] = True,
+        ws_ping_interval: Optional[float] = 20.0,
+        ws_ping_timeout: Optional[float] = 20.0,
+        ws_per_message_deflate: bool = True,
         lifespan: LifespanType = "auto",
         env_file: Optional[Union[str, os.PathLike]] = None,
         log_config: Optional[Union[Dict[str, Any], str]] = LOGGING_CONFIG,
@@ -231,7 +231,7 @@ class Config:
         debug: bool = False,
         reload: bool = False,
         reload_dirs: Optional[Union[List[str], str]] = None,
-        reload_delay: Optional[float] = None,
+        reload_delay: float = 0.25,
         reload_includes: Optional[Union[List[str], str]] = None,
         reload_excludes: Optional[Union[List[str], str]] = None,
         workers: Optional[int] = None,
@@ -245,7 +245,7 @@ class Config:
         backlog: int = 2048,
         timeout_keep_alive: int = 5,
         timeout_notify: int = 30,
-        callback_notify: Callable[..., Awaitable[None]] = None,
+        callback_notify: Optional[Callable[..., Awaitable[None]]] = None,
         ssl_keyfile: Optional[str] = None,
         ssl_certfile: Optional[Union[str, os.PathLike]] = None,
         ssl_keyfile_password: Optional[str] = None,
@@ -277,7 +277,7 @@ class Config:
         self.interface = interface
         self.debug = debug
         self.reload = reload
-        self.reload_delay = reload_delay or 0.25
+        self.reload_delay = reload_delay
         self.workers = workers or 1
         self.proxy_headers = proxy_headers
         self.server_header = server_header

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import platform
@@ -455,33 +456,33 @@ def main(
 
 
 def run(
-    app: typing.Union["ASGIApplication", str],
+    app: typing.Union["ASGIApplication", typing.Callable, str],
     *,
     host: str = "127.0.0.1",
     port: int = 8000,
     uds: typing.Optional[str] = None,
     fd: typing.Optional[int] = None,
     loop: LoopSetupType = "auto",
-    http: HTTPProtocolType = "auto",
-    ws: WSProtocolType = "auto",
+    http: typing.Union[typing.Type[asyncio.Protocol], HTTPProtocolType] = "auto",
+    ws: typing.Union[typing.Type[asyncio.Protocol], WSProtocolType] = "auto",
     ws_max_size: int = 16777216,
-    ws_ping_interval: float = 20.0,
-    ws_ping_timeout: float = 20.0,
+    ws_ping_interval: typing.Optional[float] = 20.0,
+    ws_ping_timeout: typing.Optional[float] = 20.0,
     ws_per_message_deflate: bool = True,
     lifespan: LifespanType = "auto",
     interface: InterfaceType = "auto",
     debug: bool = False,
     reload: bool = False,
-    reload_dirs: typing.Optional[typing.List[str]] = None,
-    reload_includes: typing.Optional[typing.List[str]] = None,
-    reload_excludes: typing.Optional[typing.List[str]] = None,
+    reload_dirs: typing.Optional[typing.Union[typing.List[str], str]] = None,
+    reload_includes: typing.Optional[typing.Union[typing.List[str], str]] = None,
+    reload_excludes: typing.Optional[typing.Union[typing.List[str], str]] = None,
     reload_delay: float = 0.25,
     workers: typing.Optional[int] = None,
-    env_file: typing.Optional[str] = None,
+    env_file: typing.Optional[typing.Union[str, os.PathLike]] = None,
     log_config: typing.Optional[
         typing.Union[typing.Dict[str, typing.Any], str]
     ] = LOGGING_CONFIG,
-    log_level: typing.Optional[str] = None,
+    log_level: typing.Optional[typing.Union[str, int]] = None,
     access_log: bool = True,
     proxy_headers: bool = True,
     server_header: bool = True,
@@ -493,10 +494,10 @@ def run(
     limit_max_requests: typing.Optional[int] = None,
     timeout_keep_alive: int = 5,
     ssl_keyfile: typing.Optional[str] = None,
-    ssl_certfile: typing.Optional[str] = None,
+    ssl_certfile: typing.Optional[typing.Union[str, os.PathLike]] = None,
     ssl_keyfile_password: typing.Optional[str] = None,
-    ssl_version: int = int(SSL_PROTOCOL_VERSION),
-    ssl_cert_reqs: int = int(ssl.CERT_NONE),
+    ssl_version: int = SSL_PROTOCOL_VERSION,
+    ssl_cert_reqs: int = ssl.CERT_NONE,
     ssl_ca_certs: typing.Optional[str] = None,
     ssl_ciphers: str = "TLSv1",
     headers: typing.Optional[typing.List[typing.Tuple[str, str]]] = None,


### PR DESCRIPTION
After breaking the logs on 0.18.0 (see the fix on https://github.com/encode/uvicorn/pull/1541) because of https://github.com/encode/uvicorn/pull/1423 I've been thinking of a way to have avoided that...

I came up with this. This PR adds a test that matches the type annotation and default values of `run()` and `Config.__init__()`.

This PR also fixes the mismatches.