### PR TITLE
docs: fix simple typo, compability -> compatibility

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -219,7 +219,7 @@ class WebSocketProtocol(websockets.WebSocketServerProtocol):
                 if "headers" in message:
                     self.extra_headers.extend(
                         # ASGI spec requires bytes
-                        # But for compability we need to convert it to strings
+                        # But for compatibility we need to convert it to strings
                         (name.decode("latin-1"), value.decode("latin-1"))
                         for name, value in message["headers"]
                     )


### PR DESCRIPTION
There is a small typo in uvicorn/protocols/websockets/websockets_impl.py.

Should read `compatibility` rather than `compability`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md