### PR TITLE
Drop httpx version to 0.23.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ trustme==0.9.0
 cryptography==3.4.8
 coverage==6.4.1
 coverage-conditional-plugin==0.5.0
-httpx==1.0.0b0
+httpx==0.23.0
 watchgod==0.8.2
 
 # Documentation


### PR DESCRIPTION
0.23.0 is actually the latest... And dependabot is not able to go back from 1.0 to 0.x.