### PR TITLE
Allow force polling when using reload with watchfiles

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,6 +53,9 @@ Options:
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
+  --reload-force-polling          Force auto-reload to use polling rather than
+                                  file system notifications. This option has
+                                  no effect unless watchfiles is installed.
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,6 +120,9 @@ Options:
   --reload-delay FLOAT            Delay between previous and next check if
                                   application needs to be. Defaults to 0.25s.
                                   [default: 0.25]
+  --reload-force-polling          Force auto-reload to use polling rather than
+                                  file system notifications. This option has
+                                  no effect unless watchfiles is installed.
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -234,6 +234,7 @@ class Config:
         reload_delay: float = 0.25,
         reload_includes: Optional[Union[List[str], str]] = None,
         reload_excludes: Optional[Union[List[str], str]] = None,
+        reload_force_polling: Optional[bool] = None,
         workers: Optional[int] = None,
         proxy_headers: bool = True,
         server_header: bool = True,
@@ -278,6 +279,7 @@ class Config:
         self.debug = debug
         self.reload = reload
         self.reload_delay = reload_delay
+        self.reload_force_polling = reload_force_polling or False
         self.workers = workers or 1
         self.proxy_headers = proxy_headers
         self.server_header = server_header

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -117,6 +117,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     " Defaults to 0.25s.",
 )
 @click.option(
+    "--reload-force-polling",
+    is_flag=True,
+    default=False,
+    help="Force auto-reload to use polling rather than file system notifications. "
+    "This option has no effect unless watchfiles is installed.",
+)
+@click.option(
     "--workers",
     default=None,
     type=int,
@@ -378,6 +385,7 @@ def main(
     reload_includes: typing.List[str],
     reload_excludes: typing.List[str],
     reload_delay: float,
+    reload_force_polling: bool,
     workers: int,
     env_file: str,
     log_config: str,
@@ -430,6 +438,7 @@ def main(
         reload_includes=reload_includes or None,
         reload_excludes=reload_excludes or None,
         reload_delay=reload_delay,
+        reload_force_polling=reload_force_polling,
         workers=workers,
         proxy_headers=proxy_headers,
         server_header=server_header,
@@ -477,6 +486,7 @@ def run(
     reload_includes: typing.Optional[typing.Union[typing.List[str], str]] = None,
     reload_excludes: typing.Optional[typing.Union[typing.List[str], str]] = None,
     reload_delay: float = 0.25,
+    reload_force_polling: typing.Optional[bool] = None,
     workers: typing.Optional[int] = None,
     env_file: typing.Optional[typing.Union[str, os.PathLike]] = None,
     log_config: typing.Optional[
@@ -530,6 +540,7 @@ def run(
         reload_includes=reload_includes,
         reload_excludes=reload_excludes,
         reload_delay=reload_delay,
+        reload_force_polling=reload_force_polling,
         workers=workers,
         env_file=env_file,
         log_config=log_config,

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -72,10 +72,12 @@ class WatchFilesReload(BaseReload):
             self.reload_dirs.append(Path.cwd())
 
         self.watch_filter = FileFilter(config)
+        self.force_polling = config.reload_force_polling
         self.watcher = watch(
             *self.reload_dirs,
             watch_filter=None,
             stop_event=self.should_exit,
+            force_polling=self.force_polling,
             # using yield_on_timeout here mostly to make sure tests don't
             # hang forever, won't affect the class's behavior
             yield_on_timeout=True,


### PR DESCRIPTION
Recent release prioritizes the excellent `watchfiles` file-system notifications based library over the now-deprecated `watchgod` polling based library. This is overall an excellent development, but it leaves some windows developers who rely on containers out in the cold, since filesystem notifications aren't reliably passed through from windows to linux (see [docker for windows issue](https://github.com/docker/for-win/issues/8479), and [workaround](https://levelup.gitconnected.com/docker-desktop-on-wsl2-the-problem-with-mixing-file-systems-a8b5dcd79b22) tldr: "don't do that, just use WSL's filesystem and everything works")

This PR offers a bridge and escape hatch to allow for some transition time while we migrate our projects from blended file systems (windows + WSL, a natural starting point for many developers dealing with employer-provided windows hardware) to a WSL-only project filesystem format. I promise to start new projects as WSL only, but for now, allowing for polling rather than system notifications seems to work on blended setups.

The only change this PR proposes is to add a command line flag to allow a developer like me to opt in to the new-default-hotness `watchfiles` library while still running the polling variant of the watcher on existing projects. 

The proposed API follows along with conventions established by other reload kwargs, and appears in usage like so:

```shell
uvicorn main:app --reload --reload-force-polling
```

Throughout the source code diff the new variable is called `reload_force_polling` and is entirely optional (default=False).

For testing and coverage I've started this draft PR by modifying existing tests only. Thus far I've modified the test to make sure that the reloader initializes fully and the test to make sure that the polling side of the `watchfiles` api was used and successful for a changed .py file. 

The test patterns in this diff could be easily extended to other tests if needed, though this library may not need to extensively test all permutations of the `watchfiles` polling switch. It seemed more important to just ensure that the flag is honored when its passed. That said, I'm happy to add the modification to other tests if desired.

Thanks for the maintenance, docs, and frequent releases. Please consider this minor enhancement for merging - or let me know what I need to add/change to get it ready.