### PR TITLE
Improve typing of app factory

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -209,7 +209,7 @@ def _normalize_dirs(dirs: Union[List[str], str, None]) -> List[str]:
 class Config:
     def __init__(
         self,
-        app: Union["ASGIApplication", Callable, str],
+        app: Union["ASGIApplication", Callable[..., Optional["ASGIApplication"]], str],
         host: str = "127.0.0.1",
         port: int = 8000,
         uds: Optional[str] = None,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -456,7 +456,9 @@ def main(
 
 
 def run(
-    app: typing.Union["ASGIApplication", typing.Callable, str],
+    app: typing.Union[
+        "ASGIApplication", typing.Callable[..., typing.Optional["ASGIApplication"]], str
+    ],
     *,
     host: str = "127.0.0.1",
     port: int = 8000,


### PR DESCRIPTION
Original discussion, approved by @Kludex :
https://github.com/encode/uvicorn/discussions/1595#discussioncomment-3348105

> 
> There is a type definition for appin uvicorn.Config.__init__(...):
> app: Union["ASGIApplication", Callable, str],  
> 
> **So app receives any Callable, which is obviously incorrect. My first proposal is to set here type Callable[Any, "ASGIApplication"] instead of plain Callable. By doing this mypy will raise an error and modern code editors will give a hint of an error too.**
