### PR TITLE
Cooperative signal handling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -260,7 +260,6 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-
 ### Running with Gunicorn
 
 [Gunicorn][gunicorn] is a mature, fully featured server and process manager.

--- a/docs/index.md
+++ b/docs/index.md
@@ -260,6 +260,10 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+!!! note
+    Both `server.run` and `server.serve` install custom signal handlers while the server runs.
+    The original signal handlers are restored and, if appropriate, invoked once the server finishes.
+
 ### Running with Gunicorn
 
 [Gunicorn][gunicorn] is a mature, fully featured server and process manager.

--- a/docs/index.md
+++ b/docs/index.md
@@ -260,9 +260,6 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-!!! note
-    Both `server.run` and `server.serve` install custom signal handlers while the server runs.
-    The original signal handlers are restored and, if appropriate, invoked once the server finishes.
 
 ### Running with Gunicorn
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -46,7 +46,6 @@ else:
 
 
 @pytest.mark.anyio
-@pytest.mark.skipif(sys.platform == "win32", reason="require unix-like signal handling")
 @pytest.mark.parametrize("exception_signal", signals)
 @pytest.mark.parametrize("capture_signal", signal_captures)
 async def test_server_interrupt(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,10 @@
-from typing import Generator
+from __future__ import annotations
+
 import asyncio
 import os
 import signal
 import sys
+from typing import Generator
 
 import pytest
 
@@ -15,7 +17,7 @@ class CaughtSignal(Exception):
 
 
 @pytest.fixture(params=[signal.SIGINT, signal.SIGTERM])
-def exception_signal(request: "type[pytest.FixtureRequest]") -> Generator[signal.Signals, None, None]:  # pragma: py-win32
+def exception_signal(request: type[pytest.FixtureRequest]) -> Generator[signal.Signals, None, None]:  # pragma: py-win32
     """Fixture that replaces SIGINT/SIGTERM handling with a normal exception"""
 
     def raise_handler(*_: object) -> None:
@@ -27,12 +29,15 @@ def exception_signal(request: "type[pytest.FixtureRequest]") -> Generator[signal
 
 
 @pytest.fixture(params=[signal.SIGINT, signal.SIGTERM])
-def async_exception_signal(request: "type[pytest.FixtureRequest]") -> Generator[signal.Signals, None, None]:  # pragma: py-win32
+def async_exception_signal(  # pragma: py-win32
+    request: type[pytest.FixtureRequest]
+) -> Generator[signal.Signals, None, None]:
     """Fixture that replaces SIGINT/SIGTERM handling with a normal exception"""
 
     def raise_handler(*_: object) -> None:
         raise CaughtSignal
 
+    asyncio.get_running_loop().add_signal_handler
     original_handler = signal.signal(request.param, raise_handler)
     yield request.param
     signal.signal(request.param, original_handler)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 import signal
 import sys
 from typing import Callable, ContextManager, Generator
@@ -50,7 +49,7 @@ async def test_server_interrupt(
     async def interrupt_running(srv: Server):
         while not srv.started:
             await asyncio.sleep(0.01)
-        os.kill(os.getpid(), exception_signal)
+        signal.raise_signal(exception_signal)
 
     server = Server(Config(app=dummy_app, loop="asyncio"))
     asyncio.create_task(interrupt_running(server))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,7 +30,7 @@ def exception_signal(request: type[pytest.FixtureRequest]) -> Generator[signal.S
 
 @pytest.fixture(params=[signal.SIGINT, signal.SIGTERM])
 def async_exception_signal(  # pragma: py-win32
-    request: type[pytest.FixtureRequest]
+    request: type[pytest.FixtureRequest],
 ) -> Generator[signal.Signals, None, None]:
     """Fixture that replaces SIGINT/SIGTERM handling with a normal exception"""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,60 @@
+from typing import Generator
+import asyncio
+import os
+import signal
+import sys
+
+import pytest
+
+from uvicorn.config import Config
+from uvicorn.server import Server
+
+
+class CaughtSignal(Exception):
+    pass
+
+
+@pytest.fixture(params=[signal.SIGINT, signal.SIGTERM])
+def exception_signal(request: "type[pytest.FixtureRequest]") -> Generator[signal.Signals, None, None]:  # pragma: py-win32
+    """Fixture that replaces SIGINT/SIGTERM handling with a normal exception"""
+
+    def raise_handler(*_: object) -> None:
+        raise CaughtSignal
+
+    original_handler = signal.signal(request.param, raise_handler)
+    yield request.param
+    signal.signal(request.param, original_handler)
+
+
+@pytest.fixture(params=[signal.SIGINT, signal.SIGTERM])
+def async_exception_signal(request: "type[pytest.FixtureRequest]") -> Generator[signal.Signals, None, None]:  # pragma: py-win32
+    """Fixture that replaces SIGINT/SIGTERM handling with a normal exception"""
+
+    def raise_handler(*_: object) -> None:
+        raise CaughtSignal
+
+    original_handler = signal.signal(request.param, raise_handler)
+    yield request.param
+    signal.signal(request.param, original_handler)
+
+
+async def dummy_app(scope, receive, send):  # pragma: py-win32
+    pass
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(sys.platform == "win32", reason="require unix-like signal handling")
+async def test_server_interrupt(exception_signal: signal.Signals):  # pragma: py-win32
+    """Test interrupting a Server that is run explicitly inside asyncio"""
+
+    async def interrupt_running(srv: Server):
+        while not srv.started:
+            await asyncio.sleep(0.01)
+        os.kill(os.getpid(), exception_signal)
+
+    server = Server(Config(app=dummy_app, loop="asyncio"))
+    asyncio.create_task(interrupt_running(server))
+    with pytest.raises(CaughtSignal):
+        await server.serve()
+    # set by the server's graceful exit handler
+    assert server.should_exit

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -324,7 +324,7 @@ class Server:
         # If we did gracefully shut down due to a signal, try to
         # trigger the expected behaviour now; multiple signals would be
         # done LIFO, see https://stackoverflow.com/questions/48434964
-        for captured_signal in reversed(self._captured_signals):  # pragma: py-win32
+        for captured_signal in reversed(self._captured_signals):
             signal.raise_signal(captured_signal)
 
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -12,7 +12,7 @@ import threading
 import time
 from email.utils import formatdate
 from types import FrameType
-from typing import TYPE_CHECKING, Sequence, Union
+from typing import TYPE_CHECKING, Generator, Sequence, Union
 
 import click
 
@@ -308,16 +308,14 @@ class Server:
             await server.wait_closed()
 
     @contextlib.contextmanager
-    def capture_signals(self):
+    def capture_signals(self) -> Generator[None, None, None]:
         # Signals can only be listened to from the main thread.
         if threading.current_thread() is not threading.main_thread():
             yield
             return
         # always use signal.signal, even if loop.add_signal_handler is available
         # this allows to restore previous signal handlers later on
-        original_handlers = {
-            sig: signal.signal(sig, self.handle_exit) for sig in HANDLED_SIGNALS
-        }
+        original_handlers = {sig: signal.signal(sig, self.handle_exit) for sig in HANDLED_SIGNALS}
         try:
             yield
         finally:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import platform
@@ -57,11 +58,17 @@ class Server:
         self.force_exit = False
         self.last_notified = 0.0
 
+        self._captured_signals: list[int] = []
+
     def run(self, sockets: list[socket.socket] | None = None) -> None:
         self.config.setup_event_loop()
         return asyncio.run(self.serve(sockets=sockets))
 
     async def serve(self, sockets: list[socket.socket] | None = None) -> None:
+        with self.capture_signals():
+            await self._serve(sockets)
+
+    async def _serve(self, sockets: list[socket.socket] | None = None) -> None:
         process_id = os.getpid()
 
         config = self.config
@@ -69,8 +76,6 @@ class Server:
             config.load()
 
         self.lifespan = config.lifespan_class(config)
-
-        self.install_signal_handlers()
 
         message = "Started server process [%d]"
         color_message = "Started server process [" + click.style("%d", fg="cyan") + "]"
@@ -302,22 +307,30 @@ class Server:
         for server in self.servers:
             await server.wait_closed()
 
-    def install_signal_handlers(self) -> None:
+    @contextlib.contextmanager
+    def capture_signals(self):
+        # Signals can only be listened to from the main thread.
         if threading.current_thread() is not threading.main_thread():
-            # Signals can only be listened to from the main thread.
+            yield
             return
-
-        loop = asyncio.get_event_loop()
-
+        # always use signal.signal, even if loop.add_signal_handler is available
+        # this allows to restore previous signal handlers later on
+        original_handlers = {
+            sig: signal.signal(sig, self.handle_exit) for sig in HANDLED_SIGNALS
+        }
         try:
-            for sig in HANDLED_SIGNALS:
-                loop.add_signal_handler(sig, self.handle_exit, sig, None)
-        except NotImplementedError:  # pragma: no cover
-            # Windows
-            for sig in HANDLED_SIGNALS:
-                signal.signal(sig, self.handle_exit)
+            yield
+        finally:
+            for sig, handler in original_handlers.items():
+                signal.signal(sig, handler)
+        # If we did gracefully shut down due to a signal, try to
+        # trigger the expected behaviour now; multiple signals would be
+        # done LIFO, see https://stackoverflow.com/questions/48434964
+        for captured_signal in reversed(self._captured_signals):  # pragma: py-win32
+            signal.raise_signal(captured_signal)
 
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
+        self._captured_signals.append(sig)
         if self.should_exit and sig == signal.SIGINT:
             self.force_exit = True
         else:


### PR DESCRIPTION
* [x]  I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
* [x]  I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
* [x]  I've updated the documentation accordingly.

-------------------

This PR adjust the signal handling of `uvicorn.server.Server` to integrate with `asyncio` applications by not suppressing shutdown signals. Major changes include:

* Original signal handlers are restored before `Server.serve` finishes
* When terminated by a signal, the appropriate original signal handler is invoked if possible

In the usual case, this allows CTRL+C to end both `uvicorn` *and* the containing async application. Closes #1579.

-------------------

There is a caveat for tests in that signal handling on Windows is not as precise as on Unix (see e.g. [Stackoverflow: How to handle a signal.SIGINT on a Windows OS machine?](https://stackoverflow.com/questions/35772001/how-to-handle-a-signal-sigint-on-a-windows-os-machine)). For testing, I could not setup a situation where the tests receive a signal *without the test environment also being interrupted by it*.