### PR TITLE
Remove parser reference to break the cyclic reference to protocol

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -145,6 +145,7 @@ class H11Protocol(asyncio.Protocol):
             self.flow.resume_writing()
         if exc is None:
             self.transport.close()
+            self._unset_keepalive_if_required()
 
     def eof_received(self) -> None:
         pass

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -137,6 +137,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             self.flow.resume_writing()
         if exc is None:
             self.transport.close()
+            self._unset_keepalive_if_required()
 
         self.parser = None
 

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -138,6 +138,8 @@ class HttpToolsProtocol(asyncio.Protocol):
         if exc is None:
             self.transport.close()
 
+        self.parser = None
+
     def eof_received(self) -> None:
         pass
 


### PR DESCRIPTION
This removes the reference to the parser after losing connection so during the teardown of the protocol there will be no cyclic ref to it freeing up the object to be collected by the garbage collector.

Fixes #1564 