### PR TITLE
typing: Config.forwarded_allow_ips can also be a list of strings

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -370,7 +370,7 @@ class Config:
         if workers is None and "WEB_CONCURRENCY" in os.environ:
             self.workers = int(os.environ["WEB_CONCURRENCY"])
 
-        self.forwarded_allow_ips: Union[List[str], str]  # help mypy
+        self.forwarded_allow_ips: Union[List[str], str]
         if forwarded_allow_ips is None:
             self.forwarded_allow_ips = os.environ.get(
                 "FORWARDED_ALLOW_IPS", "127.0.0.1"

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -238,7 +238,7 @@ class Config:
         proxy_headers: bool = True,
         server_header: bool = True,
         date_header: bool = True,
-        forwarded_allow_ips: Optional[str] = None,
+        forwarded_allow_ips: Optional[Union[List[str], str]] = None,
         root_path: str = "",
         limit_concurrency: Optional[int] = None,
         limit_max_requests: Optional[int] = None,
@@ -370,6 +370,7 @@ class Config:
         if workers is None and "WEB_CONCURRENCY" in os.environ:
             self.workers = int(os.environ["WEB_CONCURRENCY"])
 
+        self.forwarded_allow_ips: Union[List[str], str]  # help mypy
         if forwarded_allow_ips is None:
             self.forwarded_allow_ips = os.environ.get(
                 "FORWARDED_ALLOW_IPS", "127.0.0.1"

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -487,7 +487,7 @@ def run(
     proxy_headers: bool = True,
     server_header: bool = True,
     date_header: bool = True,
-    forwarded_allow_ips: typing.Optional[str] = None,
+    forwarded_allow_ips: typing.Optional[typing.Union[typing.List[str], str]] = None,
     root_path: str = "",
     limit_concurrency: typing.Optional[int] = None,
     backlog: int = 2048,


### PR DESCRIPTION
Ultimately, the value is passed to `ProxyHeadersMiddleware` as `trusted_hosts` constructor argument, which accepts either a list of strings or a string.

This is only relevant when running Uvicorn programmatically.

https://github.com/encode/uvicorn/blob/b21ecabc5bf911f571e0629438315a1e5472065c/uvicorn/config.py#L518-L520

https://github.com/encode/uvicorn/blob/b22c9506b282e9c81591ed7f48781dc5759df0e0/uvicorn/middleware/proxy_headers.py#L28