### PR TITLE
Improve ProxyHeadersMiddleware

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -117,7 +117,7 @@ async def test_proxy_headers_invalid_x_forwarded_for() -> None:
 
 @pytest.mark.anyio
 async def test_proxy_headers_empty_x_forwarded_for() -> None:
-    # fallback to the default behavior if x-forwarded-for is an empty list for some reason
+    # fallback to the default behavior if x-forwarded-for is an empty list
     # https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
     transport = httpx.ASGITransport(app=app_with_middleware, client=("1.2.3.4", 8080))

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -32,8 +32,14 @@ async def app(
         # trusted proxy list
         (["127.0.0.1", "10.0.0.1"], "Remote: https://1.2.3.4:0"),
         ("127.0.0.1, 10.0.0.1", "Remote: https://1.2.3.4:0"),
+        # trusted proxy network
+        ("127.0.0.0/24, 10.0.0.1", "Remote: https://1.2.3.4:0"),
         # request from untrusted proxy
         ("192.168.0.1", "Remote: http://127.0.0.1:123"),
+        # request from untrusted proxy network
+        ("192.168.0.0/16", "Remote: http://127.0.0.1:123"),
+        # request from client running on proxy server
+        (["127.0.0.1", "1.2.3.4"], "Remote: https://1.2.3.4:0"),
     ],
 )
 async def test_proxy_headers_trusted_hosts(

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -33,12 +33,14 @@ async def app(
         (["127.0.0.1", "10.0.0.1"], "Remote: https://1.2.3.4:0"),
         ("127.0.0.1, 10.0.0.1", "Remote: https://1.2.3.4:0"),
         # trusted proxy network
+        # https://github.com/encode/uvicorn/issues/1068#issuecomment-1004813267
         ("127.0.0.0/24, 10.0.0.1", "Remote: https://1.2.3.4:0"),
         # request from untrusted proxy
         ("192.168.0.1", "Remote: http://127.0.0.1:123"),
         # request from untrusted proxy network
         ("192.168.0.0/16", "Remote: http://127.0.0.1:123"),
-        # request from client running on proxy server
+        # request from client running on proxy server itself
+        # https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
         (["127.0.0.1", "1.2.3.4"], "Remote: https://1.2.3.4:0"),
     ],
 )
@@ -109,3 +111,24 @@ async def test_proxy_headers_invalid_x_forwarded_for() -> None:
         response = await client.get("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "Remote: https://1.2.3.4:0"
+
+
+@pytest.mark.anyio
+async def test_proxy_headers_empty_x_forwarded_for() -> None:
+    # fallback to the default behavior if x-forwarded-for is an empty list for some reason
+    # https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
+    app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
+    transport = httpx.ASGITransport(app=app_with_middleware, client=("1.2.3.4", 8080))
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        headers = httpx.Headers(
+            {
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-For": "",
+            },
+            encoding="latin-1",
+        )
+        response = await client.get("/", headers=headers)
+    assert response.status_code == 200
+    assert response.text == "Remote: https://1.2.3.4:8080"

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -48,7 +48,9 @@ async def test_proxy_headers_trusted_hosts(
     trusted_hosts: Union[List[str], str], response_text: str
 ) -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
-    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(
+        app=app_with_middleware, base_url="http://testserver"
+    ) as client:
         headers = {"X-Forwarded-Proto": "https", "X-Forwarded-For": "1.2.3.4"}
         response = await client.get("/", headers=headers)
 
@@ -82,7 +84,9 @@ async def test_proxy_headers_multiple_proxies(
     trusted_hosts: Union[List[str], str], response_text: str
 ) -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
-    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(
+        app=app_with_middleware, base_url="http://testserver"
+    ) as client:
         headers = {
             "X-Forwarded-Proto": "https",
             "X-Forwarded-For": "1.2.3.4, 10.0.2.1, 192.168.0.2",
@@ -96,7 +100,9 @@ async def test_proxy_headers_multiple_proxies(
 @pytest.mark.anyio
 async def test_proxy_headers_invalid_x_forwarded_for() -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
-    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(
+        app=app_with_middleware, base_url="http://testserver"
+    ) as client:
         headers = httpx.Headers(
             {
                 "X-Forwarded-Proto": "https",
@@ -115,7 +121,9 @@ async def test_proxy_headers_empty_x_forwarded_for() -> None:
     # https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
     transport = httpx.ASGITransport(app=app_with_middleware, client=("1.2.3.4", 8080))
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
         headers = httpx.Headers(
             {
                 "X-Forwarded-Proto": "https",

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -48,9 +48,7 @@ async def test_proxy_headers_trusted_hosts(
     trusted_hosts: Union[List[str], str], response_text: str
 ) -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
-    async with httpx.AsyncClient(
-        app=app_with_middleware, base_url="http://testserver"
-    ) as client:
+    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
         headers = {"X-Forwarded-Proto": "https", "X-Forwarded-For": "1.2.3.4"}
         response = await client.get("/", headers=headers)
 
@@ -76,15 +74,15 @@ async def test_proxy_headers_trusted_hosts(
         ),
         # should set first untrusted as remote address
         (["192.168.0.2", "127.0.0.1"], "Remote: https://10.0.2.1:0"),
+        # Mixed literals and networks
+        (["127.0.0.1", "10.0.0.0/8", "192.168.0.2"], "Remote: https://1.2.3.4:0"),
     ],
 )
 async def test_proxy_headers_multiple_proxies(
     trusted_hosts: Union[List[str], str], response_text: str
 ) -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
-    async with httpx.AsyncClient(
-        app=app_with_middleware, base_url="http://testserver"
-    ) as client:
+    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
         headers = {
             "X-Forwarded-Proto": "https",
             "X-Forwarded-For": "1.2.3.4, 10.0.2.1, 192.168.0.2",
@@ -98,9 +96,7 @@ async def test_proxy_headers_multiple_proxies(
 @pytest.mark.anyio
 async def test_proxy_headers_invalid_x_forwarded_for() -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
-    async with httpx.AsyncClient(
-        app=app_with_middleware, base_url="http://testserver"
-    ) as client:
+    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
         headers = httpx.Headers(
             {
                 "X-Forwarded-Proto": "https",
@@ -119,9 +115,7 @@ async def test_proxy_headers_empty_x_forwarded_for() -> None:
     # https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
     transport = httpx.ASGITransport(app=app_with_middleware, client=("1.2.3.4", 8080))
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://testserver"
-    ) as client:
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         headers = httpx.Headers(
             {
                 "X-Forwarded-Proto": "https",

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -44,7 +44,7 @@ class _TrustedHosts:
                 except ValueError:
                     self.trusted_literals.add(host)
 
-    def __contains__(self, item: str):
+    def __contains__(self, item: Optional[str]) -> bool:
         if self.always_trust:
             return True
 
@@ -67,6 +67,7 @@ class _TrustedHosts:
         # See https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
         if host in self:
             return x_forwarded_for_hosts[0]
+        return host
 
 
 class ProxyHeadersMiddleware:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
         ASGI3Application,
         ASGIReceiveCallable,
         ASGISendCallable,
+        HTTPScope,
         Scope,
+        WebSocketScope,
     )
 
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -12,7 +12,12 @@ import ipaddress
 from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union, cast
 
 if TYPE_CHECKING:
-    from asgiref.typing import ASGI3Application, ASGIReceiveCallable, ASGISendCallable, Scope
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        Scope,
+    )
 
 
 def _parse_raw_hosts(value: str) -> List[str]:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -37,8 +37,9 @@ class _TrustedHosts:
                 trusted_hosts = _parse_raw_hosts(trusted_hosts)
             for host in trusted_hosts:
                 try:
-                    # Try parsing the trusted host as an IPv4Network to allow checking a whole range.
-                    # See https://github.com/encode/uvicorn/issues/1068#issuecomment-1004813267
+                    # Try parsing the trusted host as an IPv4Network
+                    # to allow checking a whole range.
+                    # https://github.com/encode/uvicorn/issues/1068
                     self.trusted_networks.add(ipaddress.IPv4Network(host))
                 except ValueError:
                     self.trusted_literals.add(host)
@@ -101,8 +102,9 @@ class ProxyHeadersMiddleware:
                     x_forwarded_for = headers[b"x-forwarded-for"].decode("latin1")
                     host = self.trusted_hosts.get_trusted_client_host(x_forwarded_for)
 
-                    # Host is None or an empty string if the x-forwarded-for header is empty.
-                    # See https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
+                    # Host is None or an empty string
+                    # if the x-forwarded-for header is empty.
+                    # See https://github.com/encode/uvicorn/issues/1068
                     if host:
                         port = 0
                         scope["client"] = (host, port)  # type: ignore[arg-type]

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -9,15 +9,10 @@ the connecting client, rather that the connecting proxy.
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
 import ipaddress
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast, Set
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union, cast
 
 if TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGI3Application,
-        ASGIReceiveCallable,
-        ASGISendCallable,
-        Scope,
-    )
+    from asgiref.typing import ASGI3Application, ASGIReceiveCallable, ASGISendCallable, Scope
 
 
 def _parse_raw_hosts(value: str) -> List[str]:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -8,17 +8,60 @@ the connecting client, rather that the connecting proxy.
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
+import ipaddress
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast, Set
 
 if TYPE_CHECKING:
     from asgiref.typing import (
         ASGI3Application,
         ASGIReceiveCallable,
         ASGISendCallable,
-        HTTPScope,
         Scope,
-        WebSocketScope,
     )
+
+
+def _parse_raw_hosts(value: str) -> List[str]:
+    return [item.strip() for item in value.split(",")]
+
+
+class _TrustedHosts:
+    def __init__(self, trusted_hosts: Union[List[str], str]) -> None:
+        self.trusted_networks: Set[ipaddress.IPv4Network] = set()
+        self.trusted_literals: Set[str] = set()
+
+        self.always_trust = trusted_hosts == "*"
+
+        if not self.always_trust:
+            if isinstance(trusted_hosts, str):
+                trusted_hosts = _parse_raw_hosts(trusted_hosts)
+            for host in trusted_hosts:
+                try:
+                    self.trusted_networks.add(ipaddress.IPv4Network(host))
+                except ValueError:
+                    self.trusted_literals.add(host)
+
+    def __contains__(self, item: str):
+        if self.always_trust:
+            return True
+
+        try:
+            ip = ipaddress.IPv4Address(item)
+            return any(ip in net for net in self.trusted_networks)
+        except ValueError:
+            return item in self.trusted_literals
+
+    def get_trusted_client_host(self, x_forwarded_for: str) -> Optional[str]:
+        x_forwarded_for_hosts = _parse_raw_hosts(x_forwarded_for)
+        if self.always_trust:
+            return x_forwarded_for_hosts[0]
+
+        host = None
+        for host in reversed(x_forwarded_for_hosts):
+            if host not in self:
+                return host
+        # The request came from a client on the proxy itself. Trust it.
+        if host in self:
+            return x_forwarded_for_hosts[0]
 
 
 class ProxyHeadersMiddleware:
@@ -28,23 +71,7 @@ class ProxyHeadersMiddleware:
         trusted_hosts: Union[List[str], str] = "127.0.0.1",
     ) -> None:
         self.app = app
-        if isinstance(trusted_hosts, str):
-            self.trusted_hosts = {item.strip() for item in trusted_hosts.split(",")}
-        else:
-            self.trusted_hosts = set(trusted_hosts)
-        self.always_trust = "*" in self.trusted_hosts
-
-    def get_trusted_client_host(
-        self, x_forwarded_for_hosts: List[str]
-    ) -> Optional[str]:
-        if self.always_trust:
-            return x_forwarded_for_hosts[0]
-
-        for host in reversed(x_forwarded_for_hosts):
-            if host not in self.trusted_hosts:
-                return host
-
-        return None
+        self.trusted_hosts = _TrustedHosts(trusted_hosts)
 
     async def __call__(
         self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
@@ -54,7 +81,7 @@ class ProxyHeadersMiddleware:
             client_addr: Optional[Tuple[str, int]] = scope.get("client")
             client_host = client_addr[0] if client_addr else None
 
-            if self.always_trust or client_host in self.trusted_hosts:
+            if client_host in self.trusted_hosts:
                 headers = dict(scope["headers"])
 
                 if b"x-forwarded-proto" in headers:
@@ -68,10 +95,7 @@ class ProxyHeadersMiddleware:
                     # X-Forwarded-For header. We've lost the connecting client's port
                     # information by now, so only include the host.
                     x_forwarded_for = headers[b"x-forwarded-for"].decode("latin1")
-                    x_forwarded_for_hosts = [
-                        item.strip() for item in x_forwarded_for.split(",")
-                    ]
-                    host = self.get_trusted_client_host(x_forwarded_for_hosts)
+                    host = self.trusted_hosts.get_trusted_client_host(x_forwarded_for)
                     port = 0
                     scope["client"] = (host, port)  # type: ignore[arg-type]
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -28,7 +28,6 @@ class _TrustedHosts:
     def __init__(self, trusted_hosts: Union[List[str], str]) -> None:
         self.trusted_networks: Set[ipaddress.IPv4Network] = set()
         self.trusted_literals: Set[str] = set()
-
         self.always_trust = trusted_hosts == "*"
 
         if not self.always_trust:
@@ -36,6 +35,8 @@ class _TrustedHosts:
                 trusted_hosts = _parse_raw_hosts(trusted_hosts)
             for host in trusted_hosts:
                 try:
+                    # Try parsing the trusted host as an IPv4Network to allow checking a whole range.
+                    # See https://github.com/encode/uvicorn/issues/1068#issuecomment-1004813267
                     self.trusted_networks.add(ipaddress.IPv4Network(host))
                 except ValueError:
                     self.trusted_literals.add(host)
@@ -60,6 +61,7 @@ class _TrustedHosts:
             if host not in self:
                 return host
         # The request came from a client on the proxy itself. Trust it.
+        # See https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
         if host in self:
             return x_forwarded_for_hosts[0]
 
@@ -96,7 +98,11 @@ class ProxyHeadersMiddleware:
                     # information by now, so only include the host.
                     x_forwarded_for = headers[b"x-forwarded-for"].decode("latin1")
                     host = self.trusted_hosts.get_trusted_client_host(x_forwarded_for)
-                    port = 0
-                    scope["client"] = (host, port)  # type: ignore[arg-type]
+
+                    # Host is None or an empty string if the x-forwarded-for header is empty.
+                    # See https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576
+                    if host:
+                        port = 0
+                        scope["client"] = (host, port)  # type: ignore[arg-type]
 
         return await self.app(scope, receive, send)


### PR DESCRIPTION
**Summary**
This PR addresses multiple issues mentioned in https://github.com/encode/uvicorn/issues/1068 to improve the `ProxyHeadersMiddleware`.
- :bug: Fix the `host` for requests from clients running on the proxy server itself. (The main issue)
- :bug: Fallback to host that was already set for empty `x-forwarded-for` headers. ([Mentioned](https://github.com/encode/uvicorn/issues/1068#issuecomment-855371576) by @b0g3r)
- ✨ Also allow to specify IP ranges in CIDR notation as trusted hosts. ([Mentioned](https://github.com/encode/uvicorn/issues/1068#issuecomment-1004813267) by @jalaziz) This greatly simplifies deployments on docker swarm / kubernetes, where the reverse proxy might have a dynamic IP.