### PR TITLE
Fix bug in `WebSocketProtocol.asgi_receive`

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -631,7 +631,7 @@ async def test_server_reject_connection(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_server_can_read_messages_in_buffer_after_close(
+async def test_server_can_read_messages_in_buffer_after_client_close(
     ws_protocol_cls, http_protocol_cls
 ):
     frames = []
@@ -657,4 +657,53 @@ async def test_server_can_read_messages_in_buffer_after_close(
     async with run_server(config):
         await send_text("ws://127.0.0.1:8000")
 
+    assert frames == [b"abc", b"abc", b"abc"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", [WebSocketProtocol])
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_can_read_messages_in_buffer_after_server_close(
+    ws_protocol_cls, http_protocol_cls
+):
+    """
+    Note: this doesn't work with WSProtocol.
+    """
+
+    frames = []
+
+    class App(WebSocketResponse):
+        async def websocket_connect(self, message):
+            await self.send({"type": "websocket.accept"})
+            # Ensure server doesn't start reading frames from read buffer until
+            # after server has sent close frame, but server is still able to
+            # read these frames
+            await asyncio.sleep(0.2)
+            await self.send({"type": "websocket.close"})
+
+        async def websocket_receive(self, message):
+            frames.append(message.get("bytes"))
+
+    async def send_text(url):
+        async with websockets.connect(url) as websocket:
+            await websocket.send(b"abc")
+            await websocket.send(b"abc")
+            await websocket.send(b"abc")
+
+            # Wait until after server has sent close frame
+            await asyncio.sleep(0.3)
+
+            try:
+                # Client will fail to send this frame
+                await websocket.send(b"abc")
+            except websockets.exceptions.ConnectionClosed:
+                pass
+            else:
+                raise AssertionError("connection was not closed")
+
+    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    async with run_server(config):
+        await send_text("ws://127.0.0.1:8000")
+
+    # Client tried to send 4 frames, could only send 3
     assert frames == [b"abc", b"abc", b"abc"]


### PR DESCRIPTION
@Kludex @euri10 

Note: this PR obsoletes [this old one](https://github.com/encode/uvicorn/pull/1272), which was closed anyway

There were 2 things to fix in https://github.com/encode/uvicorn/issues/1230:

- ensure the server can read frames in the read queue after **the client** has sent the close frame
- ensure the server can read frames in the read queue after **the server** has sent the close frame

The first item was fixed was fixed by this PR: https://github.com/encode/uvicorn/pull/1252. But I realized after this PR was merged that the second item hadn't been fixed.

This PR fixes the second item. It ensures that the server can "drain" unread frames in the read queue even after the server has sent the close frame, as long as those frames were sent before the server sent the close frame.

As with the first item, the second item [is part of the websockets spec](https://datatracker.ietf.org/doc/html/rfc6455#section-1.4). The following code, using just the `websockets` library, makes it clear that this is the intended behavior of this library.

I did not include code in this PR that fixes this bug in `wsproto_impl.py`, because I'm not familiar with `wsproto`. That said, I don't think we should gate this fix on the corresponding fix in `wsproto`.

`client.py`

```py
import asyncio

import websockets


async def hello():
    async with websockets.connect("ws://localhost:8765") as websocket:
        await websocket.send("message 1")
        await websocket.send("message 2")
        await websocket.send("message 3")

        # Sleep until after server has sent close frame
        await asyncio.sleep(0.3)

        try:
            await websocket.send("message 4")
        except websockets.exceptions.ConnectionClosed as e:
            print("message 4 not sent, connection closed:", e)


asyncio.run(hello())
```

`server.py`

```py
import asyncio

import websockets


async def handler(websocket, *args):
    # Give client time to send frames that go into read queue before server sends close frame
    await asyncio.sleep(0.2)
    await websocket.close(1000)

    # Server can still read these messages from read queue after sending close frame
    print(await websocket.recv())
    print(await websocket.recv())
    print(await websocket.recv())


async def main():
    async with websockets.serve(handler, "localhost", 8765):
        await asyncio.Future()  # Run forever


asyncio.run(main())
```