### PR TITLE
Correctly handle Upgrade-requests for HTTP/2 by ignoring them

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 97.66
+fail_under = 97.63
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 97.69
+fail_under = 97.66
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -204,17 +204,16 @@ class H11Protocol(asyncio.Protocol):
                     "headers": self.headers,
                 }
 
-                is_connection_upgrade = any(
-                    name == b"connection"
-                    and b"upgrade"
-                    in [token.lower().strip() for token in value.split(b",")]
-                    for name, value in self.headers
-                )
-                is_http2 = any(
-                    name == b"upgrade" and value == b"h2c"
-                    for name, value in self.headers
-                )
-                if is_connection_upgrade and not is_http2:
+                is_upgrade, is_http2 = False, False
+                for name, value in self.headers:
+                    if name == b"connection":
+                        tokens = [token.lower().strip() for token in value.split(b",")]
+                        if b"upgrade" in tokens:
+                            is_upgrade = True
+                    elif name == b"upgrade" and value == b"h2c":
+                        is_http2 = True
+
+                if is_upgrade and not is_http2:
                     self.handle_upgrade(event)
                     return
 

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -168,6 +168,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         for name, value in self.headers:
             if name == b"upgrade":
                 upgrade_value = value.lower()
+
         if upgrade_value == b"h2c":
             return
         elif upgrade_value != b"websocket" or self.ws_protocol_class is None:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -245,7 +245,16 @@ class HttpToolsProtocol(asyncio.Protocol):
         if http_version != "1.1":
             self.scope["http_version"] = http_version
         if self.parser.should_upgrade():
+<<<<<<< HEAD
             return
+=======
+            http2 = any(
+                name == b"upgrade" and value.lower() == b"h2c"
+                for name, value in self.headers
+            )
+            if not http2:
+                return
+>>>>>>> 7a22ba8 (Alternative work)
         parsed_url = httptools.parse_url(self.url)
         raw_path = parsed_url.path
         path = raw_path.decode("ascii")

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -296,7 +296,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             self.pipeline.appendleft((self.cycle, app))
 
     def on_body(self, body: bytes) -> None:
-        if self.parser.should_upgrade() or self.cycle.response_complete:
+        if (self.parser.should_upgrade() and not self.is_http2) or self.cycle.response_complete:
             return
         self.cycle.body += body
         if len(self.cycle.body) > HIGH_WATER_LIMIT:
@@ -304,7 +304,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.cycle.message_event.set()
 
     def on_message_complete(self) -> None:
-        if self.parser.should_upgrade() or self.cycle.response_complete:
+        if (self.parser.should_upgrade() and not self.is_http2) or self.cycle.response_complete:
             return
         self.cycle.more_body = False
         self.cycle.message_event.set()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -296,7 +296,9 @@ class HttpToolsProtocol(asyncio.Protocol):
             self.pipeline.appendleft((self.cycle, app))
 
     def on_body(self, body: bytes) -> None:
-        if (self.parser.should_upgrade() and not self.is_http2) or self.cycle.response_complete:
+        if (
+            self.parser.should_upgrade() and not self.is_http2
+        ) or self.cycle.response_complete:
             return
         self.cycle.body += body
         if len(self.cycle.body) > HIGH_WATER_LIMIT:
@@ -304,7 +306,9 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.cycle.message_event.set()
 
     def on_message_complete(self) -> None:
-        if (self.parser.should_upgrade() and not self.is_http2) or self.cycle.response_complete:
+        if (
+            self.parser.should_upgrade() and not self.is_http2
+        ) or self.cycle.response_complete:
             return
         self.cycle.more_body = False
         self.cycle.message_event.set()


### PR DESCRIPTION
(Fix for https://github.com/encode/uvicorn/issues/1501)

MDN (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade) says: 

_The server can choose to ignore the request, for any reason, in which case it should just respond as though the Upgrade header had not been sent (for example, with a 200 OK)._

The previous implementation could only upgrade requests for WebSockets and generated errors for "Upgrade: h2c".

Example for `uvicorn example:app`:

```python
async def app(scope, receive, send):
    assert scope['type'] == 'http'

    await send({
        'type': 'http.response.start',
        'status': 200,
        'headers': [
            [b'content-type', b'text/plain'],
        ],
    })
    await send({
        'type': 'http.response.body',

```

With this patch the server will send the correct result:

```bash
$ curl -v --http2 localhost:8000
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.81.0
> Accept: */*
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AAMAAABkAAQCAAAAAAIAAAAA
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< date: Sun, 11 Sep 2022 21:14:15 GMT
< server: uvicorn
< content-type: text/plain
< transfer-encoding: chunked
<
* Connection #0 to host localhost left intact
```

Previous behaviour:

```bash
$ curl -v --http2 localhost:8000
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.81.0
> Accept: */*
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AAMAAABkAAQCAAAAAAIAAAAA
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 400 Bad Request
< content-type: text/plain; charset=utf-8
< connection: close
< Transfer-Encoding: chunked
<
* Closing connection 0
Unsupported upgrade request.
```