### PR TITLE
Bump minimal `httptools` version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 [project.optional-dependencies]
 standard = [
     "colorama>=0.4;sys_platform == 'win32'",
-    "httptools>=0.4.0",
+    "httptools>=0.5.0",
     "python-dotenv>=0.13",
     "PyYAML>=5.1",
     "uvloop>=0.14.0,!=0.15.0,!=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",


### PR DESCRIPTION
Bumping minimal version due to security issue on `httptools`.

Reference: https://github.com/MagicStack/httptools/issues/82