### PR TITLE
add note in Settings on using WatchFiles on WSL

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -40,7 +40,7 @@ If Uvicorn _cannot_ load [watchfiles](https://pypi.org/project/watchfiles/) at r
 
 For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Uvicorn can see it.
 
-Note that if you use Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), for example when running a Docker container on Windows, you might have to set the environment variable `WATCHFILES_FORCE_POLLING`, for file changes to trigger a reload.
+Note that if you use Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), for example when running a Docker container on Windows, you might have to set the environment variable `WATCHFILES_FORCE_POLLING`, for file changes to trigger a reload. See [watchfiles documentation](https://watchfiles.helpmanual.io/api/watch/) for further details.
 
 Using Uvicorn with watchfiles will enable the following options (which are otherwise ignored).
 * `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in `--reload-exclude`.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -38,8 +38,11 @@ If Uvicorn _cannot_ load [watchfiles](https://pypi.org/project/watchfiles/) at r
 
 ### Reloading with watchfiles
 
-For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Uvicorn can see it. This will enable the following options (which are otherwise ignored).
+For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Uvicorn can see it.
 
+Note that if you use Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), for example when running a Docker container on Windows, you have to set the environment variable `WATCHFILES_FORCE_POLLING` to `True`, otherwise reloading will silently fail.
+
+Using Uvicorn with watchfiles will enable the following options (which are otherwise ignored).
 * `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in `--reload-exclude`.
 * `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These defaults can be overwritten by including them in `--reload-include`.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -40,12 +40,15 @@ If Uvicorn _cannot_ load [watchfiles](https://pypi.org/project/watchfiles/) at r
 
 For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Uvicorn can see it.
 
-Note that if you use Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), for example when running a Docker container on Windows, you might have to set the environment variable `WATCHFILES_FORCE_POLLING`, for file changes to trigger a reload. See [watchfiles documentation](https://watchfiles.helpmanual.io/api/watch/) for further details.
-
 Using Uvicorn with watchfiles will enable the following options (which are otherwise ignored).
 
 * `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in `--reload-exclude`.
 * `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These defaults can be overwritten by including them in `--reload-include`.
+
+!!! tip
+    When using Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), you might
+    have to set the `WATCHFILES_FORCE_POLLING` environment variable, for file changes to trigger a reload.
+    See [watchfiles documentation](https://watchfiles.helpmanual.io/api/watch/) for further details.
 
 ## Production
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -43,6 +43,7 @@ For more nuanced control over which file modifications trigger reloads, install 
 Note that if you use Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), for example when running a Docker container on Windows, you might have to set the environment variable `WATCHFILES_FORCE_POLLING`, for file changes to trigger a reload. See [watchfiles documentation](https://watchfiles.helpmanual.io/api/watch/) for further details.
 
 Using Uvicorn with watchfiles will enable the following options (which are otherwise ignored).
+
 * `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in `--reload-exclude`.
 * `--reload-exclude <glob-pattern>` - Specify a glob pattern to match files or directories which will excluded from watching. May be used multiple times. By default the following patterns are excluded: `.*, .py[cod], .sw.*, ~*`. These defaults can be overwritten by including them in `--reload-include`.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -40,7 +40,7 @@ If Uvicorn _cannot_ load [watchfiles](https://pypi.org/project/watchfiles/) at r
 
 For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Uvicorn can see it.
 
-Note that if you use Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), for example when running a Docker container on Windows, you have to set the environment variable `WATCHFILES_FORCE_POLLING` to `True`, otherwise reloading will silently fail.
+Note that if you use Uvicorn through [WSL](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux), for example when running a Docker container on Windows, you might have to set the environment variable `WATCHFILES_FORCE_POLLING`, for file changes to trigger a reload.
 
 Using Uvicorn with watchfiles will enable the following options (which are otherwise ignored).
 * `--reload-include <glob-pattern>` - Specify a glob pattern to match files or directories which will be watched. May be used multiple times. By default the following patterns are included: `*.py`. These defaults can be overwritten by including them in `--reload-exclude`.


### PR DESCRIPTION
Following a frustrating 2hours of debugging why reloading stopped working when I rebuilt my Docker contrainer with uvicorn recently, stumbling upon @samuelcolvin 's very helpful comment on `WATCHFILES_FORCE_POLLING`, and @Kludex 's subtle hint that PR's are welcome to improve the documentation.... here's a PR that improves the documentation.

Relates to the discussion here: https://github.com/encode/uvicorn/pull/1437

Hope it's helpful!