### PR TITLE
Change Server.started to asyncio.Event

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -50,7 +50,7 @@ class Server:
         self.config = config
         self.server_state = ServerState()
 
-        self.started = False
+        self.started = asyncio.Event()
         self.should_exit = False
         self.force_exit = False
         self.last_notified = 0.0
@@ -169,7 +169,7 @@ class Server:
             # logged by `config.bind_socket()`.
             pass
 
-        self.started = True
+        self.started.set()
 
     def _log_started_message(self, listeners: Sequence[socket.SocketType]) -> None:
         config = self.config


### PR DESCRIPTION
It doesn't seem to possible to get notified when the server has started, because `Server.started` is currently a `bool`.
Changing it to an `asyncio.Event` would make it possible, by awaiting `Server.started.wait()`, but this is a breaking change. Other options would be to add a new `Server.started_event: asyncio.Event`, or to be able to register a callback.