### PR TITLE
Revert "Use updated headers from server state"

### DIFF
--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -1,7 +1,3 @@
-import asyncio
-import datetime as dt
-import sys
-
 import httpx
 import pytest
 
@@ -22,28 +18,6 @@ async def test_default_default_headers():
         async with httpx.AsyncClient() as client:
             response = await client.get("http://127.0.0.1:8000")
             assert response.headers["server"] == "uvicorn" and response.headers["date"]
-
-
-@pytest.mark.skipif(
-    sys.platform != "linux",
-    reason="This fails on other OSs. If you know why, please help us.",
-)
-@pytest.mark.anyio
-async def test_date_headers_update():  # pragma: no cover
-    config = Config(app=app, loop="asyncio")
-    async with run_server(config):
-        async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
-            date = response.headers["date"]
-            first_date = dt.datetime.strptime(date, "%a, %d %b %Y %H:%M:%S %Z")
-
-            await asyncio.sleep(1)
-
-            response = await client.get("http://127.0.0.1:8000")
-            date = response.headers["date"]
-            second_date = dt.datetime.strptime(date, "%a, %d %b %Y %H:%M:%S %Z")
-
-            assert second_date - first_date == dt.timedelta(seconds=1)
 
 
 @pytest.mark.anyio

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -92,6 +92,7 @@ class H11Protocol(asyncio.Protocol):
         self.server_state = server_state
         self.connections = server_state.connections
         self.tasks = server_state.tasks
+        self.default_headers = server_state.default_headers
 
         # Per-connection state
         self.transport: asyncio.Transport = None  # type: ignore[assignment]
@@ -229,7 +230,7 @@ class H11Protocol(asyncio.Protocol):
                     logger=self.logger,
                     access_logger=self.access_logger,
                     access_log=self.access_log,
-                    default_headers=self.server_state.default_headers,
+                    default_headers=self.default_headers,
                     message_event=asyncio.Event(),
                     on_response=self.on_response_complete,
                 )

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -90,6 +90,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.server_state = server_state
         self.connections = server_state.connections
         self.tasks = server_state.tasks
+        self.default_headers = server_state.default_headers
 
         # Per-connection state
         self.transport: asyncio.Transport = None  # type: ignore[assignment]
@@ -198,7 +199,7 @@ class HttpToolsProtocol(asyncio.Protocol):
     def send_400_response(self, msg: str) -> None:
 
         content = [STATUS_LINE[400]]
-        for name, value in self.server_state.default_headers:
+        for name, value in self.default_headers:
             content.extend([name, b": ", value, b"\r\n"])
         content.extend(
             [
@@ -273,7 +274,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             logger=self.logger,
             access_logger=self.access_logger,
             access_log=self.access_log,
-            default_headers=self.server_state.default_headers,
+            default_headers=self.default_headers,
             message_event=asyncio.Event(),
             expect_100_continue=self.expect_100_continue,
             keep_alive=http_version != "1.0",


### PR DESCRIPTION
Reverts encode/uvicorn#1665

It fails on Ubuntu as well. It was just luck. cc @euri10 

I'll create a PR without any test, unless you have a better idea.

See: https://github.com/encode/uvicorn/pull/1606#issuecomment-1259219877