### PR TITLE
Implement `--limit-request-header-count` flag

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,6 +97,8 @@ Options:
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
+  --limit-request-header-count INTEGER
+                                  Maximum number of HTTP headers to accept.
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
   --limit-max-requests INTEGER    Maximum number of requests to service before

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,8 @@ Options:
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
+  --limit-request-header-count INTEGER
+                                  Maximum number of HTTP headers to accept.
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
   --limit-max-requests INTEGER    Maximum number of requests to service before

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -14,7 +14,6 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
-    Final,
     List,
     Optional,
     Tuple,
@@ -90,7 +89,7 @@ INTERFACES: List[InterfaceType] = ["auto", "asgi3", "asgi2", "wsgi"]
 
 # Use the same value as gunicorn
 # https://github.com/benoitc/gunicorn/blob/cf55d2cec277f220ebd605989ce78ad1bb553c46/gunicorn/http/message.py#L21
-MAX_HEADERS: Final = 32768
+MAX_HEADERS = 32768
 SSL_PROTOCOL_VERSION: int = ssl.PROTOCOL_TLS_SERVER
 
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -14,6 +14,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Final,
     List,
     Optional,
     Tuple,
@@ -87,7 +88,9 @@ LOOP_SETUPS: Dict[LoopSetupType, Optional[str]] = {
 }
 INTERFACES: List[InterfaceType] = ["auto", "asgi3", "asgi2", "wsgi"]
 
-
+# Use the same value as gunicorn
+# https://github.com/benoitc/gunicorn/blob/cf55d2cec277f220ebd605989ce78ad1bb553c46/gunicorn/http/message.py#L21
+MAX_HEADERS: Final = 32768
 SSL_PROTOCOL_VERSION: int = ssl.PROTOCOL_TLS_SERVER
 
 
@@ -240,6 +243,7 @@ class Config:
         root_path: str = "",
         limit_concurrency: Optional[int] = None,
         limit_max_requests: Optional[int] = None,
+        limit_request_header_count: int = 100,
         backlog: int = 2048,
         timeout_keep_alive: int = 5,
         timeout_notify: int = 30,
@@ -282,6 +286,7 @@ class Config:
         self.root_path = root_path
         self.limit_concurrency = limit_concurrency
         self.limit_max_requests = limit_max_requests
+        self.limit_request_header_count = min(limit_request_header_count, MAX_HEADERS)
         self.backlog = backlog
         self.timeout_keep_alive = timeout_keep_alive
         self.timeout_notify = timeout_notify

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -256,6 +256,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     " HTTP 503 responses.",
 )
 @click.option(
+    "--limit-request-header-count",
+    type=int,
+    default=100,
+    help="Maximum number of HTTP headers to accept.",
+)
+@click.option(
     "--backlog",
     type=int,
     default=2048,
@@ -385,6 +391,7 @@ def main(
     forwarded_allow_ips: str,
     root_path: str,
     limit_concurrency: int,
+    limit_request_header_count: int,
     backlog: int,
     limit_max_requests: int,
     timeout_keep_alive: int,
@@ -432,6 +439,7 @@ def main(
         forwarded_allow_ips=forwarded_allow_ips,
         root_path=root_path,
         limit_concurrency=limit_concurrency,
+        limit_request_header_count=limit_request_header_count,
         backlog=backlog,
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
@@ -484,6 +492,7 @@ def run(
     forwarded_allow_ips: typing.Optional[typing.Union[typing.List[str], str]] = None,
     root_path: str = "",
     limit_concurrency: typing.Optional[int] = None,
+    limit_request_header_count: int = 100,
     backlog: int = 2048,
     limit_max_requests: typing.Optional[int] = None,
     timeout_keep_alive: int = 5,
@@ -534,6 +543,7 @@ def run(
         forwarded_allow_ips=forwarded_allow_ips,
         root_path=root_path,
         limit_concurrency=limit_concurrency,
+        limit_request_header_count=limit_request_header_count,
         backlog=backlog,
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,

--- a/uvicorn/protocols/http/app_factory.py
+++ b/uvicorn/protocols/http/app_factory.py
@@ -1,0 +1,43 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application as ASGIApp,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        Scope,
+    )
+
+
+def create_app(status_code: int, message: str) -> "ASGIApp":
+    """
+    Create an ASGI application that always returns the given status code and message
+    in the body.
+
+    Used for handling errors in the HTTP protocol implementations.
+    """
+
+    async def app(
+        scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ) -> None:
+        response_start: "HTTPResponseStartEvent" = {
+            "type": "http.response.start",
+            "status": status_code,
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"content-length", str(len(message)).encode("ascii")),
+                (b"connection", b"close"),
+            ],
+        }
+        await send(response_start)
+
+        response_body: "HTTPResponseBodyEvent" = {
+            "type": "http.response.body",
+            "body": message.encode("utf-8"),
+            "more_body": False,
+        }
+        await send(response_body)
+
+    return app

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,14 +1,4 @@
 import asyncio
-import typing
-
-if typing.TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGIReceiveCallable,
-        ASGISendCallable,
-        HTTPResponseBodyEvent,
-        HTTPResponseStartEvent,
-        Scope,
-    )
 
 CLOSE_HEADER = (b"connection", b"close")
 
@@ -45,24 +35,3 @@ class FlowControl:
         if self.write_paused:
             self.write_paused = False
             self._is_writable_event.set()
-
-
-async def service_unavailable(
-    scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
-) -> None:
-    response_start: "HTTPResponseStartEvent" = {
-        "type": "http.response.start",
-        "status": 503,
-        "headers": [
-            (b"content-type", b"text/plain; charset=utf-8"),
-            (b"connection", b"close"),
-        ],
-    }
-    await send(response_start)
-
-    response_body: "HTTPResponseBodyEvent" = {
-        "type": "http.response.body",
-        "body": b"Service Unavailable",
-        "more_body": False,
-    }
-    await send(response_body)

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -9,11 +9,11 @@ import h11
 
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
+from uvicorn.protocols.http.app_factory import create_app
 from uvicorn.protocols.http.flow_control import (
     CLOSE_HEADER,
     HIGH_WATER_LIMIT,
     FlowControl,
-    service_unavailable,
 )
 from uvicorn.protocols.utils import (
     get_client_addr,
@@ -215,9 +215,13 @@ class H11Protocol(asyncio.Protocol):
                     len(self.connections) >= self.limit_concurrency
                     or len(self.tasks) >= self.limit_concurrency
                 ):
-                    app = service_unavailable
+                    app = create_app(503, "Service Unavailable")
                     message = "Exceeded concurrency limit."
                     self.logger.warning(message)
+                elif len(self.headers) >= self.config.limit_request_header_count:
+                    message = "Too many headers in request."
+                    self.logger.warning(message)
+                    app = create_app(400, message)
                 else:
                     app = self.app
 

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -39,6 +39,7 @@ class UvicornWorker(Worker):
             "timeout_notify": self.timeout,
             "callback_notify": self.callback_notify,
             "limit_max_requests": self.max_requests,
+            "limit_request_header_count": self.cfg.limit_request_fields,
             "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
         }
 


### PR DESCRIPTION
## Description

This PR implements the flag `--limit-request-header-count` proposed on #157.

## Notes

- I thought [431](https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-431-status-code/) would make sense, but no. That's only on the size, not the number of headers. Also, [`gunicorn` also sends 400](https://github.com/benoitc/gunicorn/blob/cf55d2cec277f220ebd605989ce78ad1bb553c46/gunicorn/workers/base.py#L208-L233).

## Checklist

- [ ] Make sure the flag is properly passed from `gunicorn` to `uvicorn`.
	`limit_request_fields` :arrow_right: `limit_request_header_count`.

## Questions

Q.: Should we actually match the name to `gunicorn`?
A.: Nah, I think the name here makes more sense.

Q.: Is this implementation correct? We should not check the length of the headers when we already have the size, right? We should check it when we already know that we have more headers than what is allowed!
A.: ???