### PR TITLE
Implement `--limit-request-header-count` flag

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,6 +97,10 @@ Options:
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
+  --limit-request-header-count INTEGER
+                                  Maximum number of HTTP headers to accept.
+                                  Defaults to 100, and it can't be larger than
+                                  32768.
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
   --limit-max-requests INTEGER    Maximum number of requests to service before

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,10 @@ Options:
   --limit-concurrency INTEGER     Maximum number of concurrent connections or
                                   tasks to allow, before issuing HTTP 503
                                   responses.
+  --limit-request-header-count INTEGER
+                                  Maximum number of HTTP headers to accept.
+                                  Defaults to 100, and it can't be larger than
+                                  32768.
   --backlog INTEGER               Maximum number of connections to hold in
                                   backlog
   --limit-max-requests INTEGER    Maximum number of requests to service before

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -88,6 +88,9 @@ LOOP_SETUPS: Dict[LoopSetupType, Optional[str]] = {
 INTERFACES: List[InterfaceType] = ["auto", "asgi3", "asgi2", "wsgi"]
 
 
+# Use the same value as gunicorn
+# https://github.com/benoitc/gunicorn/blob/cf55d2cec277f220ebd605989ce78ad1bb553c46/gunicorn/http/message.py#L21
+MAX_HEADERS = 32768
 SSL_PROTOCOL_VERSION: int = ssl.PROTOCOL_TLS_SERVER
 
 
@@ -240,6 +243,7 @@ class Config:
         root_path: str = "",
         limit_concurrency: Optional[int] = None,
         limit_max_requests: Optional[int] = None,
+        limit_request_header_count: int = 100,
         backlog: int = 2048,
         timeout_keep_alive: int = 5,
         timeout_notify: int = 30,
@@ -282,6 +286,7 @@ class Config:
         self.root_path = root_path
         self.limit_concurrency = limit_concurrency
         self.limit_max_requests = limit_max_requests
+        self.limit_request_header_count = min(limit_request_header_count, MAX_HEADERS)
         self.backlog = backlog
         self.timeout_keep_alive = timeout_keep_alive
         self.timeout_notify = timeout_notify

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -256,6 +256,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     " HTTP 503 responses.",
 )
 @click.option(
+    "--limit-request-header-count",
+    type=int,
+    default=100,
+    help="Maximum number of HTTP headers to accept. "
+    "Defaults to 100, and it can't be larger than 32768.",
+)
+@click.option(
     "--backlog",
     type=int,
     default=2048,
@@ -385,6 +392,7 @@ def main(
     forwarded_allow_ips: str,
     root_path: str,
     limit_concurrency: int,
+    limit_request_header_count: int,
     backlog: int,
     limit_max_requests: int,
     timeout_keep_alive: int,
@@ -432,6 +440,7 @@ def main(
         forwarded_allow_ips=forwarded_allow_ips,
         root_path=root_path,
         limit_concurrency=limit_concurrency,
+        limit_request_header_count=limit_request_header_count,
         backlog=backlog,
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
@@ -484,6 +493,7 @@ def run(
     forwarded_allow_ips: typing.Optional[typing.Union[typing.List[str], str]] = None,
     root_path: str = "",
     limit_concurrency: typing.Optional[int] = None,
+    limit_request_header_count: int = 100,
     backlog: int = 2048,
     limit_max_requests: typing.Optional[int] = None,
     timeout_keep_alive: int = 5,

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -39,6 +39,7 @@ class UvicornWorker(Worker):
             "timeout_notify": self.timeout,
             "callback_notify": self.callback_notify,
             "limit_max_requests": self.max_requests,
+            "limit_request_header_count": self.cfg.limit_request_fields,
             "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
         }
 


### PR DESCRIPTION
- Replaces #1682

Please check #1682 before reviewing this.

## Checklist

- [ ] h11 implementation. See https://github.com/python-hyper/h11/issues/155 for more information.
- [ ] Check if the flag `limit_request_fields` on `gunicorn` is correctly passed to `uvicorn`.
- [ ] Add an entry to "Resource Limits" section in the documentation.