### PR TITLE
Implement `--timeout-request-start` flag

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -241,6 +241,7 @@ class Config:
         limit_concurrency: Optional[int] = None,
         limit_max_requests: Optional[int] = None,
         backlog: int = 2048,
+        timeout_request_start: int = 10,
         timeout_keep_alive: int = 5,
         timeout_notify: int = 30,
         callback_notify: Optional[Callable[..., Awaitable[None]]] = None,
@@ -283,6 +284,7 @@ class Config:
         self.limit_concurrency = limit_concurrency
         self.limit_max_requests = limit_max_requests
         self.backlog = backlog
+        self.timeout_request_start = timeout_request_start
         self.timeout_keep_alive = timeout_keep_alive
         self.timeout_notify = timeout_notify
         self.callback_notify = callback_notify

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -268,6 +268,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     help="Maximum number of requests to service before terminating the process.",
 )
 @click.option(
+    "--timeout-request-start",
+    type=int,
+    default=10,
+    help="Timeout unless request headers complete within this time.",
+    show_default=True,
+)
+@click.option(
     "--timeout-keep-alive",
     type=int,
     default=5,
@@ -387,6 +394,7 @@ def main(
     limit_concurrency: int,
     backlog: int,
     limit_max_requests: int,
+    timeout_request_start: int,
     timeout_keep_alive: int,
     ssl_keyfile: str,
     ssl_certfile: str,
@@ -434,6 +442,7 @@ def main(
         limit_concurrency=limit_concurrency,
         backlog=backlog,
         limit_max_requests=limit_max_requests,
+        timeout_request_start=timeout_request_start,
         timeout_keep_alive=timeout_keep_alive,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
@@ -486,6 +495,7 @@ def run(
     limit_concurrency: typing.Optional[int] = None,
     backlog: int = 2048,
     limit_max_requests: typing.Optional[int] = None,
+    timeout_request_start: int = 10,
     timeout_keep_alive: int = 5,
     ssl_keyfile: typing.Optional[str] = None,
     ssl_certfile: typing.Optional[typing.Union[str, os.PathLike]] = None,
@@ -536,6 +546,7 @@ def run(
         limit_concurrency=limit_concurrency,
         backlog=backlog,
         limit_max_requests=limit_max_requests,
+        timeout_request_start=timeout_request_start,
         timeout_keep_alive=timeout_keep_alive,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,


### PR DESCRIPTION
- This PR implements one of the timeout flags mentioned on https://github.com/encode/uvicorn/issues/157.

The expected behavior from the client's perspective is to have an exception - if using a Python client.