### PR TITLE
Override default --reload-dir if passing sub-directories of cwd

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import signal
 from pathlib import Path
@@ -207,26 +208,28 @@ class TestBaseReload:
     @pytest.mark.parametrize(
         "reloader_class", [StatReload, WatchGodReload, WatchFilesReload]
     )
+    @pytest.mark.parametrize("cwd_context", [as_cwd, contextlib.nullcontext])
     def test_should_not_reload_when_only_subdirectory_is_watched(
-        self, touch_soon
+        self, touch_soon, cwd_context
     ) -> None:
-        app_dir = self.reload_path / "app"
-        app_dir_file = self.reload_path / "app" / "src" / "main.py"
-        root_file = self.reload_path / "main.py"
+        with cwd_context(self.reload_path):
+            app_dir = self.reload_path / "app"
+            app_dir_file = self.reload_path / "app" / "src" / "main.py"
+            root_file = self.reload_path / "main.py"
 
-        config = Config(
-            app="tests.test_config:asgi_app",
-            reload=True,
-            reload_dirs=[str(app_dir)],
-        )
-        reloader = self._setup_reloader(config)
+            config = Config(
+                app="tests.test_config:asgi_app",
+                reload=True,
+                reload_dirs=[str(app_dir)],
+            )
+            reloader = self._setup_reloader(config)
 
-        assert self._reload_tester(touch_soon, reloader, app_dir_file)
-        assert not self._reload_tester(
-            touch_soon, reloader, root_file, app_dir / "~ignored"
-        )
+            assert self._reload_tester(touch_soon, reloader, app_dir_file)
+            assert not self._reload_tester(
+                touch_soon, reloader, root_file, app_dir / "~ignored"
+            )
 
-        reloader.shutdown()
+            reloader.shutdown()
 
     @pytest.mark.parametrize("reloader_class", [WatchFilesReload, WatchGodReload])
     def test_override_defaults(self, touch_soon) -> None:
@@ -308,16 +311,18 @@ class TestBaseReload:
 
 
 @pytest.mark.skipif(WatchFilesReload is None, reason="watchfiles not available")
-def test_should_watch_one_dir_cwd(mocker, reload_directory_structure):
+@pytest.mark.parametrize("cwd_context", [as_cwd, contextlib.nullcontext])
+@pytest.mark.parametrize("reload_dirs", [False, True])
+def test_default_watch_dir(
+    mocker, reload_directory_structure, cwd_context, reload_dirs
+):
     mock_watch = mocker.patch("uvicorn.supervisors.watchfilesreload.watch")
-    app_dir = reload_directory_structure / "app"
-    app_first_dir = reload_directory_structure / "app_first"
 
-    with as_cwd(reload_directory_structure):
+    with cwd_context(reload_directory_structure):
         config = Config(
             app="tests.test_config:asgi_app",
             reload=True,
-            reload_dirs=[str(app_dir), str(app_first_dir)],
+            reload_dirs=[Path.cwd()] if reload_dirs else [],
         )
         WatchFilesReload(config, target=run, sockets=[])
         mock_watch.assert_called_once()
@@ -325,22 +330,21 @@ def test_should_watch_one_dir_cwd(mocker, reload_directory_structure):
 
 
 @pytest.mark.skipif(WatchFilesReload is None, reason="watchfiles not available")
-def test_should_watch_separate_dirs_outside_cwd(mocker, reload_directory_structure):
+@pytest.mark.parametrize("cwd_context", [as_cwd, contextlib.nullcontext])
+def test_should_watch_separate_dirs(mocker, reload_directory_structure, cwd_context):
     mock_watch = mocker.patch("uvicorn.supervisors.watchfilesreload.watch")
     app_dir = reload_directory_structure / "app"
     app_first_dir = reload_directory_structure / "app_first"
-    config = Config(
-        app="tests.test_config:asgi_app",
-        reload=True,
-        reload_dirs=[str(app_dir), str(app_first_dir)],
-    )
-    WatchFilesReload(config, target=run, sockets=[])
-    mock_watch.assert_called_once()
-    assert set(mock_watch.call_args[0]) == {
-        app_dir,
-        app_first_dir,
-        Path.cwd(),
-    }
+
+    with cwd_context(reload_directory_structure):
+        config = Config(
+            app="tests.test_config:asgi_app",
+            reload=True,
+            reload_dirs=[str(app_dir), str(app_first_dir)],
+        )
+        WatchFilesReload(config, target=run, sockets=[])
+        mock_watch.assert_called_once()
+        assert set(mock_watch.call_args[0]) == {app_dir, app_first_dir}
 
 
 def test_display_path_relative(tmp_path):

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -64,12 +64,7 @@ class WatchFilesReload(BaseReload):
     ) -> None:
         super().__init__(config, target, sockets)
         self.reloader_name = "WatchFiles"
-        self.reload_dirs = []
-        for directory in config.reload_dirs:
-            if Path.cwd() not in directory.parents:
-                self.reload_dirs.append(directory)
-        if Path.cwd() not in self.reload_dirs:
-            self.reload_dirs.append(Path.cwd())
+        self.reload_dirs = list(config.reload_dirs)
 
         self.watch_filter = FileFilter(config)
         self.watcher = watch(


### PR DESCRIPTION
This PR attempts to fix hot reload if a user passes a subdirectory of the current working directory using either `--reload-dir` or `--reload-include`.

The documentation explicitly says that those options, if passed, should override the current working directory.

<!-- :cli_usage: -->
```
  --reload-dir PATH               Set reload directories explicitly, instead
                                  of using the current working directory.
```

We can see [here](https://github.com/encode/uvicorn/blob/bfc8fb392d99a574106c9f77f6fc7c791504f826/uvicorn/config.py#L347) that indeed `cwd` acts as a default value. However, the constructor of `WatchFilesReload` changes that behavior by discarding `config.reload_dirs` if `cwd` is a parent of those directories.

I've added tests to make sure `test_should_not_reload_when_only_subdirectory_is_watched` works both when `cwd` is or isn't a parent of the watched directory.
I've also adapted other tests to match the documentation about `--reload-dir`, see `test_default_watch_dir` and `test_should_watch_separate_dirs`.