### PR TITLE
Adding SIGQUIT as a handled signal

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
+    # Handling SIGQUIT Fixes
+    #    - https://github.com/encode/uvicorn/issues/1116
+    #    - https://github.com/benoitc/gunicorn/issues/2604
     signal.SIGQUIT,
 )
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
+    signal.SIGQUIT,
 )
 
 logger = logging.getLogger("uvicorn.error")


### PR DESCRIPTION
Gunicorn sends a SIGQUIT instead of a SIGINT even when it receives a SIGINT, in any case, uvicorn should be able to handle SIGQUIT as well, so this is a small fix that does that.

Fixes
- https://github.com/encode/uvicorn/issues/1116

Ref: https://github.com/benoitc/gunicorn/issues/2604
