### PR TITLE
Add `SIGQUIT` handler to `UvicornWorker`

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -252,11 +252,12 @@ class Server:
     async def shutdown(self, sockets: Optional[List[socket.socket]] = None) -> None:
         logger.info("Shutting down")
 
+        # Close the sockets first before closing the servers
+        for sock in sockets or []:
+            sock.close()
         # Stop accepting new connections.
         for server in self.servers:
             server.close()
-        for sock in sockets or []:
-            sock.close()
         for server in self.servers:
             await server.wait_closed()
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -252,12 +252,11 @@ class Server:
     async def shutdown(self, sockets: Optional[List[socket.socket]] = None) -> None:
         logger.info("Shutting down")
 
-        # Close the sockets first before closing the servers
-        for sock in sockets or []:
-            sock.close()
         # Stop accepting new connections.
         for server in self.servers:
             server.close()
+        for sock in sockets or []:
+            sock.close()
         for server in self.servers:
             await server.wait_closed()
 

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -77,7 +77,8 @@ class UvicornWorker(Worker):
         signal.siginterrupt(signal.SIGUSR1, False)
 
     def _install_sigquit_handler(self) -> None:
-        """Workaround to install a SIGQUIT handler on workers.
+        """Install a SIGQUIT handler on workers.
+
         - https://github.com/encode/uvicorn/issues/1116
         - https://github.com/benoitc/gunicorn/issues/2604
         """

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -3,7 +3,6 @@ import logging
 import signal
 import sys
 from typing import Any
-import threading
 
 from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
@@ -82,9 +81,6 @@ class UvicornWorker(Worker):
         - https://github.com/encode/uvicorn/issues/1116
         - https://github.com/benoitc/gunicorn/issues/2604
         """
-        if threading.current_thread() is not threading.main_thread():
-            # Signals can only be listened to from the main thread.
-            return
 
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(signal.SIGQUIT, self.handle_exit, signal.SIGQUIT, None)


### PR DESCRIPTION
Gunicorn sends a SIGQUIT instead of a SIGINT even when it receives a SIGINT, in any case, uvicorn should be able to handle SIGQUIT as well, so this is a small fix that does that.

Fixes
- https://github.com/encode/uvicorn/issues/1116

Ref: https://github.com/benoitc/gunicorn/issues/2604