### PR TITLE
Allowing log_config to accept ConfigParser instance or a file object

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import configparser
+import io
 import json
 import logging
 import os
@@ -414,15 +416,21 @@ def test_log_config_yaml(
     mocked_logging_config_module.dictConfig.assert_called_once_with(logging_config)
 
 
-def test_log_config_file(mocked_logging_config_module: MagicMock) -> None:
+@pytest.mark.parametrize(
+    "config_file", ["log_config.ini", configparser.ConfigParser(), io.StringIO()]
+)
+def test_log_config_file(
+    mocked_logging_config_module: MagicMock,
+    config_file: typing.Union[str, configparser.RawConfigParser, typing.IO],
+) -> None:
     """
     Test that one can load a configparser config from disk.
     """
-    config = Config(app=asgi_app, log_config="log_config")
+    config = Config(app=asgi_app, log_config=config_file)
     config.load()
 
     mocked_logging_config_module.fileConfig.assert_called_once_with(
-        "log_config", disable_existing_loggers=False
+        config_file, disable_existing_loggers=False
     )
 
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -7,8 +7,10 @@ import os
 import socket
 import ssl
 import sys
+from configparser import RawConfigParser
 from pathlib import Path
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
     Awaitable,
@@ -209,7 +211,9 @@ class Config:
         ws_per_message_deflate: bool = True,
         lifespan: LifespanType = "auto",
         env_file: Optional[Union[str, os.PathLike]] = None,
-        log_config: Optional[Union[Dict[str, Any], str]] = LOGGING_CONFIG,
+        log_config: Optional[
+            Union[Dict[str, Any], str, RawConfigParser, IO]
+        ] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
         use_colors: Optional[bool] = None,
@@ -397,11 +401,13 @@ class Config:
                         "use_colors"
                     ] = self.use_colors
                 logging.config.dictConfig(self.log_config)
-            elif self.log_config.endswith(".json"):
+            elif isinstance(self.log_config, str) and self.log_config.endswith(".json"):
                 with open(self.log_config) as file:
                     loaded_config = json.load(file)
                     logging.config.dictConfig(loaded_config)
-            elif self.log_config.endswith((".yaml", ".yml")):
+            elif isinstance(self.log_config, str) and self.log_config.endswith(
+                (".yaml", ".yml")
+            ):
                 # Install the PyYAML package or the uvicorn[standard] optional
                 # dependencies to enable this functionality.
                 import yaml

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import configparser
 import logging
 import os
 import platform
@@ -481,7 +482,9 @@ def run(
     workers: typing.Optional[int] = None,
     env_file: typing.Optional[typing.Union[str, os.PathLike]] = None,
     log_config: typing.Optional[
-        typing.Union[typing.Dict[str, typing.Any], str]
+        typing.Union[
+            typing.Dict[str, typing.Any], str, configparser.RawConfigParser, typing.IO
+        ]
     ] = LOGGING_CONFIG,
     log_level: typing.Optional[typing.Union[str, int]] = None,
     access_log: bool = True,


### PR DESCRIPTION
The existing logic for the `log_config` option accepts:
* `dict` or `str` representing a JSON or YAML file name to be parsed using `logging.config.dictConfig`
* `str` representing an INI file name to be parsed using `logging.config.fileConfig`

The `logging.config.fileConfig`, however, accepts not only the file name, but possibly also an instance of `configparser.RawConfigParser` and even an open file object. Passing the instance of `configparser.RawConfigParser` (or its subclass) would be especially useful as this can accumulate configs from multiple files (`cp.read()` can be called repeatedly on different files updating its config values) instead of just a single one.

I am proposing this trivial change to allow the `log_config` option to also accept the `*ConfigParser` instance or a general file object.