### PR TITLE
Fix crash on exist with "--uds" if socket not exists

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,7 +95,6 @@ def test_cli_call_multiprocess_run() -> None:
 def test_cli_uds(tmp_path: Path) -> None:  # pragma: py-win32
     runner = CliRunner()
     uds_file = tmp_path / "uvicorn.sock"
-    uds_file.touch(exist_ok=True)
 
     with mock.patch.object(Config, "bind_socket") as mock_bind_socket:
         with mock.patch.object(Multiprocess, "run") as mock_run:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -568,7 +568,10 @@ def run(
     else:
         server.run()
     if config.uds:
-        os.remove(config.uds)  # pragma: py-win32
+        try:
+            os.remove(config.uds)  # pragma: py-win32
+        except FileNotFoundError:
+            pass
 
     if not server.started and not config.should_reload and config.workers == 1:
         sys.exit(STARTUP_FAILURE)

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -567,11 +567,8 @@ def run(
         Multiprocess(config, target=server.run, sockets=[sock]).run()
     else:
         server.run()
-    if config.uds:
-        try:
-            os.remove(config.uds)  # pragma: py-win32
-        except FileNotFoundError:
-            pass
+    if config.uds and os.path.exists(config.uds):
+        os.remove(config.uds)  # pragma: py-win32
 
     if not server.started and not config.should_reload and config.workers == 1:
         sys.exit(STARTUP_FAILURE)


### PR DESCRIPTION
Currently uvicorn may crash when exiting if run with the "--uds" option, and if Uvicorn exits before the socket creation (For instance if the application to run crash on statup).

This PR fix the issue by ignoring the exception in that case.