### PR TITLE
Enable cache on the pipeline

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: "pip"
+          cache-dependency-path: "requirements.txt"
       - name: "Install dependencies"
         run: "scripts/install"
         shell: bash


### PR DESCRIPTION
There was a previous discussion about this: https://github.com/encode/httpx/pull/1680

One of the goals is to reduce the time on the pipeline, the other is to reduce the amount of networking resources. :pray: 

There were no arguments against this, only a note (my own) about the fact that we always need to install the latest dependencies from the `setup.py` (now `pyproject.toml`).

The thing is that the cache entry is removed (if not used) after 7 days, see [here](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy). Also, once a month we have updates via Dependabot on the `requirements.txt`, which triggers a new cache entry. Which means once a month we'll have the latest `uvicorn` dependencies - I think it's reasonable. 