### PR TITLE
Warn user when reload and workers flag are used together

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -557,3 +557,12 @@ def test_config_use_subprocess(reload, workers, expected):
     config = Config(app=asgi_app, reload=reload, workers=workers)
     config.load()
     assert config.use_subprocess == expected
+
+
+def test_warn_when_using_reload_and_workers(caplog: pytest.LogCaptureFixture) -> None:
+    Config(app=asgi_app, reload=True, workers=2)
+    assert len(caplog.records) == 1
+    assert (
+        '"workers" flag is ignored when reloading is enabled.'
+        in caplog.records[0].message
+    )

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -372,6 +372,9 @@ class Config:
         else:
             self.forwarded_allow_ips = forwarded_allow_ips
 
+        if self.reload and self.workers > 1:
+            logger.warning("Workers flag is ignored when reloading is enabled.")
+
     @property
     def asgi_version(self) -> Literal["2.0", "3.0"]:
         mapping: Dict[str, Literal["2.0", "3.0"]] = {

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -373,7 +373,7 @@ class Config:
             self.forwarded_allow_ips = forwarded_allow_ips
 
         if self.reload and self.workers > 1:
-            logger.warning("Workers flag is ignored when reloading is enabled.")
+            logger.warning('"workers" flag is ignored when reloading is enabled.')
 
     @property
     def asgi_version(self) -> Literal["2.0", "3.0"]:


### PR DESCRIPTION
Either this, or `RuntimeError` will do.