### PR TITLE
Make pyproject.toml PEP 621 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "uvicorn"
 dynamic = ["version"]
 description = "The lightning-fast ASGI server."
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.7"
 authors = [
     { name = "Tom Christie", email = "tom@tomchristie.com" },


### PR DESCRIPTION
The issue is (had issues with building this with buildroot), which requires this to be correct:

```text
$ validate-pyproject pyproject.toml                          
Invalid file: pyproject.toml
[ERROR] `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
```

For more info: https://peps.python.org/pep-0621/#license

After this change:

```text
$ validate-pyproject pyproject.toml
Valid file: pyproject.toml
```

For the record:

```text
$ validate-pyproject --version     
validate_pyproject 0.10.1
```