### PR TITLE
Check if handshake is completed before sending frame on wsproto shutdown

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 97.82
+fail_under = 97.87
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 97.87
+fail_under = 97.92
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ async def run_server(config: Config, sockets=None):
     await asyncio.sleep(0.1)
     try:
         yield server
-    except BaseException:
+    except BaseException:  # pragma: no cover
         traceback.print_exc()
     finally:
         await server.shutdown()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import traceback
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 
@@ -14,8 +13,6 @@ async def run_server(config: Config, sockets=None):
     await asyncio.sleep(0.1)
     try:
         yield server
-    except BaseException:  # pragma: no cover
-        traceback.print_exc()
     finally:
         await server.shutdown()
         task.cancel()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import traceback
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 
@@ -13,6 +14,8 @@ async def run_server(config: Config, sockets=None):
     await asyncio.sleep(0.1)
     try:
         yield server
+    except BaseException:
+        traceback.print_exc()
     finally:
         await server.shutdown()
         task.cancel()

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -345,6 +345,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
             data = await self.recv()
         except ConnectionClosed as exc:
             self.closed_event.set()
+            if self.ws_server.closing:
+                return {"type": "websocket.disconnect", "code": 1012}
             return {"type": "websocket.disconnect", "code": exc.code}
 
         msg: WebSocketReceiveEvent = {  # type: ignore[typeddict-item]

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -125,9 +125,12 @@ class WSProtocol(asyncio.Protocol):
         self.writable.set()
 
     def shutdown(self):
-        self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
-        output = self.conn.send(wsproto.events.CloseConnection(code=1012))
-        self.transport.write(output)
+        if self.handshake_complete:
+            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
+            output = self.conn.send(wsproto.events.CloseConnection(code=1012))
+            self.transport.write(output)
+        else:
+            self.send_500_response()
         self.transport.close()
 
     def on_task_complete(self, task):
@@ -222,9 +225,8 @@ class WSProtocol(asyncio.Protocol):
     async def run_asgi(self):
         try:
             result = await self.app(self.scope, self.receive, self.send)
-        except BaseException as exc:
-            msg = "Exception in ASGI application\n"
-            self.logger.error(msg, exc_info=exc)
+        except BaseException:
+            self.logger.exception("Exception in ASGI application\n")
             if not self.handshake_complete:
                 self.send_500_response()
             self.transport.close()
@@ -257,14 +259,15 @@ class WSProtocol(asyncio.Protocol):
                 extensions = []
                 if self.config.ws_per_message_deflate:
                     extensions.append(PerMessageDeflate())
-                output = self.conn.send(
-                    wsproto.events.AcceptConnection(
-                        subprotocol=subprotocol,
-                        extensions=extensions,
-                        extra_headers=extra_headers,
+                if not self.transport.is_closing():
+                    output = self.conn.send(
+                        wsproto.events.AcceptConnection(
+                            subprotocol=subprotocol,
+                            extensions=extensions,
+                            extra_headers=extra_headers,
+                        )
                     )
-                )
-                self.transport.write(output)
+                    self.transport.write(output)
 
             elif message_type == "websocket.close":
                 self.queue.put_nowait({"type": "websocket.disconnect", "code": None})


### PR DESCRIPTION
- Closes #596

I'm extremely happy about this PR. I understand WebSocket things now. :sweat_smile:

## How to test it?

Application:
```python
import asyncio


async def app(scope, receive, send):
    assert scope["type"] == "websocket"
    event = await receive()
    assert event["type"] == "websocket.connect"

    print("Go ahead, stop the server...")
    await asyncio.sleep(10)
    print("Too late!")

    await send({"type": "websocket.accept"})
```
Client (I've used curl):
```bash
curl --include \
     --no-buffer \
     --header "Connection: Upgrade" \
     --header "Upgrade: websocket" \
     --header "Host: example.com:80" \
     --header "Origin: http://example.com:80" \
     --header "Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==" \
     --header "Sec-WebSocket-Version: 13" \
     http://localhost:8000/
```

## Checklist

- [x] Include every behavior introduced here on `websockets` implementation.
- [x] Tests