### PR TITLE
Use correct WebSocket error codes

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -553,7 +553,9 @@ async def test_client_connection_lost(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_not_accept_on_connection_lost(ws_protocol_cls, http_protocol_cls):
+async def test_connection_lost_before_handshake_complete(
+    ws_protocol_cls, http_protocol_cls
+):
     send_accept_task = asyncio.Event()
     disconnect_message = {}
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -568,9 +568,7 @@ async def test_connection_lost_before_handshake_complete(
         disconnect_message = await receive()
 
     async def websocket_session(uri):
-        async with websockets.client.connect(uri):
-            while True:
-                await asyncio.sleep(0.1)
+        await websockets.client.connect(uri)
 
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
     async with run_server(config):

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -70,7 +70,7 @@ class WSProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection made", prefix)
 
     def connection_lost(self, exc):
-        self.queue.put_nowait({"type": "websocket.disconnect"})
+        self.queue.put_nowait({"type": "websocket.disconnect", "code": 1005})
         self.connections.remove(self)
 
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -267,7 +267,7 @@ class WSProtocol(asyncio.Protocol):
                     self.transport.write(output)
 
             elif message_type == "websocket.close":
-                self.queue.put_nowait({"type": "websocket.disconnect", "code": None})
+                self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     self.scope["client"],


### PR DESCRIPTION
This is a very confusing subject.

There are 4 ways for us to send `websocket.disconnect` to the application:

| WSProtocol | WebSocketProtocol | Event | Code |
| :---: | :---: | --- | --- |
| :white_check_mark: | :white_check_mark: | Server shutdown | [`1012`](https://mailarchive.ietf.org/arch/msg/hybi/P_1vbD9uyHl63nbIIbFxKMfSwcM/) (Service Restart) |
| :white_check_mark: | :white_check_mark: | Client sent close frame | Send the code passed to the server i.e. `wsproto` sends `event.code`, and `websockets` sends `exc.code` |
| :white_check_mark: | :white_check_mark: | Handshake failed | [`1006`](https://www.rfc-editor.org/rfc/rfc6455.html) (Abnormal Closure) |
| :white_check_mark: | :white_check_mark: | Connection lost without close frame | [`1005`](https://www.rfc-editor.org/rfc/rfc6455.html) (No Status Rcvd) |

Note: If the connection was lost before the handshake was completed, then it should be a `1006`.

This PR aims to match the behavior on both websockets implementations, and fixes https://github.com/encode/uvicorn/pull/1737/files#r1009855193.