### PR TITLE
Add activate virtual environment before running testing scripts

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,6 +66,11 @@ $ scripts/install
 We use custom shell scripts to automate testing, linting,
 and documentation building workflow.
 
+Activate virtual environment before testing:
+```shell
+$ source venv/bin/activate
+```
+
 To run the tests, use:
 
 ```shell


### PR DESCRIPTION
You will get an error if you don't run testing scripts in a virtual environment, which is not mentioned in the documentation. I wrote a discussion [#1755 ](https://github.com/encode/uvicorn/discussions/1755) about it.