### PR TITLE
Remove unused `handle_no_connect` on `wsproto`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 98.28
+fail_under = 98.50
 show_missing = true
 skip_covered = true
 exclude_lines =


### PR DESCRIPTION
Neither [`RejectConnection`](https://github.com/python-hyper/wsproto/blob/a7d9ff0c34567b042d025db555595bb6234f89e8/src/wsproto/events.py#L91-L127) nor [`RejectData`](https://github.com/python-hyper/wsproto/blob/a7d9ff0c34567b042d025db555595bb6234f89e8/src/wsproto/events.py#L134-L151) have the `reason` field that `handle_no_connect` assumes both have, for that, I'm pretty confident this is never reached.

What those lines try to solve, it's already handled on `data_receive`.