### PR TITLE
Experimental: integrate httparse

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,8 @@ Options:
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
-  --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
+  --http [auto|h11|httptools|httparse]
+                                  HTTP protocol implementation.  [default:
                                   auto]
   --ws [auto|none|websockets|wsproto]
                                   WebSocket protocol implementation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,8 @@ Options:
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
-  --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
+  --http [auto|h11|httptools|httparse]
+                                  HTTP protocol implementation.  [default:
                                   auto]
   --ws [auto|none|websockets|wsproto]
                                   WebSocket protocol implementation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .[standard]
 
 # Experimental
-httparse==0.1.1
+httparse==0.1.2
 
 # Type annotation
 asgiref==3.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 -e .[standard]
 
+# Experimental
+httparse==0.1.1
+
 # Type annotation
 asgiref==3.5.2
 

--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -14,6 +14,11 @@ except ImportError:  # pragma: no cover
     uvloop = None
 
 try:
+    import httparse
+except ImportError:  # pragma: no cover
+    httparse = None
+
+try:
     import httptools
 except ImportError:  # pragma: no cover
     httptools = None
@@ -46,7 +51,11 @@ async def test_http_auto():
     config = Config(app=app)
     server_state = ServerState()
     protocol = AutoHTTPProtocol(config=config, server_state=server_state)
-    expected_http = "H11Protocol" if httptools is None else "HttpToolsProtocol"
+    expected_http = (
+        "H11Protocol"
+        if httptools is None
+        else ("HttpToolsProtocol" if httparse is None else "HttparseProtocol")
+    )
     assert type(protocol).__name__ == expected_http
 
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -49,7 +49,7 @@ from uvicorn.middleware.wsgi import WSGIMiddleware
 if TYPE_CHECKING:
     from asgiref.typing import ASGIApplication
 
-HTTPProtocolType = Literal["auto", "h11", "httptools"]
+HTTPProtocolType = Literal["auto", "h11", "httptools", "httparse"]
 WSProtocolType = Literal["auto", "none", "websockets", "wsproto"]
 LifespanType = Literal["auto", "on", "off"]
 LoopSetupType = Literal["none", "auto", "asyncio", "uvloop"]
@@ -67,6 +67,7 @@ HTTP_PROTOCOLS: Dict[HTTPProtocolType, str] = {
     "auto": "uvicorn.protocols.http.auto:AutoHTTPProtocol",
     "h11": "uvicorn.protocols.http.h11_impl:H11Protocol",
     "httptools": "uvicorn.protocols.http.httptools_impl:HttpToolsProtocol",
+    "httparse": "uvicorn.protocols.http.httparse_impl:HttparseProtocol",
 }
 WS_PROTOCOLS: Dict[WSProtocolType, Optional[str]] = {
     "auto": "uvicorn.protocols.websockets.auto:AutoWebSocketsProtocol",

--- a/uvicorn/protocols/http/auto.py
+++ b/uvicorn/protocols/http/auto.py
@@ -2,13 +2,21 @@ import asyncio
 from typing import Type
 
 AutoHTTPProtocol: Type[asyncio.Protocol]
+
 try:
-    import httptools  # noqa
+    import httparse  # noqa
 except ImportError:  # pragma: no cover
-    from uvicorn.protocols.http.h11_impl import H11Protocol
+    try:
+        import httptools  # noqa
+    except ImportError:  # pragma: no cover
+        from uvicorn.protocols.http.h11_impl import H11Protocol
 
-    AutoHTTPProtocol = H11Protocol
-else:  # pragma: no cover
-    from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+        AutoHTTPProtocol = H11Protocol
+    else:  # pragma: no cover
+        from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
 
-    AutoHTTPProtocol = HttpToolsProtocol
+        AutoHTTPProtocol = HttpToolsProtocol
+else:
+    from uvicorn.protocols.http.httparse_impl import HttparseProtocol
+
+    AutoHTTPProtocol = HttparseProtocol

--- a/uvicorn/protocols/http/httparse_impl.py
+++ b/uvicorn/protocols/http/httparse_impl.py
@@ -1,0 +1,616 @@
+import asyncio
+import http
+import logging
+import re
+import sys
+import urllib
+from asyncio.events import TimerHandle
+from collections import deque
+from typing import TYPE_CHECKING, Callable, Deque, List, Optional, Tuple, Union, cast
+
+import httparse
+
+from uvicorn.config import Config
+from uvicorn.logging import TRACE_LOG_LEVEL
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    service_unavailable,
+)
+from uvicorn.protocols.utils import (
+    get_client_addr,
+    get_local_addr,
+    get_path_with_query_string,
+    get_remote_addr,
+    is_ssl,
+)
+from uvicorn.server import ServerState
+
+if sys.version_info < (3, 8):  # pragma: py-gte-38
+    from typing_extensions import Literal
+else:  # pragma: py-lt-38
+    from typing import Literal
+
+if TYPE_CHECKING:
+    from asgiref.typing import (
+        ASGI3Application,
+        ASGIReceiveEvent,
+        ASGISendEvent,
+        HTTPDisconnectEvent,
+        HTTPRequestEvent,
+        HTTPResponseBodyEvent,
+        HTTPResponseStartEvent,
+        HTTPScope,
+    )
+
+HEADER_RE = re.compile(b'[\x00-\x1F\x7F()<>@,;:[]={} \t\\"]')
+HEADER_VALUE_RE = re.compile(b"[\x00-\x1F\x7F]")
+
+
+def _get_status_line(status_code: int) -> bytes:
+    try:
+        phrase = http.HTTPStatus(status_code).phrase.encode()
+    except ValueError:
+        phrase = b""
+    return b"".join([b"HTTP/1.1 ", str(status_code).encode(), b" ", phrase, b"\r\n"])
+
+
+STATUS_LINE = {
+    status_code: _get_status_line(status_code) for status_code in range(100, 600)
+}
+
+
+class HttparseProtocol(asyncio.Protocol):
+    def __init__(
+        self,
+        config: Config,
+        server_state: ServerState,
+        _loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        if not config.loaded:
+            config.load()
+
+        self.config = config
+        self.app = config.loaded_app
+        self.loop = _loop or asyncio.get_event_loop()
+        self.logger = logging.getLogger("uvicorn.error")
+        self.access_logger = logging.getLogger("uvicorn.access")
+        self.access_log = self.access_logger.hasHandlers()
+        self.parser = httparse.RequestParser()
+        self.ws_protocol_class = config.ws_protocol_class
+        self.root_path = config.root_path
+        self.limit_concurrency = config.limit_concurrency
+
+        # Timeouts
+        self.timeout_keep_alive_task: Optional[TimerHandle] = None
+        self.timeout_keep_alive = config.timeout_keep_alive
+
+        # Global state
+        self.server_state = server_state
+        self.connections = server_state.connections
+        self.tasks = server_state.tasks
+
+        # Per-connection state
+        self.transport: asyncio.Transport = None  # type: ignore[assignment]
+        self.flow: FlowControl = None  # type: ignore[assignment]
+        self.server: Optional[Tuple[str, int]] = None
+        self.client: Optional[Tuple[str, int]] = None
+        self.scheme: Optional[Literal["http", "https"]] = None
+        self.pipeline: Deque[Tuple[RequestResponseCycle, ASGI3Application]] = deque()
+
+        # Per-request state
+        self._buffer = b""
+        self._parsed: Optional[httparse.ParsedRequest] = None
+        self.scope: HTTPScope = None  # type: ignore[assignment]
+        self.headers: List[Tuple[bytes, bytes]] = None  # type: ignore[assignment]
+        self.expect_100_continue = False
+        self.cycle: RequestResponseCycle = None  # type: ignore[assignment]
+
+    # Protocol interface
+    def connection_made(  # type: ignore[override]
+        self, transport: asyncio.Transport
+    ) -> None:
+        self.connections.add(self)
+
+        self.transport = transport
+        self.flow = FlowControl(transport)
+        self.server = get_local_addr(transport)
+        self.client = get_remote_addr(transport)
+        self.scheme = "https" if is_ssl(transport) else "http"
+
+        if self.logger.level <= TRACE_LOG_LEVEL:
+            prefix = "%s:%d - " % self.client if self.client else ""
+            self.logger.log(TRACE_LOG_LEVEL, "%sHTTP connection made", prefix)
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        self.connections.discard(self)
+
+        if self.logger.level <= TRACE_LOG_LEVEL:
+            prefix = "%s:%d - " % self.client if self.client else ""
+            self.logger.log(TRACE_LOG_LEVEL, "%sHTTP connection lost", prefix)
+
+        if self.cycle and not self.cycle.response_complete:
+            self.cycle.disconnected = True
+        if self.cycle is not None:
+            self.cycle.message_event.set()
+        if self.flow is not None:
+            self.flow.resume_writing()
+        if exc is None:
+            self.transport.close()
+            self._unset_keepalive_if_required()
+
+        self.parser = httparse.RequestParser()
+
+    def _unset_keepalive_if_required(self) -> None:
+        if self.timeout_keep_alive_task is not None:
+            self.timeout_keep_alive_task.cancel()
+            self.timeout_keep_alive_task = None
+
+    def _get_upgrade(self) -> Optional[bytes]:
+        connection = []
+        upgrade = None
+        for name, value in self.headers:
+            if name == b"connection":
+                connection = [token.lower().strip() for token in value.split(b",")]
+            if name == b"upgrade":
+                upgrade = value.lower()
+        if b"upgrade" in connection:
+            return upgrade
+        return None
+
+    def _should_upgrade_to_ws(self) -> bool:
+        if self.ws_protocol_class is None:
+            if self.config.ws == "auto":
+                msg = "Unsupported upgrade request."
+                self.logger.warning(msg)
+                msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
+                self.logger.warning(msg)
+            return False
+        return True
+
+    def data_received(self, data: bytes) -> None:
+        self._unset_keepalive_if_required()
+
+        self._buffer += data
+
+        if self._parsed is None:
+            self._attempt_to_parse_request()
+        else:
+            self._consume_body()
+
+    def eof_received(self) -> None:
+        if self._parsed is None:
+            msg = "Invalid HTTP request received."
+            self.logger.warning(msg)
+            self.send_400_response(msg)
+            return
+
+        if self.cycle is not None:
+            self.cycle.more_body = False
+            self.cycle.message_event.set()
+
+        self._parsed = None
+
+    def _attempt_to_parse_request(self) -> None:
+        try:
+            parsed = self.parser.parse(self._buffer)
+        except httparse._httparse.ParsingError:
+            return
+
+        if parsed is None:
+            return
+
+        # Rust's httparse does not validate HTTP methods, but our tests
+        # expect some basic checks like for h11 and httptools.
+        if not parsed.method.isalpha():
+            return
+
+        self._parsed = parsed
+
+        self.expect_100_continue = False
+        self.headers = []
+
+        for h in parsed.headers:
+            name = h.name.lower().encode("utf-8")
+            value = h.value
+            if name == b"expect" and value.lower() == b"100-continue":
+                self.expect_100_continue = True
+            self.headers.append((name, value))
+
+        http_version = {
+            0: "1.0",
+            1: "1.1",
+        }.get(parsed.version, str(parsed.version))
+        method = parsed.method
+        raw_path = parsed.path
+
+        path, _, query = raw_path.partition("?")
+
+        if "%" in path:
+            path = urllib.parse.unquote(path)
+
+        self.scope = {
+            "type": "http",
+            "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
+            "http_version": http_version,
+            "server": self.server,
+            "client": self.client,
+            "scheme": str(self.scheme),
+            "root_path": self.root_path,
+            "headers": self.headers,
+            "method": method,
+            "path": path,
+            "raw_path": raw_path.encode("ascii"),
+            "query_string": query.encode("ascii"),
+            "extensions": {},
+        }
+
+        upgrade = self._get_upgrade()
+        if upgrade == b"websocket" and self._should_upgrade_to_ws():
+            self._handle_websocket_upgrade()
+            return
+
+        # Handle 503 responses when 'limit_concurrency' is exceeded.
+        if self.limit_concurrency is not None and (
+            len(self.connections) >= self.limit_concurrency
+            or len(self.tasks) >= self.limit_concurrency
+        ):
+            app = service_unavailable
+            message = "Exceeded concurrency limit."
+            self.logger.warning(message)
+        else:
+            app = self.app
+
+        existing_cycle = self.cycle
+        self.cycle = RequestResponseCycle(
+            scope=self.scope,
+            transport=self.transport,
+            flow=self.flow,
+            logger=self.logger,
+            access_logger=self.access_logger,
+            access_log=self.access_log,
+            default_headers=self.server_state.default_headers,
+            message_event=asyncio.Event(),
+            expect_100_continue=self.expect_100_continue,
+            keep_alive=http_version != "1.0",
+            on_response=self._on_response_complete,
+        )
+        if existing_cycle is None or existing_cycle.response_complete:
+            # Standard case - start processing the request.
+            task = self.loop.create_task(self.cycle.run_asgi(app))
+            task.add_done_callback(self.tasks.discard)
+            self.tasks.add(task)
+        else:
+            # Pipelined HTTP requests need to be queued up.
+            self.flow.pause_reading()
+            self.pipeline.appendleft((self.cycle, app))
+
+        self._buffer = self._buffer[parsed.body_start_offset :]
+
+        if self._buffer:
+            self._consume_body()
+
+    def _handle_websocket_upgrade(self) -> None:
+        assert self._parsed is not None
+
+        if self.logger.level <= TRACE_LOG_LEVEL:
+            prefix = "%s:%d - " % self.client if self.client else ""
+            self.logger.log(TRACE_LOG_LEVEL, "%sUpgrading to WebSocket", prefix)
+
+        self.connections.discard(self)
+        method = self.scope["method"].encode("ascii")
+        target = self._parsed.path.encode("ascii")
+        output = [method, b" ", target, b" HTTP/1.1\r\n"]
+        for name, value in self.scope["headers"]:
+            output += [name, b": ", value, b"\r\n"]
+        output.append(b"\r\n")
+        protocol = self.ws_protocol_class(  # type: ignore[call-arg, misc]
+            config=self.config, server_state=self.server_state
+        )
+        protocol.connection_made(self.transport)
+        protocol.data_received(b"".join(output))
+        self.transport.set_protocol(protocol)
+
+    def send_400_response(self, msg: str) -> None:
+
+        content = [STATUS_LINE[400]]
+        for name, value in self.server_state.default_headers:
+            content.extend([name, b": ", value, b"\r\n"])
+        content.extend(
+            [
+                b"content-type: text/plain; charset=utf-8\r\n",
+                b"content-length: " + str(len(msg)).encode("ascii") + b"\r\n",
+                b"connection: close\r\n",
+                b"\r\n",
+                msg.encode("ascii"),
+            ]
+        )
+        self.transport.write(b"".join(content))
+        self.transport.close()
+
+    def _consume_body(self) -> None:
+        if self.cycle.response_complete:
+            return
+
+        body = self._buffer
+        assert body
+        self.cycle.body += body
+        self._buffer = b""
+        if len(self.cycle.body) > HIGH_WATER_LIMIT:
+            self.flow.pause_reading()
+        self.cycle.message_event.set()
+
+    def _on_response_complete(self) -> None:
+        # Callback for pipelined HTTP requests to be started.
+        self.server_state.total_requests += 1
+
+        if self.transport.is_closing():
+            return
+
+        # Set a short Keep-Alive timeout.
+        self._unset_keepalive_if_required()
+
+        self.timeout_keep_alive_task = self.loop.call_later(
+            self.timeout_keep_alive, self.timeout_keep_alive_handler
+        )
+
+        # Unpause data reads if needed.
+        self.flow.resume_reading()
+
+        # Unblock any pipelined events.
+        if self.pipeline:
+            cycle, app = self.pipeline.pop()
+            task = self.loop.create_task(cycle.run_asgi(app))
+            task.add_done_callback(self.tasks.discard)
+            self.tasks.add(task)
+
+    def shutdown(self) -> None:
+        """
+        Called by the server to commence a graceful shutdown.
+        """
+        if self.cycle is None or self.cycle.response_complete:
+            self.transport.close()
+        else:
+            self.cycle.keep_alive = False
+
+    def pause_writing(self) -> None:
+        """
+        Called by the transport when the write buffer exceeds the high water mark.
+        """
+        self.flow.pause_writing()
+
+    def resume_writing(self) -> None:
+        """
+        Called by the transport when the write buffer drops below the low water mark.
+        """
+        self.flow.resume_writing()
+
+    def timeout_keep_alive_handler(self) -> None:
+        """
+        Called on a keep-alive connection if no new data is received after a short
+        delay.
+        """
+        if not self.transport.is_closing():
+            self.transport.close()
+
+
+class RequestResponseCycle:
+    def __init__(
+        self,
+        scope: "HTTPScope",
+        transport: asyncio.Transport,
+        flow: FlowControl,
+        logger: logging.Logger,
+        access_logger: logging.Logger,
+        access_log: bool,
+        default_headers: List[Tuple[bytes, bytes]],
+        message_event: asyncio.Event,
+        expect_100_continue: bool,
+        keep_alive: bool,
+        on_response: Callable[..., None],
+    ):
+        self.scope = scope
+        self.transport = transport
+        self.flow = flow
+        self.logger = logger
+        self.access_logger = access_logger
+        self.access_log = access_log
+        self.default_headers = default_headers
+        self.message_event = message_event
+        self.on_response = on_response
+
+        # Connection state
+        self.disconnected = False
+        self.keep_alive = keep_alive
+        self.waiting_for_100_continue = expect_100_continue
+
+        # Request state
+        self.body = b""
+        self.more_body = True
+
+        # Response state
+        self.response_started = False
+        self.response_complete = False
+        self.chunked_encoding: Optional[bool] = None
+        self.expected_content_length = 0
+
+    # ASGI exception wrapper
+    async def run_asgi(self, app: "ASGI3Application") -> None:
+        try:
+            result = await app(  # type: ignore[func-returns-value]
+                self.scope, self.receive, self.send
+            )
+        except BaseException as exc:
+            msg = "Exception in ASGI application\n"
+            self.logger.error(msg, exc_info=exc)
+            if not self.response_started:
+                await self.send_500_response()
+            else:
+                self.transport.close()
+        else:
+            if result is not None:
+                msg = "ASGI callable should return None, but returned '%s'."
+                self.logger.error(msg, result)
+                self.transport.close()
+            elif not self.response_started and not self.disconnected:
+                msg = "ASGI callable returned without starting response."
+                self.logger.error(msg)
+                await self.send_500_response()
+            elif not self.response_complete and not self.disconnected:
+                msg = "ASGI callable returned without completing response."
+                self.logger.error(msg)
+                self.transport.close()
+        finally:
+            self.on_response = lambda: None
+
+    async def send_500_response(self) -> None:
+        response_start_event: "HTTPResponseStartEvent" = {
+            "type": "http.response.start",
+            "status": 500,
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"connection", b"close"),
+            ],
+        }
+        await self.send(response_start_event)
+        response_body_event: "HTTPResponseBodyEvent" = {
+            "type": "http.response.body",
+            "body": b"Internal Server Error",
+            "more_body": False,
+        }
+        await self.send(response_body_event)
+
+    # ASGI interface
+    async def send(self, message: "ASGISendEvent") -> None:
+        message_type = message["type"]
+
+        if self.flow.write_paused and not self.disconnected:
+            await self.flow.drain()
+
+        if self.disconnected:
+            return
+
+        if not self.response_started:
+            # Sending response status line and headers
+            if message_type != "http.response.start":
+                msg = "Expected ASGI message 'http.response.start', but got '%s'."
+                raise RuntimeError(msg % message_type)
+            message = cast("HTTPResponseStartEvent", message)
+
+            self.response_started = True
+            self.waiting_for_100_continue = False
+
+            status_code = message["status"]
+            headers = self.default_headers + list(message.get("headers", []))
+
+            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+                headers = headers + [CLOSE_HEADER]
+
+            if self.access_log:
+                self.access_logger.info(
+                    '%s - "%s %s HTTP/%s" %d',
+                    get_client_addr(self.scope),
+                    self.scope["method"],
+                    get_path_with_query_string(self.scope),
+                    self.scope["http_version"],
+                    status_code,
+                )
+
+            # Write response status line and headers
+            content = [STATUS_LINE[status_code]]
+
+            for name, value in headers:
+                if HEADER_RE.search(name):
+                    raise RuntimeError("Invalid HTTP header name.")
+                if HEADER_VALUE_RE.search(value):
+                    raise RuntimeError("Invalid HTTP header value.")
+
+                name = name.lower()
+                if name == b"content-length" and self.chunked_encoding is None:
+                    self.expected_content_length = int(value.decode())
+                    self.chunked_encoding = False
+                elif name == b"transfer-encoding" and value.lower() == b"chunked":
+                    self.expected_content_length = 0
+                    self.chunked_encoding = True
+                elif name == b"connection" and value.lower() == b"close":
+                    self.keep_alive = False
+                content.extend([name, b": ", value, b"\r\n"])
+
+            if (
+                self.chunked_encoding is None
+                and self.scope["method"] != "HEAD"
+                and status_code not in (204, 304)
+            ):
+                # Neither content-length nor transfer-encoding specified
+                self.chunked_encoding = True
+                content.append(b"transfer-encoding: chunked\r\n")
+
+            content.append(b"\r\n")
+            self.transport.write(b"".join(content))
+
+        elif not self.response_complete:
+            # Sending response body
+            if message_type != "http.response.body":
+                msg = "Expected ASGI message 'http.response.body', but got '%s'."
+                raise RuntimeError(msg % message_type)
+
+            body = cast(bytes, message.get("body", b""))
+            more_body = message.get("more_body", False)
+
+            # Write response body
+            if self.scope["method"] == "HEAD":
+                self.expected_content_length = 0
+            elif self.chunked_encoding:
+                if body:
+                    content = [b"%x\r\n" % len(body), body, b"\r\n"]
+                else:
+                    content = []
+                if not more_body:
+                    content.append(b"0\r\n\r\n")
+                self.transport.write(b"".join(content))
+            else:
+                num_bytes = len(body)
+                if num_bytes > self.expected_content_length:
+                    raise RuntimeError("Response content longer than Content-Length")
+                else:
+                    self.expected_content_length -= num_bytes
+                self.transport.write(body)
+
+            # Handle response completion
+            if not more_body:
+                if self.expected_content_length != 0:
+                    raise RuntimeError("Response content shorter than Content-Length")
+                self.response_complete = True
+                self.message_event.set()
+                if not self.keep_alive:
+                    self.transport.close()
+                self.on_response()
+
+        else:
+            # Response already sent
+            msg = "Unexpected ASGI message '%s' sent, after response already completed."
+            raise RuntimeError(msg % message_type)
+
+    async def receive(self) -> "ASGIReceiveEvent":
+        if self.waiting_for_100_continue and not self.transport.is_closing():
+            self.transport.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+            self.waiting_for_100_continue = False
+
+        if not self.disconnected and not self.response_complete:
+            self.flow.resume_reading()
+            await self.message_event.wait()
+            self.message_event.clear()
+
+        message: "Union[HTTPDisconnectEvent, HTTPRequestEvent]"
+        if self.disconnected or self.response_complete:
+            message = {"type": "http.disconnect"}
+        else:
+            message = {
+                "type": "http.request",
+                "body": self.body,
+                "more_body": self.more_body,
+            }
+            self.body = b""
+
+        return message

--- a/uvicorn/protocols/http/httparse_impl.py
+++ b/uvicorn/protocols/http/httparse_impl.py
@@ -195,7 +195,7 @@ class HttparseProtocol(asyncio.Protocol):
     def _attempt_to_parse_request(self) -> None:
         try:
             parsed = self.parser.parse(self._buffer)
-        except httparse._httparse.ParsingError:
+        except httparse.ParsingError:
             return
 
         if parsed is None:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -18,11 +18,14 @@ from uvicorn.config import Config
 
 if TYPE_CHECKING:
     from uvicorn.protocols.http.h11_impl import H11Protocol
+    from uvicorn.protocols.http.httparse_impl import HttparseProtocol
     from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
     from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
     from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
-    Protocols = Union[H11Protocol, HttpToolsProtocol, WSProtocol, WebSocketProtocol]
+    Protocols = Union[
+        H11Protocol, HttpToolsProtocol, HttparseProtocol, WSProtocol, WebSocketProtocol
+    ]
 
 
 HANDLED_SIGNALS = (


### PR DESCRIPTION
Hi folks,

I'm opening this PR as the result of playing with @adriangb's [httparse](https://github.com/adriangb/httparse) port this morning.

Overall, integration went fine! As this (hopefully passing) PR will attest.

This is mostly an experiment to play with both Uvicorn and httparse. I'm not sure we want to integrate, though that might be a nice [experimental feature](https://github.com/encode/uvicorn/discussions/1762) possibility? Edit: Ha! https://github.com/Kludex/uvicorn-extensions/tree/main/src/python/uvicorn-httparse @Kludex ;-)

On the Uvicorn side, there are a few things that came out of this experiment:

* I had to add `protocol.eof_received()` calls in tests. Out of consistency, I added it even when it's not _required_ (e.g. in HTTP GET requests, which don't have a body). Maybe I'm missing something here. Both `h11` and `httptools` are able to detect "no more request content will be sent" on their own (`h11` triggers the `EndOfMessage` event, and `httptools` calls the `.on_message_complete()` callback). But `httparse` works on an external `buffer`, and when asyncio gets request EOF, `data_received()` isn't called with `b""`, instead `eof_received()` is called. If I find the way h11 and httptools do this, perhaps I can do the same and not use `eof_received()`. Until then, calling this in tests has become required for `httparse`.
  * Edit: further investigation. As far as I understand, `httptools` is based on the C++ library [llhttp](https://llhttp.org/). It seems like it uses `Content-Length` to tell "enough data has been sent, request is done". Rust's `httparse` only deals with request headers (not the body), so that's the kind of checks we'd have to do ourselves. But what about `Transfer-Encoding: chunked` requests, which don't have `Content-Length`? It seems we really do want to leverage `eof_received()`.

On the `httparse` side, some interesting bits cc @adriangb:

* Rust's `httparse` doesn't do HTTP method checking. If that's correct, I think it's fair that the port doesn't do checks either. So I had to implement some basic checks myself.
* `httparse` may raise errors in case of invalid HTTP content, such as `InvalidHttpVersion`, but those exceptions aren't exposed on the library. E.g. I had to do `except httparse._httparse.ParsingError` to handle the "invalid HTTP request" case.
* Not sure which types Rust's `httparse` uses, but `parsed.method` and `parsed.path` might be better as `bytes` rather than pre-decoded `str`. h11 uses bytes, and so does httptools.

I guess the next step could be to contribute this to [Kludex/uvicorn-extensions](https://github.com/Kludex/uvicorn-extensions/tree/main/src/python/uvicorn-httparse)? This brings questions about making sure the test suite of `uvicorn-extensions` matches up to the extensive checks we do in "main" uvicorn. (Here we add `httparser` as an extra pytest parameter to `test_http.py`, but in extensions `test_http.py` would have to be copied over.)