### PR TITLE
Fix watchfiles file filtering

### DIFF
--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -85,6 +85,6 @@ class WatchFilesReload(BaseReload):
     def should_restart(self) -> Optional[List[Path]]:
         changes = next(self.watcher)
         if changes:
-            unique_paths = {Path(c[1]) for c in changes if self.watch_filter(*c)}
+            unique_paths = {Path(c[1]) for c in changes}
             return [p for p in unique_paths]
         return None


### PR DESCRIPTION
## Description

PR encode/uvicorn#1437 added file watching with `watchfiles` to a new module, `uvicorn.supervisors.watchfilesreload`. The module included a `FileFilter` class.

https://github.com/encode/uvicorn/blob/b06cc6376dfc566637a79607d5755d9519b3d6c6/uvicorn/supervisors/watchfilesreload.py#L11

Currently, the `FileFilter` class is instantiated when initializing `class WatchFilesReload`, but not passed to [`watchfiles.watch()`](https://watchfiles.helpmanual.io/api/watch/). Instead, `watchfiles.watch(watch_filter=None)` is used.

https://github.com/encode/uvicorn/blob/b06cc6376dfc566637a79607d5755d9519b3d6c6/uvicorn/supervisors/watchfilesreload.py#L74-L82

As a result, `watchfiles` does not filter out the expected changes. It detects changes to `.mypy_cache` and `.pyc` files that should be ignored.

Minimal repro:

```sh
mkdir uvicorn-watchfiles && cd $_
python3 -m venv .venv
. .venv/bin/activate
python -m pip install 'uvicorn[standard]==0.19.0' 'fastapi==0.87.0'
mkdir uvicorn_watchfiles
touch uvicorn_watchfiles/{__init__,main}.py
```

`main.py`:

```py
#!/usr/bin/env python3
import uvicorn
from fastapi import FastAPI

LOG_LEVEL = "DEBUG"
LOGGING_CONFIG = {
    "version": 1,
    "disable_existing_loggers": True,
    "formatters": {
        "uvicorn": {
            "()": "uvicorn.logging.DefaultFormatter",
            "format": "%(levelprefix)s %(name)-10s %(message)s",
        },
    },
    "handlers": {
        "default": {
            "class": "logging.StreamHandler",
            "formatter": "uvicorn",
            "level": LOG_LEVEL,
            "stream": "ext://sys.stdout",
        }
    },
    "root": {"handlers": ["default"], "level": LOG_LEVEL},
    "loggers": {
        "fastapi": {"propagate": True},
        "uvicorn": {"propagate": True},
        "uvicorn.access": {"propagate": True},
        "uvicorn.asgi": {"propagate": True},
        "uvicorn.error": {"propagate": True},
        "watchfiles.main": {"propagate": True},
    },
}

app = FastAPI()


@app.get("/")
def index():
    return {"home": "index"}


if __name__ == "__main__":
    uvicorn.run(
        "main:app",
        log_config=LOGGING_CONFIG,
        port=8100,
        reload=True,
    )

```

Start it up:

```text
~/dev/uvicorn-watchfiles via 🐍 v3.10.8 (.venv)
❯ python uvicorn_watchfiles/main.py
INFO:     uvicorn.error Will watch for changes in these directories: ['/Users/brendon/dev/uvicorn-watchfiles']
INFO:     uvicorn.error Uvicorn running on http://127.0.0.1:8100 (Press CTRL+C to quit)
INFO:     uvicorn.error Started reloader process [17460] using WatchFiles
INFO:     uvicorn.error Started server process [17462]
INFO:     uvicorn.error Waiting for application startup.
INFO:     uvicorn.error Application startup complete.
```

Save `main.py`, check the server logs, and note that `watchfiles` is detecting changes to `.mypy_cache` and `.pyc` files:

```text
DEBUG:    watchfiles.main 1 change detected: {(<Change.modified: 2>, '/Users/brendon/dev/uvicorn-watchfiles/uvicorn_watchfiles/main.py')}
WARNING:  uvicorn.error WatchFiles detected changes in 'uvicorn_watchfiles/main.py'. Reloading...
INFO:     uvicorn.error Shutting down
INFO:     uvicorn.error Waiting for application shutdown.
INFO:     uvicorn.error Application shutdown complete.
INFO:     uvicorn.error Finished server process [17462]
DEBUG:    watchfiles.main 6 changes detected: {(<Change.added: 1>, '/Users/brendon/dev/uvicorn-watchfiles/.mypy_cache/3.11/@plugins_snapshot.json'), (<Change.added: 1>, '/Users/brendon/dev/uvicorn-watchfiles/.mypy_cache/3.11/uvicorn_watchfiles/main.meta.json.14bba34c58afcb99'), (<Change.deleted: 3>, '/Users/brendon/dev/uvicorn-watchfiles/.mypy_cache/3.11/@plugins_snapshot.json.0ceebf87e3a886f7'), (<Change.added: 1>, '/Users/brendon/dev/uvicorn-watchfiles/.mypy_cache/3.11/uvicorn_watchfiles/main.meta.json'), (<Change.added: 1>, '/Users/brendon/dev/uvicorn-watchfiles/.mypy_cache/3.11/@plugins_snapshot.json.0ceebf87e3a886f7'), (<Change.deleted: 3>, '/Users/brendon/dev/uvicorn-watchfiles/.mypy_cache/3.11/uvicorn_watchfiles/main.meta.json.14bba34c58afcb99')}
INFO:     uvicorn.error Started server process [17481]
INFO:     uvicorn.error Waiting for application startup.
INFO:     uvicorn.error Application startup complete.
DEBUG:    watchfiles.main 3 changes detected: {(<Change.deleted: 3>, '/Users/brendon/dev/uvicorn-watchfiles/uvicorn_watchfiles/__pycache__/main.cpython-310.pyc.4403978160'), (<Change.added: 1>, '/Users/brendon/dev/uvicorn-watchfiles/uvicorn_watchfiles/__pycache__/main.cpython-310.pyc.4403978160'), (<Change.added: 1>, '/Users/brendon/dev/uvicorn-watchfiles/uvicorn_watchfiles/__pycache__/main.cpython-310.pyc')}
```

## Changes

This PR will:

- Update the arguments to `FileFilter.__call__` to match those expected by `watchfiles.watch()`.
- Pass the `FileFilter` instance to `watchfiles.watch()`.

When the changes from this PR are used with the minimal repro above, `watchfiles` will correctly filter out changes to `.mypy_cache` and `.pyc` files.

```text
~/dev/uvicorn-watchfiles via 🐍 v3.10.8 (.venv) took 30m39s
❯ python uvicorn_watchfiles/main.py
INFO:     uvicorn.error Will watch for changes in these directories: ['/Users/brendon/dev/uvicorn-watchfiles']
INFO:     uvicorn.error Uvicorn running on http://127.0.0.1:8100 (Press CTRL+C to quit)
INFO:     uvicorn.error Started reloader process [17571] using WatchFiles
INFO:     uvicorn.error Started server process [17573]
INFO:     uvicorn.error Waiting for application startup.
INFO:     uvicorn.error Application startup complete.
DEBUG:    watchfiles.main 1 change detected: {(<Change.modified: 2>, '/Users/brendon/dev/uvicorn-watchfiles/uvicorn_watchfiles/main.py')}
WARNING:  uvicorn.error WatchFiles detected changes in 'uvicorn_watchfiles/main.py'. Reloading...
INFO:     uvicorn.error Shutting down
INFO:     uvicorn.error Waiting for application shutdown.
INFO:     uvicorn.error Application shutdown complete.
INFO:     uvicorn.error Finished server process [17573]
INFO:     uvicorn.error Started server process [17586]
INFO:     uvicorn.error Waiting for application startup.
INFO:     uvicorn.error Application startup complete.
```

Tests pass without any changes, but it would be great to update the tests to prevent this problem from recurring.

In the future, we could simplify file filtering by removing the `FileFilter` class and using [`watchfiles` filters](https://watchfiles.helpmanual.io/api/filters/) instead. The main limitation is that `watchfiles` filters accept regular expressions for pattern matching (with `re.compile`). Uvicorn accepts globs instead of regexes.

## Related

- encode/uvicorn#1437
- samuelcolvin/watchfiles#207
