### PR TITLE
Don't send all default sec-websocket-protocol headers #1778

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -111,6 +111,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
         self.extra_headers = [
             (name.decode("latin-1"), value.decode("latin-1"))
             for name, value in server_state.default_headers
+            if name != b"sec-websocket-protocol"
         ]
 
     def connection_made(  # type: ignore[override]

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -64,7 +64,11 @@ class WSProtocol(asyncio.Protocol):
         # Shared server state
         self.connections = server_state.connections
         self.tasks = server_state.tasks
-        self.default_headers = server_state.default_headers
+        self.default_headers = [
+            (name, value)
+            for name, value in server_state.default_headers
+            if name != b"sec-websocket-protocol"
+        ]
 
         # Connection state
         self.transport: asyncio.Transport = None  # type: ignore[assignment]


### PR DESCRIPTION
Filter 'sec-websocket-protocol' out of default headers sent back from websocket connection response.

Now both websockets and wsproto implementations only send the "Sec-WebSocket-Protocol" header, which is coming from asgi app's "websocket.accept" response's subprotocol attribute.

Here are the client logs in specific use case (server using wsproto) before and after the change:

before
```
= connection is CONNECTING
> GET / HTTP/1.1
> Host: localhost:9000
> Upgrade: websocket
> Connection: Upgrade
> Sec-WebSocket-Key: AQQBEBthOKPARvgOFdjYyA==
> Sec-WebSocket-Version: 13
> Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
> Sec-WebSocket-Protocol: ocpp2.0.1
> User-Agent: Python/3.10 websockets/10.4
< HTTP/1.1 101 
< Upgrade: WebSocket
< Connection: Upgrade
< Sec-WebSocket-Accept: ArNgSce+IFih3H3Qiu+xpNrAl7g=
< Sec-WebSocket-Protocol: ocpp2.0.1
< Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=15
< date: Sun, 27 Nov 2022 12:02:55 GMT
< server: uvicorn
< sec-websocket-protocol: ocpp2.0.1, ocpp2.0, ocpp1.6
! failing connection with code 1006
x half-closing TCP connection
= connection is CLOSED
Traceback (most recent call last):
...
websockets.exceptions.InvalidHandshake: multiple subprotocols: ocpp2.0.1, ocpp2.0.1, ocpp2.0, ocpp1.6
```

after
```
= connection is CONNECTING
> GET / HTTP/1.1
> Host: localhost:9000
> Upgrade: websocket
> Connection: Upgrade
> Sec-WebSocket-Key: edu4QYLcHALRanIBdVSkgw==
> Sec-WebSocket-Version: 13
> Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits
> Sec-WebSocket-Protocol: ocpp2.0.1
> User-Agent: Python/3.10 websockets/10.4
< HTTP/1.1 101 
< Upgrade: WebSocket
< Connection: Upgrade
< Sec-WebSocket-Accept: ebunKPodFfJlZxRtANXtINO8xcM=
< Sec-WebSocket-Protocol: ocpp2.0.1
< Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=15
< date: Sun, 27 Nov 2022 09:55:51 GMT
< server: uvicorn
= connection is OPEN
= connection is CLOSING
> CLOSE 1000 (OK) [2 bytes]
< CLOSE 1000 (OK) [2 bytes]
= connection is CLOSED
```