### PR TITLE
add pyyaml to reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ wsproto==1.2.0
 build==0.8.0
 twine==4.0.1
 
+# Application
+pyyaml==6.0
+
 # Testing
 autoflake==1.7.7
 black==22.10.0


### PR DESCRIPTION
When using the `--log-config` flag, uvicorn fails if pyyaml is not installed:

```
File "/usr/local/lib/python3.9/site-packages/uvicorn/config.py", line 411, in configure_logging
    loaded_config = yaml.safe_load(file)
NameError: name 'yaml' is not defined
```