### PR TITLE
Replace `files` by `exclude` on mypy configuration

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -11,6 +11,6 @@ set -x
 ./scripts/sync-version
 ${PREFIX}black --check --diff --target-version=py37 $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
-${PREFIX}mypy --show-error-codes
+${PREFIX}mypy --show-error-codes $SOURCE_FILES
 ${PREFIX}isort --check --diff --project=uvicorn $SOURCE_FILES
 ${PREFIX}python -m tools.cli_usage --check

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,23 +6,16 @@ max-line-length = 88
 disallow_untyped_defs = True
 ignore_missing_imports = True
 follow_imports = silent
-files =
-    uvicorn/,
-    tests/middleware/test_wsgi.py,
-    tests/middleware/test_proxy_headers.py,
-    tests/test_config.py,
-    tests/test_lifespan.py,
-    tests/test_main.py,
-    tests/test_default_headers.py,
-    tests/test_cli.py,
-    tests/conftest.py,
-    tests/importer,
-    tests/response.py,
-    tests/__init__.py,
-    tests/supervisors/test_multiprocess.py,
-    tests/test_ssl.py,
-    tests/utils.py
-
+# NOTE: If you are seing this, feel free to create a PR to cover the below files.
+exclude = (?x)
+  ^(
+    |tests/protocols/test_websocket.py
+    |tests/middleware/test_logging.py
+    |tests/supervisors/test_reload.py
+    |tests/protocols/test_http.py
+    |tests/test_auto_detection.py
+    |tests/protocols/test_utils.py
+  )$
 
 [mypy-tests.*]
 disallow_untyped_defs = False


### PR DESCRIPTION
- Closes #998

The idea here is to, instead of define the files covered, we'll now ignore the ones that are not covered, so if new files are created, we don't need to add them to the list.