### PR TITLE
Fix one example in REAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ async def app(scope, receive, send):
         'type': 'http.response.start',
         'status': 200,
         'headers': [
-            [b'content-type', b'text/plain'],
+            (b'content-type', b'text/plain'),
         ],
     })
     await send({


### PR DESCRIPTION
error: List item 0 has incompatible type "List[bytes]"; expected "Tuple[bytes, bytes]"  [list-item]

Linked #998

I just spotted this example because I used it. Maybe other example contains typing mistake. This one should be fine at runtime but the type is more wide so I just fixed it. I didn't typyfied the exemple completely but can if you want.