### PR TITLE
Use unused TCP ports on the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
+import contextlib
 import os
+import socket
 import ssl
 from copy import deepcopy
 from hashlib import md5
@@ -215,3 +217,15 @@ def touch_soon():
 
     for t in threads:
         t.join()
+
+
+def _unused_port(socket_type: int) -> int:
+    """Find an unused localhost port from 1024-65535 and return it."""
+    with contextlib.closing(socket.socket(type=socket_type)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture
+def unused_tcp_port() -> int:
+    return _unused_port(socket.SOCK_STREAM)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,6 +226,8 @@ def _unused_port(socket_type: int) -> int:
         return sock.getsockname()[1]
 
 
+# This was copied from pytest-asyncio.
+# Ref.: https://github.com/pytest-dev/pytest-asyncio/blob/25d9592286682bc6dbfbf291028ff7a9594cf283/pytest_asyncio/plugin.py#L525-L527  # noqa: E501
 @pytest.fixture
 def unused_tcp_port() -> int:
     return _unused_port(socket.SOCK_STREAM)

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -168,7 +168,7 @@ async def test_default_logging(
         assert "Waiting for application startup" in messages.pop(0)
         assert "ASGI 'lifespan' protocol appears unsupported" in messages.pop(0)
         assert "Application startup complete" in messages.pop(0)
-        assert f"Uvicorn running on http://127.0.0.1" in messages.pop(0)
+        assert "Uvicorn running on http://127.0.0.1" in messages.pop(0)
         assert '"GET / HTTP/1.1" 204' in messages.pop(0)
         assert "Shutting down" in messages.pop(0)
 

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -822,7 +822,7 @@ async def test_invalid_http_request(request_line, protocol_cls, caplog):
 
 
 @pytest.mark.skipif(HttpToolsProtocol is None, reason="httptools is not installed")
-def test_fragmentation():
+def test_fragmentation(unused_tcp_port: int):
     def receive_all(sock):
         chunks = []
         while True:
@@ -837,7 +837,7 @@ def test_fragmentation():
     def send_fragmented_req(path):
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect(("127.0.0.1", 8000))
+        sock.connect(("127.0.0.1", unused_tcp_port))
         d = (
             f"GET {path} HTTP/1.1\r\n" "Host: localhost\r\n" "Connection: close\r\n\r\n"
         ).encode()
@@ -855,7 +855,7 @@ def test_fragmentation():
         sock.close()
         return resp
 
-    config = Config(app=app, http="httptools")
+    config = Config(app=app, http="httptools", port=unused_tcp_port)
     server = Server(config=config)
     t = threading.Thread(target=server.run)
     t.daemon = True

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -51,15 +51,19 @@ class WebSocketResponse:
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_invalid_upgrade(ws_protocol_cls, http_protocol_cls):
+async def test_invalid_upgrade(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     def app(scope):
         return None
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls)
+    config = Config(
+        app=app, ws=ws_protocol_cls, http=http_protocol_cls, port=unused_tcp_port
+    )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                "http://127.0.0.1:8000",
+                f"http://127.0.0.1:{unused_tcp_port}",
                 headers={
                     "upgrade": "websocket",
                     "connection": "upgrade",
@@ -85,7 +89,9 @@ async def test_invalid_upgrade(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_accept_connection(ws_protocol_cls, http_protocol_cls):
+async def test_accept_connection(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -94,9 +100,15 @@ async def test_accept_connection(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             return websocket.open
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        is_open = await open_connection("ws://127.0.0.1:8000")
+        is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert is_open
 
 
@@ -104,7 +116,7 @@ async def test_accept_connection(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_supports_permessage_deflate_extension(
-    ws_protocol_cls, http_protocol_cls
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -115,9 +127,15 @@ async def test_supports_permessage_deflate_extension(
         async with websockets.connect(url, extensions=extension_factories) as websocket:
             return [extension.name for extension in websocket.extensions]
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        extension_names = await open_connection("ws://127.0.0.1:8000")
+        extension_names = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert "permessage-deflate" in extension_names
 
 
@@ -125,7 +143,7 @@ async def test_supports_permessage_deflate_extension(
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_can_disable_permessage_deflate_extension(
-    ws_protocol_cls, http_protocol_cls
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -144,16 +162,19 @@ async def test_can_disable_permessage_deflate_extension(
         http=http_protocol_cls,
         lifespan="off",
         ws_per_message_deflate=False,
+        port=unused_tcp_port,
     )
     async with run_server(config):
-        extension_names = await open_connection("ws://127.0.0.1:8000")
+        extension_names = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert "permessage-deflate" not in extension_names
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_close_connection(ws_protocol_cls, http_protocol_cls):
+async def test_close_connection(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.close"})
@@ -165,16 +186,22 @@ async def test_close_connection(ws_protocol_cls, http_protocol_cls):
             return False
         return True  # pragma: no cover
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        is_open = await open_connection("ws://127.0.0.1:8000")
+        is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert not is_open
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_headers(ws_protocol_cls, http_protocol_cls):
+async def test_headers(ws_protocol_cls, http_protocol_cls, unused_tcp_port: int):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             headers = self.scope.get("headers")
@@ -186,16 +213,22 @@ async def test_headers(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             return websocket.open
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        is_open = await open_connection("ws://127.0.0.1:8000")
+        is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert is_open
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_extra_headers(ws_protocol_cls, http_protocol_cls):
+async def test_extra_headers(ws_protocol_cls, http_protocol_cls, unused_tcp_port: int):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send(
@@ -206,16 +239,24 @@ async def test_extra_headers(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             return websocket.response_headers
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        extra_headers = await open_connection("ws://127.0.0.1:8000")
+        extra_headers = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert extra_headers.get("extra") == "header"
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_path_and_raw_path(ws_protocol_cls, http_protocol_cls):
+async def test_path_and_raw_path(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             path = self.scope.get("path")
@@ -228,16 +269,24 @@ async def test_path_and_raw_path(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             return websocket.open
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        is_open = await open_connection("ws://127.0.0.1:8000/one%2Ftwo")
+        is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}/one%2Ftwo")
         assert is_open
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_text_data_to_client(ws_protocol_cls, http_protocol_cls):
+async def test_send_text_data_to_client(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -247,16 +296,24 @@ async def test_send_text_data_to_client(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             return await websocket.recv()
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        data = await get_data("ws://127.0.0.1:8000")
+        data = await get_data(f"ws://127.0.0.1:{unused_tcp_port}")
         assert data == "123"
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_binary_data_to_client(ws_protocol_cls, http_protocol_cls):
+async def test_send_binary_data_to_client(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -266,16 +323,24 @@ async def test_send_binary_data_to_client(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             return await websocket.recv()
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        data = await get_data("ws://127.0.0.1:8000")
+        data = await get_data(f"ws://127.0.0.1:{unused_tcp_port}")
         assert data == b"123"
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_and_close_connection(ws_protocol_cls, http_protocol_cls):
+async def test_send_and_close_connection(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -292,9 +357,15 @@ async def test_send_and_close_connection(ws_protocol_cls, http_protocol_cls):
                 is_open = False
             return (data, is_open)
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        (data, is_open) = await get_data("ws://127.0.0.1:8000")
+        (data, is_open) = await get_data(f"ws://127.0.0.1:{unused_tcp_port}")
         assert data == "123"
         assert not is_open
 
@@ -302,7 +373,9 @@ async def test_send_and_close_connection(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_text_data_to_server(ws_protocol_cls, http_protocol_cls):
+async def test_send_text_data_to_server(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -316,16 +389,24 @@ async def test_send_text_data_to_server(ws_protocol_cls, http_protocol_cls):
             await websocket.send("abc")
             return await websocket.recv()
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        data = await send_text("ws://127.0.0.1:8000")
+        data = await send_text(f"ws://127.0.0.1:{unused_tcp_port}")
         assert data == "abc"
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_binary_data_to_server(ws_protocol_cls, http_protocol_cls):
+async def test_send_binary_data_to_server(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -339,16 +420,24 @@ async def test_send_binary_data_to_server(ws_protocol_cls, http_protocol_cls):
             await websocket.send(b"abc")
             return await websocket.recv()
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        data = await send_text("ws://127.0.0.1:8000")
+        data = await send_text(f"ws://127.0.0.1:{unused_tcp_port}")
         assert data == b"abc"
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_after_protocol_close(ws_protocol_cls, http_protocol_cls):
+async def test_send_after_protocol_close(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -367,9 +456,15 @@ async def test_send_after_protocol_close(ws_protocol_cls, http_protocol_cls):
                 is_open = False
             return (data, is_open)
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        (data, is_open) = await get_data("ws://127.0.0.1:8000")
+        (data, is_open) = await get_data(f"ws://127.0.0.1:{unused_tcp_port}")
         assert data == "123"
         assert not is_open
 
@@ -377,41 +472,59 @@ async def test_send_after_protocol_close(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_missing_handshake(ws_protocol_cls, http_protocol_cls):
+async def test_missing_handshake(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     async def app(app, receive, send):
         pass
 
     async def connect(url):
         await websockets.connect(url)
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
-            await connect("ws://127.0.0.1:8000")
+            await connect(f"ws://127.0.0.1:{unused_tcp_port}")
         assert exc_info.value.status_code == 500
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_before_handshake(ws_protocol_cls, http_protocol_cls):
+async def test_send_before_handshake(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     async def app(scope, receive, send):
         await send({"type": "websocket.send", "text": "123"})
 
     async def connect(url):
         await websockets.connect(url)
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
-            await connect("ws://127.0.0.1:8000")
+            await connect(f"ws://127.0.0.1:{unused_tcp_port}")
         assert exc_info.value.status_code == 500
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_duplicate_handshake(ws_protocol_cls, http_protocol_cls):
+async def test_duplicate_handshake(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     async def app(scope, receive, send):
         await send({"type": "websocket.accept"})
         await send({"type": "websocket.accept"})
@@ -420,17 +533,25 @@ async def test_duplicate_handshake(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             _ = await websocket.recv()
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
         with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
-            await connect("ws://127.0.0.1:8000")
+            await connect(f"ws://127.0.0.1:{unused_tcp_port}")
         assert exc_info.value.code == 1006
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_asgi_return_value(ws_protocol_cls, http_protocol_cls):
+async def test_asgi_return_value(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     """
     The ASGI callable should return 'None'. If it doesn't make sure that
     the connection is closed with an error condition.
@@ -444,10 +565,16 @@ async def test_asgi_return_value(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             _ = await websocket.recv()
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
         with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
-            await connect("ws://127.0.0.1:8000")
+            await connect(f"ws://127.0.0.1:{unused_tcp_port}")
         assert exc_info.value.code == 1006
 
 
@@ -460,7 +587,9 @@ async def test_asgi_return_value(ws_protocol_cls, http_protocol_cls):
     [None, "test", False],
     ids=["none_as_reason", "normal_reason", "without_reason"],
 )
-async def test_app_close(ws_protocol_cls, http_protocol_cls, code, reason):
+async def test_app_close(
+    ws_protocol_cls, http_protocol_cls, code, reason, unused_tcp_port: int
+):
     async def app(scope, receive, send):
         while True:
             message = await receive()
@@ -485,10 +614,16 @@ async def test_app_close(ws_protocol_cls, http_protocol_cls, code, reason):
             await websocket.send("abc")
             await websocket.recv()
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
         with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
-            await websocket_session("ws://127.0.0.1:8000")
+            await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
         assert exc_info.value.code == (code or 1000)
         assert exc_info.value.reason == (reason or "")
 
@@ -496,7 +631,7 @@ async def test_app_close(ws_protocol_cls, http_protocol_cls, code, reason):
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_client_close(ws_protocol_cls, http_protocol_cls):
+async def test_client_close(ws_protocol_cls, http_protocol_cls, unused_tcp_port: int):
     async def app(scope, receive, send):
         while True:
             message = await receive()
@@ -512,15 +647,23 @@ async def test_client_close(ws_protocol_cls, http_protocol_cls):
             await websocket.ping()
             await websocket.send("abc")
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        await websocket_session("ws://127.0.0.1:8000")
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_client_connection_lost(ws_protocol_cls, http_protocol_cls):
+async def test_client_connection_lost(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     got_disconnect_event = False
 
     async def app(scope, receive, send):
@@ -540,9 +683,12 @@ async def test_client_connection_lost(ws_protocol_cls, http_protocol_cls):
         http=http_protocol_cls,
         lifespan="off",
         ws_ping_interval=0.0,
+        port=unused_tcp_port,
     )
     async with run_server(config):
-        async with websockets.client.connect("ws://127.0.0.1:8000") as websocket:
+        async with websockets.client.connect(
+            f"ws://127.0.0.1:{unused_tcp_port}"
+        ) as websocket:
             websocket.transport.close()
             await asyncio.sleep(0.1)
             got_disconnect_event_before_shutdown = got_disconnect_event
@@ -554,7 +700,7 @@ async def test_client_connection_lost(ws_protocol_cls, http_protocol_cls):
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_connection_lost_before_handshake_complete(
-    ws_protocol_cls, http_protocol_cls
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
     send_accept_task = asyncio.Event()
     disconnect_message = {}
@@ -570,9 +716,17 @@ async def test_connection_lost_before_handshake_complete(
     async def websocket_session(uri):
         await websockets.client.connect(uri)
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        task = asyncio.create_task(websocket_session("ws://127.0.0.1:8000"))
+        task = asyncio.create_task(
+            websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+        )
         await asyncio.sleep(0.1)
         task.cancel()
         send_accept_task.set()
@@ -583,7 +737,9 @@ async def test_connection_lost_before_handshake_complete(
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_send_close_on_server_shutdown(ws_protocol_cls, http_protocol_cls):
+async def test_send_close_on_server_shutdown(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     disconnect_message = {}
 
     async def app(scope, receive, send):
@@ -601,9 +757,17 @@ async def test_send_close_on_server_shutdown(ws_protocol_cls, http_protocol_cls)
             while True:
                 await asyncio.sleep(0.1)
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        task = asyncio.create_task(websocket_session("ws://127.0.0.1:8000"))
+        task = asyncio.create_task(
+            websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+        )
         await asyncio.sleep(0.1)
         disconnect_message_before_shutdown = disconnect_message
 
@@ -616,7 +780,9 @@ async def test_send_close_on_server_shutdown(ws_protocol_cls, http_protocol_cls)
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 @pytest.mark.parametrize("subprotocol", ["proto1", "proto2"])
-async def test_subprotocols(ws_protocol_cls, http_protocol_cls, subprotocol):
+async def test_subprotocols(
+    ws_protocol_cls, http_protocol_cls, subprotocol, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept", "subprotocol": subprotocol})
@@ -627,9 +793,17 @@ async def test_subprotocols(ws_protocol_cls, http_protocol_cls, subprotocol):
         ) as websocket:
             return websocket.subprotocol
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        accepted_subprotocol = await get_subprotocol("ws://127.0.0.1:8000")
+        accepted_subprotocol = await get_subprotocol(
+            f"ws://127.0.0.1:{unused_tcp_port}"
+        )
         assert accepted_subprotocol == subprotocol
 
 
@@ -661,6 +835,7 @@ async def test_send_binary_data_to_server_bigger_than_default(
     client_size_sent,
     server_size_max,
     expected_result,
+    unused_tcp_port: int,
 ):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -681,21 +856,24 @@ async def test_send_binary_data_to_server_bigger_than_default(
         http=http_protocol_cls,
         lifespan="off",
         ws_max_size=server_size_max,
+        port=unused_tcp_port,
     )
     async with run_server(config):
         if expected_result == 0:
-            data = await send_text("ws://127.0.0.1:8000")
+            data = await send_text(f"ws://127.0.0.1:{unused_tcp_port}")
             assert data == b"\x01" * client_size_sent
         else:
             with pytest.raises(websockets.ConnectionClosedError) as e:
-                data = await send_text("ws://127.0.0.1:8000")
+                data = await send_text(f"ws://127.0.0.1:{unused_tcp_port}")
             assert e.value.code == expected_result
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_server_reject_connection(ws_protocol_cls, http_protocol_cls):
+async def test_server_reject_connection(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     async def app(scope, receive, send):
         assert scope["type"] == "websocket"
 
@@ -719,16 +897,22 @@ async def test_server_reject_connection(ws_protocol_cls, http_protocol_cls):
         except Exception:
             pass
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        await websocket_session("ws://127.0.0.1:8000")
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
-    ws_protocol_cls, http_protocol_cls
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
     frames = []
     disconnect_message = {}
@@ -754,9 +938,15 @@ async def test_server_can_read_messages_in_buffer_after_close(
             await websocket.send(b"abc")
             await websocket.send(b"abc")
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        await send_text("ws://127.0.0.1:8000")
+        await send_text(f"ws://127.0.0.1:{unused_tcp_port}")
 
     assert frames == [b"abc", b"abc", b"abc"]
     assert disconnect_message == {"type": "websocket.disconnect", "code": 1000}
@@ -765,7 +955,9 @@ async def test_server_can_read_messages_in_buffer_after_close(
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_default_server_headers(ws_protocol_cls, http_protocol_cls):
+async def test_default_server_headers(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -774,16 +966,24 @@ async def test_default_server_headers(ws_protocol_cls, http_protocol_cls):
         async with websockets.connect(url) as websocket:
             return websocket.response_headers
 
-    config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config = Config(
+        app=App,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
     async with run_server(config):
-        headers = await open_connection("ws://127.0.0.1:8000")
+        headers = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert headers.get("server") == "uvicorn" and "date" in headers
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_no_server_headers(ws_protocol_cls, http_protocol_cls):
+async def test_no_server_headers(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -798,16 +998,17 @@ async def test_no_server_headers(ws_protocol_cls, http_protocol_cls):
         http=http_protocol_cls,
         lifespan="off",
         server_header=False,
+        port=unused_tcp_port,
     )
     async with run_server(config):
-        headers = await open_connection("ws://127.0.0.1:8000")
+        headers = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert "server" not in headers
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", ONLY_WS_PROTOCOL)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_no_date_header(ws_protocol_cls, http_protocol_cls):
+async def test_no_date_header(ws_protocol_cls, http_protocol_cls, unused_tcp_port: int):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send({"type": "websocket.accept"})
@@ -822,16 +1023,19 @@ async def test_no_date_header(ws_protocol_cls, http_protocol_cls):
         http=http_protocol_cls,
         lifespan="off",
         date_header=False,
+        port=unused_tcp_port,
     )
     async with run_server(config):
-        headers = await open_connection("ws://127.0.0.1:8000")
+        headers = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert "date" not in headers
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_multiple_server_header(ws_protocol_cls, http_protocol_cls):
+async def test_multiple_server_header(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
             await self.send(
@@ -853,7 +1057,8 @@ async def test_multiple_server_header(ws_protocol_cls, http_protocol_cls):
         ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
+        port=unused_tcp_port,
     )
     async with run_server(config):
-        headers = await open_connection("ws://127.0.0.1:8000")
+        headers = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert headers.get_all("Server") == ["uvicorn", "over-ridden", "another-value"]

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -12,55 +12,58 @@ async def app(scope, receive, send):
 
 
 @pytest.mark.anyio
-async def test_default_default_headers():
-    config = Config(app=app, loop="asyncio", limit_max_requests=1)
+async def test_default_default_headers(unused_tcp_port: int):
+    config = Config(app=app, loop="asyncio", limit_max_requests=1, port=unused_tcp_port)
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert response.headers["server"] == "uvicorn" and response.headers["date"]
 
 
 @pytest.mark.anyio
-async def test_override_server_header():
+async def test_override_server_header(unused_tcp_port: int):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden")],
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert (
                 response.headers["server"] == "over-ridden" and response.headers["date"]
             )
 
 
 @pytest.mark.anyio
-async def test_disable_default_server_header():
+async def test_disable_default_server_header(unused_tcp_port: int):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         server_header=False,
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert "server" not in response.headers
 
 
 @pytest.mark.anyio
-async def test_override_server_header_multiple_times():
+async def test_override_server_header_multiple_times(unused_tcp_port: int):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden"), ("Server", "another-value")],
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert (
                 response.headers["server"] == "over-ridden, another-value"
                 and response.headers["date"]
@@ -68,16 +71,17 @@ async def test_override_server_header_multiple_times():
 
 
 @pytest.mark.anyio
-async def test_add_additional_header():
+async def test_add_additional_header(unused_tcp_port: int):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("X-Additional", "new-value")],
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert (
                 response.headers["x-additional"] == "new-value"
                 and response.headers["server"] == "uvicorn"
@@ -86,14 +90,15 @@ async def test_add_additional_header():
 
 
 @pytest.mark.anyio
-async def test_disable_default_date_header():
+async def test_disable_default_date_header(unused_tcp_port: int):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         date_header=False,
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert "date" not in response.headers

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,39 +35,45 @@ def _has_ipv6(host):
 @pytest.mark.parametrize(
     "host, url",
     [
-        pytest.param(None, "http://127.0.0.1:8000", id="default"),
-        pytest.param("localhost", "http://127.0.0.1:8000", id="hostname"),
+        pytest.param(None, "http://127.0.0.1", id="default"),
+        pytest.param("localhost", "http://127.0.0.1", id="hostname"),
         pytest.param(
             "::1",
-            "http://[::1]:8000",
+            "http://[::1]",
             id="ipv6",
             marks=pytest.mark.skipif(not _has_ipv6("::1"), reason="IPV6 not enabled"),
         ),
     ],
 )
-async def test_run(host, url):
-    config = Config(app=app, host=host, loop="asyncio", limit_max_requests=1)
+async def test_run(host, url: str, unused_tcp_port: int):
+    config = Config(
+        app=app, host=host, loop="asyncio", limit_max_requests=1, port=unused_tcp_port
+    )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(url)
+            response = await client.get(f"{url}:{unused_tcp_port}")
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
-async def test_run_multiprocess():
-    config = Config(app=app, loop="asyncio", workers=2, limit_max_requests=1)
+async def test_run_multiprocess(unused_tcp_port: int):
+    config = Config(
+        app=app, loop="asyncio", workers=2, limit_max_requests=1, port=unused_tcp_port
+    )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
-async def test_run_reload():
-    config = Config(app=app, loop="asyncio", reload=True, limit_max_requests=1)
+async def test_run_reload(unused_tcp_port: int):
+    config = Config(
+        app=app, loop="asyncio", reload=True, limit_max_requests=1, port=unused_tcp_port
+    )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get("http://127.0.0.1:8000")
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -17,6 +17,7 @@ async def test_run(
     tls_certificate_server_cert_path,
     tls_certificate_private_key_path,
     tls_ca_certificate_pem_path,
+    unused_tcp_port: int,
 ):
     config = Config(
         app=app,
@@ -25,16 +26,20 @@ async def test_run(
         ssl_keyfile=tls_certificate_private_key_path,
         ssl_certfile=tls_certificate_server_cert_path,
         ssl_ca_certs=tls_ca_certificate_pem_path,
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
 async def test_run_chain(
-    tls_ca_ssl_context, tls_certificate_key_and_chain_path, tls_ca_certificate_pem_path
+    tls_ca_ssl_context,
+    tls_certificate_key_and_chain_path,
+    tls_ca_certificate_pem_path,
+    unused_tcp_port: int,
 ):
     config = Config(
         app=app,
@@ -42,24 +47,28 @@ async def test_run_chain(
         limit_max_requests=1,
         ssl_certfile=tls_certificate_key_and_chain_path,
         ssl_ca_certs=tls_ca_certificate_pem_path,
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
-async def test_run_chain_only(tls_ca_ssl_context, tls_certificate_key_and_chain_path):
+async def test_run_chain_only(
+    tls_ca_ssl_context, tls_certificate_key_and_chain_path, unused_tcp_port: int
+):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_key_and_chain_path,
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
 
@@ -69,6 +78,7 @@ async def test_run_password(
     tls_certificate_server_cert_path,
     tls_ca_certificate_pem_path,
     tls_certificate_private_key_encrypted_path,
+    unused_tcp_port: int,
 ):
     config = Config(
         app=app,
@@ -78,8 +88,9 @@ async def test_run_password(
         ssl_certfile=tls_certificate_server_cert_path,
         ssl_keyfile_password="uvicorn password for the win",
         ssl_ca_certs=tls_ca_certificate_pem_path,
+        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get("https://127.0.0.1:8000")
+            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204


### PR DESCRIPTION
There are two goals here:
1. The test suite doesn't care about other applications running on the same machine.
2. Be able to run the tests concurrently.

For 2, there's another step that needs to be done, which I don't intend to suggest yet, but people can already install `pytest-xdist`, and run `pytest -n auto`. On my machine, I'm able to run the test suite in 6 seconds, instead of the normal 53 seconds.