### PR TITLE
Remove MacOS pipeline

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
     steps:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-python@v4"


### PR DESCRIPTION
The MacOS pipeline is 10x more expensive than Linux. See on https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers, and on the image below.

![image](https://user-images.githubusercontent.com/7353520/207645396-16ed0cfb-8e5c-49c9-8a09-984ea2c0259b.png)

This affects the organization, and the people forking `uvicorn` - I run a lot of pipelines on a fork, and exhausted my free plan. :cry: 