### PR TITLE
Version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## 1.0.0 - CHANGE DATE
+
 ## 0.20.0 - 2022-11-20
 
 ### Added

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.20.0"
+__version__ = "1.0.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
I'll use this PR to track what is a prerequisite for 1.0.0.

- [ ] Allow users to customize the access logger.
- [ ] 100% test coverage - at the present moment it has 98.5%.

> **Note**
> This description may be updated from time to time.