### PR TITLE
tests: test multiprocess with sockets

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -128,6 +128,7 @@ async def test_run_multiprocess_with_sockets():
             await asyncio.sleep(0.1)
 
 
+@pytest.mark.anyio
 async def test_exit_on_create_server_with_invalid_host() -> None:
     with pytest.raises(SystemExit) as exc_info:
         config = Config(app=app, host="illegal_host")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -126,8 +126,8 @@ async def test_run_multiprocess_with_sockets():
             while not server.started:
                 await asyncio.sleep(0.1)
             await asyncio.sleep(0.1)
-            
-            
+
+
 async def test_exit_on_create_server_with_invalid_host() -> None:
     with pytest.raises(SystemExit) as exc_info:
         config = Config(app=app, host="illegal_host")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import socket
 from logging import WARNING
@@ -113,3 +114,14 @@ def test_run_match_config_params() -> None:
         if key not in ("app_dir",)
     }
     assert config_params == run_params
+
+
+@pytest.mark.anyio
+async def test_run_multiprocess_with_sockets():
+    config = Config(app=app, workers=2, limit_max_requests=1)
+    with socket.socket() as sock:
+        sock.bind(("localhost", 0))
+        async with run_server(config, sockets=[sock]) as server:
+            while not server.started:
+                await asyncio.sleep(0.1)
+            await asyncio.sleep(0.1)


### PR DESCRIPTION
Covers `server.py` line 105-125

https://github.com/encode/uvicorn/blob/d613cbea388bafafb6f642077c035ed137deea61/uvicorn/server.py#L105-L125

Before PR (Windows):
```
Name                                           Stmts   Miss     Cover   Missing
-------------------------------------------------------------------------------
uvicorn\server.py                                156     26    83.33%   105-125, 160-163, 245-247, 263, 274-277, 307-310
-------------------------------------------------------------------------------
TOTAL                                           4994     64    98.72%
```
Before PR (Ubuntu):
```
Name                                           Stmts   Miss     Cover   Missing
-------------------------------------------------------------------------------
uvicorn/server.py                                171     22    87.13%   115-125, 141, 160-163, 245-247, 263, 274-277, 307-310
-------------------------------------------------------------------------------
TOTAL                                           5102     67    98.69%
```


After PR (Windows):
```
Name                                           Stmts   Miss     Cover   Missing
-------------------------------------------------------------------------------
uvicorn\server.py                                156     15    90.38%   160-163, 245-247, 263, 274-277, 307-310
-------------------------------------------------------------------------------
TOTAL                                           5003     54    98.92%
```

After PR (Ubuntu):
```
Name                                           Stmts   Miss     Cover   Missing
-------------------------------------------------------------------------------
uvicorn/server.py                                171     16    90.64%   141, 160-163, 245-247, 263, 274-277, 307-310
-------------------------------------------------------------------------------
TOTAL                                           5111     63    98.77%
```