### PR TITLE
tests: test to start server with invalid host

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,9 +117,9 @@ def test_run_match_config_params() -> None:
 
 
 @pytest.mark.anyio
-async def test_run_invalid_host(caplog: pytest.LogCaptureFixture) -> None:
-    with pytest.raises(SystemExit):
+async def test_exit_on_create_server_with_invalid_host() -> None:
+    with pytest.raises(SystemExit) as exc_info:
         config = Config(app=app, host="illegal_host")
         server = Server(config=config)
         await server.serve()
-    assert "ERROR" == caplog.records[-1].levelname
+    assert exc_info.value.code == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,4 +122,4 @@ async def test_run_invalid_host(caplog: pytest.LogCaptureFixture) -> None:
         config = Config(app=app, host="illegal_host")
         server = Server(config=config)
         await server.serve()
-    assert "[Errno 11001] getaddrinfo failed" in caplog.records[-1].message
+    assert "ERROR" == caplog.records[-1].levelname

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from tests.utils import run_server
+from uvicorn import Server
 from uvicorn.config import Config
 from uvicorn.main import run
 
@@ -113,3 +114,12 @@ def test_run_match_config_params() -> None:
         if key not in ("app_dir",)
     }
     assert config_params == run_params
+
+
+@pytest.mark.anyio
+async def test_run_invalid_host(caplog: pytest.LogCaptureFixture) -> None:
+    with pytest.raises(SystemExit):
+        config = Config(app=app, host="illegal_host")
+        server = Server(config=config)
+        await server.serve()
+    assert "[Errno 11001] getaddrinfo failed" in caplog.records[-1].message


### PR DESCRIPTION
Covers `server.py` lines 160-163

Before PR (Ubuntu):
```
Name                                           Stmts   Miss     Cover   Missing
-------------------------------------------------------------------------------
uvicorn/server.py                                171     22    87.13%   115-125, 141, 160-163, 245-247, 263, 274-277, 307-310
-------------------------------------------------------------------------------
TOTAL                                           5102     67    98.69%
```

After PR (Ubuntu):
```
Name                                           Stmts   Miss     Cover   Missing
-------------------------------------------------------------------------------
uvicorn/server.py                                171     18    89.47%   115-125, 141, 245-247, 263, 274-277, 307-310
-------------------------------------------------------------------------------
TOTAL                                           5110     63    98.77%
```
