### PR TITLE
Fix cli_usage tool on systems without an activated virtualenv

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -3,6 +3,7 @@
 export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
+    export PATH=${PREFIX}:${PATH}
 fi
 export SOURCE_FILES="uvicorn tests"
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -3,6 +3,7 @@
 export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
+    export PATH=${PREFIX}:${PATH}
 fi
 export SOURCE_FILES="uvicorn tests"
 


### PR DESCRIPTION
I found that `script/test` invokes `script/check`, but it haven't updated a `$PATH`

So when `script/check` invokes `${PREFIX}python -m tools.cli_usage --check`, it calls 
https://github.com/encode/uvicorn/blob/c086cebe9f6812ea95de0d65e6ff9d2f102e49be/tools/cli_usage.py#L13

without the pre-installed `uvicorn` in `$PATH`, therefore it fails

I think the easiest way is to update the `script/check`:
```shell
if [[ -z "`which uvicorn`" && -n "${PREFIX}" && ":${PATH}:" != *":${PREFIX}"* ]]; then
  echo "Extend PATH with ${PREFIX}"
  VENV_PATH="${PREFIX}"
fi
```

means: `if uvicorn is not in $PATH` and `$PREFIX is non-empty`  and `$PATH doesn't contain $PREFIX` then do smth


#### How I tested it
I checked `script/install` and `script/test` with pre-activated virtualenv and without it