### PR TITLE
Add `--timeout-graceful-shutdown` parameter

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -104,6 +104,9 @@ Options:
   --timeout-keep-alive INTEGER    Close Keep-Alive connections if no new data
                                   is received within this timeout.  [default:
                                   5]
+  --timeout-graceful-shutdown INTEGER
+                                  Maximum number of seconds to wait for
+                                  graceful shutdown.
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password

--- a/docs/index.md
+++ b/docs/index.md
@@ -171,6 +171,9 @@ Options:
   --timeout-keep-alive INTEGER    Close Keep-Alive connections if no new data
                                   is received within this timeout.  [default:
                                   5]
+  --timeout-graceful-shutdown INTEGER
+                                  Maximum number of seconds to wait for
+                                  graceful shutdown.
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -240,6 +240,7 @@ class Config:
         backlog: int = 2048,
         timeout_keep_alive: int = 5,
         timeout_notify: int = 30,
+        timeout_graceful_shutdown: Optional[int] = None,
         callback_notify: Optional[Callable[..., Awaitable[None]]] = None,
         ssl_keyfile: Optional[str] = None,
         ssl_certfile: Optional[Union[str, os.PathLike]] = None,
@@ -282,6 +283,7 @@ class Config:
         self.backlog = backlog
         self.timeout_keep_alive = timeout_keep_alive
         self.timeout_notify = timeout_notify
+        self.timeout_graceful_shutdown = timeout_graceful_shutdown
         self.callback_notify = callback_notify
         self.ssl_keyfile = ssl_keyfile
         self.ssl_certfile = ssl_certfile

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -275,6 +275,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     show_default=True,
 )
 @click.option(
+    "--timeout-graceful-shutdown",
+    type=int,
+    default=None,
+    help="Maximum number of seconds to wait for graceful shutdown.",
+)
+@click.option(
     "--ssl-keyfile", type=str, default=None, help="SSL key file", show_default=True
 )
 @click.option(
@@ -388,6 +394,7 @@ def main(
     backlog: int,
     limit_max_requests: int,
     timeout_keep_alive: int,
+    timeout_graceful_shutdown: typing.Optional[int],
     ssl_keyfile: str,
     ssl_certfile: str,
     ssl_keyfile_password: str,
@@ -435,6 +442,7 @@ def main(
         backlog=backlog,
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
+        timeout_graceful_shutdown=timeout_graceful_shutdown,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         ssl_keyfile_password=ssl_keyfile_password,
@@ -487,6 +495,7 @@ def run(
     backlog: int = 2048,
     limit_max_requests: typing.Optional[int] = None,
     timeout_keep_alive: int = 5,
+    timeout_graceful_shutdown: typing.Optional[int] = None,
     ssl_keyfile: typing.Optional[str] = None,
     ssl_certfile: typing.Optional[typing.Union[str, os.PathLike]] = None,
     ssl_keyfile_password: typing.Optional[str] = None,
@@ -537,6 +546,7 @@ def run(
         backlog=backlog,
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
+        timeout_graceful_shutdown=timeout_graceful_shutdown,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         ssl_keyfile_password=ssl_keyfile_password,


### PR DESCRIPTION
- Closes https://github.com/encode/uvicorn/issues/451
- Closes https://github.com/encode/uvicorn/issues/675

## Description

This PR adds the `--timeout-graceful-shutdown` parameter, which sets a timeout on tasks that the server is waiting to perform the `shutdown` lifespan event.

This timeout doesn't act on the `shutdown` lifespan event i.e. the `shutdown` event is supposed to run even in the scenario the tasks are timed out.

I need to think of a nice test for this. Ideas?

## Notes

1. The `--graceful-timeout` from `gunicorn` is conceptually different from `--timeout-graceful-shutdown`. The first forcefully kills the worker, and the latter cancels the tasks that are running after `uvicorn` said "I'm not receiving more requests, I'm just going to finish some tasks". 

2. An alternative name for this parameter could be `--timeout-tasks-shutdown`, or similar.

3. The logs are horrible when a task is cancelled. Should it be fine tho? :shrug: 

## Missing

- [ ] Add an entry on the documentation, and mention the difference with `--graceful-timeout` from `gunicorn`.
- [ ] Add a test case.