### PR TITLE
Change default `--app-dir` from from "." (dot) to "" (empty string).

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,7 +119,7 @@ Options:
   --version                       Display the uvicorn version and exit.
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
-                                  the current working directory.  [default: .]
+                                  the current working directory.
   --h11-max-incomplete-event-size INTEGER
                                   For h11, the maximum number of bytes to
                                   buffer of an incomplete event.

--- a/docs/index.md
+++ b/docs/index.md
@@ -186,7 +186,7 @@ Options:
   --version                       Display the uvicorn version and exit.
   --app-dir TEXT                  Look for APP in the specified directory, by
                                   adding this to the PYTHONPATH. Defaults to
-                                  the current working directory.  [default: .]
+                                  the current working directory.
   --h11-max-incomplete-event-size INTEGER
                                   For h11, the maximum number of bytes to
                                   buffer of an incomplete event.

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -335,7 +335,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
 )
 @click.option(
     "--app-dir",
-    default=".",
+    default="",
     show_default=True,
     help="Look for APP in the specified directory, by adding this to the PYTHONPATH."
     " Defaults to the current working directory.",


### PR DESCRIPTION
Both the dot and empty string are interpreted as the current working directory but Python, but the dot causes ugly `__file__` of imported modules. The empty string is consistent with Python behavior, inserting an empy string to sys.path when running interactively.

Discussion: https://github.com/encode/uvicorn/discussions/1814