### PR TITLE
Fix missing self.servers exception

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -115,7 +115,7 @@ class Server:
 
             # Ensure list does not have stale items if the server is run multiple times.
             self.servers.clear()
-            
+
             for sock in sockets:
                 if config.workers > 1 and platform.system() == "Windows":
                     sock = _share_socket(  # type: ignore[assignment]

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -113,6 +113,9 @@ class Server:
                 sock_data = sock.share(os.getpid())  # type: ignore[attr-defined]
                 return fromshare(sock_data)
 
+            # Ensure list does not have stale items if the server is run multiple times.
+            self.servers.clear()
+            
             for sock in sockets:
                 if config.workers > 1 and platform.system() == "Windows":
                     sock = _share_socket(  # type: ignore[assignment]

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -10,7 +10,7 @@ import threading
 import time
 from email.utils import formatdate
 from types import FrameType
-from typing import TYPE_CHECKING, List, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Set, Tuple, Union
 
 import click
 
@@ -54,7 +54,7 @@ class Server:
         self.should_exit = False
         self.force_exit = False
         self.last_notified = 0.0
-        self.servers = []
+        self.servers: List[Any] = []
 
     def run(self, sockets: Optional[List[socket.socket]] = None) -> None:
         self.config.setup_event_loop()

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -54,6 +54,7 @@ class Server:
         self.should_exit = False
         self.force_exit = False
         self.last_notified = 0.0
+        self.servers = []
 
     def run(self, sockets: Optional[List[socket.socket]] = None) -> None:
         self.config.setup_event_loop()
@@ -112,7 +113,6 @@ class Server:
                 sock_data = sock.share(os.getpid())  # type: ignore[attr-defined]
                 return fromshare(sock_data)
 
-            self.servers = []
             for sock in sockets:
                 if config.workers > 1 and platform.system() == "Windows":
                     sock = _share_socket(  # type: ignore[assignment]


### PR DESCRIPTION
If another webserver is currently parked on uvicorn's port, then this exception will occur:

```
Traceback (most recent call last):
  File "C:\Users\Markg\Documents\Repositories\idom-docs\.venv\lib\site-packages\idom\backend\default.py", line 38, in serve_development_app
    return await _default_implementation().serve_development_app(
  File "C:\Users\Markg\Documents\Repositories\idom-docs\.venv\lib\site-packages\idom\backend\starlette.py", line 76, in serve_development_app
    await serve_development_asgi(app, host, port, started)
  File "C:\Users\Markg\Documents\Repositories\idom-docs\.venv\lib\site-packages\idom\backend\_common.py", line 53, in serve_development_asgi
    await asyncio.wait_for(server.shutdown(), timeout=3)
  File "C:\Users\Markg\AppData\Local\Programs\Python\Python310\lib\asyncio\tasks.py", line 445, in wait_for
    return fut.result()
  File "C:\Users\Markg\Documents\Repositories\idom-docs\.venv\lib\site-packages\uvicorn\server.py", line 258, in shutdown
    for server in self.servers:
AttributeError: 'Server' object has no attribute 'servers'
```

This PR ensures `self.servers` is always initialized so the error can be handled gracefully.