### PR TITLE
Improve import time

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -21,8 +21,6 @@ from typing import (
     Union,
 )
 
-from h11._connection import DEFAULT_MAX_INCOMPLETE_EVENT_SIZE
-
 from uvicorn.logging import TRACE_LOG_LEVEL
 
 if sys.version_info < (3, 8):  # pragma: py-gte-38
@@ -242,7 +240,7 @@ class Config:
         ssl_ciphers: str = "TLSv1",
         headers: Optional[List[Tuple[str, str]]] = None,
         factory: bool = False,
-        h11_max_incomplete_event_size: int = DEFAULT_MAX_INCOMPLETE_EVENT_SIZE,
+        h11_max_incomplete_event_size: Optional[int] = None,
     ):
         self.app = app
         self.host = host

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -32,14 +32,6 @@ else:  # pragma: py-lt-38
 
 import click
 
-try:
-    import yaml
-except ImportError:  # pragma: no cover
-    # If the code below that depends on yaml is exercised, it will raise a NameError.
-    # Install the PyYAML package or the uvicorn[standard] optional dependencies to
-    # enable this functionality.
-    pass
-
 from uvicorn.importer import ImportFromStringError, import_from_string
 from uvicorn.middleware.asgi2 import ASGI2Middleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
@@ -410,6 +402,10 @@ class Config:
                     loaded_config = json.load(file)
                     logging.config.dictConfig(loaded_config)
             elif self.log_config.endswith((".yaml", ".yml")):
+                # Install the PyYAML package or the uvicorn[standard] optional
+                # dependencies to enable this functionality.
+                import yaml
+
                 with open(self.log_config) as file:
                     loaded_config = yaml.safe_load(file)
                     logging.config.dictConfig(loaded_config)

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -7,7 +7,6 @@ import sys
 import typing
 
 import click
-from h11._connection import DEFAULT_MAX_INCOMPLETE_EVENT_SIZE
 
 import uvicorn
 from uvicorn.config import (
@@ -344,7 +343,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--h11-max-incomplete-event-size",
     "h11_max_incomplete_event_size",
     type=int,
-    default=DEFAULT_MAX_INCOMPLETE_EVENT_SIZE,
+    default=None,
     help="For h11, the maximum number of bytes to buffer of an incomplete event.",
 )
 @click.option(
@@ -398,7 +397,7 @@ def main(
     headers: typing.List[str],
     use_colors: bool,
     app_dir: str,
-    h11_max_incomplete_event_size: int,
+    h11_max_incomplete_event_size: typing.Optional[int],
     factory: bool,
 ) -> None:
     run(
@@ -498,7 +497,7 @@ def run(
     use_colors: typing.Optional[bool] = None,
     app_dir: typing.Optional[str] = None,
     factory: bool = False,
-    h11_max_incomplete_event_size: int = DEFAULT_MAX_INCOMPLETE_EVENT_SIZE,
+    h11_max_incomplete_event_size: typing.Optional[int] = None,
 ) -> None:
     if app_dir is not None:
         sys.path.insert(0, app_dir)

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union, cast
 from urllib.parse import unquote
 
 import h11
+from h11._connection import DEFAULT_MAX_INCOMPLETE_EVENT_SIZE
 
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
@@ -79,7 +80,12 @@ class H11Protocol(asyncio.Protocol):
         self.logger = logging.getLogger("uvicorn.error")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
-        self.conn = h11.Connection(h11.SERVER, config.h11_max_incomplete_event_size)
+        self.conn = h11.Connection(
+            h11.SERVER,
+            config.h11_max_incomplete_event_size
+            if config.h11_max_incomplete_event_size is not None
+            else DEFAULT_MAX_INCOMPLETE_EVENT_SIZE,
+        )
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
         self.limit_concurrency = config.limit_concurrency


### PR DESCRIPTION
The goal of this PR is to discuss some small improvements that could be made to improve the import time of uvicorn.
There are 3 changes here:
- Do not load `yaml` until we have to parse a yaml file
- Do not load  `h11` when `httptools` is used
- Do not load Reload classes (and dependencies) when reload is not enable. Same for Multiprocess when there are no more than 1 worker

On my computer, the import time is reduced from ~60ms to ~35ms.
I don't know if the benefit is worth the changes. WDYT ?