### PR TITLE
Update h11_Impl.py

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -223,6 +223,7 @@ class H11Protocol(asyncio.Protocol):
                     "raw_path": raw_path,
                     "query_string": query_string,
                     "headers": self.headers,
+                    "transport": self.transport
                 }
 
                 upgrade = self._get_upgrade()


### PR DESCRIPTION
This update enables client cert authentication in Uvicorn  Giving access to TCP layer enables the access to cert info