### PR TITLE
Replace asgiref by internal `_types` module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 -e .[standard]
 
-# Type annotation
-asgiref==3.5.2
-
 # Explicit optionals
 a2wsgi==1.6.0
 wsproto==1.2.0

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -2,9 +2,9 @@ from typing import List, Union
 
 import httpx
 import pytest
-from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 from tests.response import Response
+from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -1,16 +1,13 @@
 import io
 import sys
-from typing import TYPE_CHECKING, AsyncGenerator, Callable, List
+from typing import AsyncGenerator, Callable, List
 
 import a2wsgi
 import httpx
 import pytest
 
-from uvicorn._types import Environ, StartResponse
+from uvicorn._types import Environ, HTTPRequestEvent, HTTPScope, StartResponse
 from uvicorn.middleware import wsgi
-
-if TYPE_CHECKING:
-    from asgiref.typing import HTTPRequestEvent, HTTPScope
 
 
 def hello_world(environ: Environ, start_response: StartResponse) -> List[bytes]:

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,12 +1,10 @@
 import signal
 import socket
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 from uvicorn import Config
+from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.supervisors import Multiprocess
-
-if TYPE_CHECKING:
-    from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 
 async def app(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,14 @@ import yaml
 from pytest_mock import MockerFixture
 
 from tests.utils import as_cwd
-from uvicorn._types import Environ, StartResponse
+from uvicorn._types import (
+    ASGIApplication,
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    Environ,
+    Scope,
+    StartResponse,
+)
 from uvicorn.config import Config
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
@@ -22,14 +29,6 @@ if sys.version_info < (3, 8):  # pragma: py-gte-38
     from typing_extensions import Literal
 else:  # pragma: py-lt-38
     from typing import Literal
-
-if typing.TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGIApplication,
-        ASGIReceiveCallable,
-        ASGISendCallable,
-        Scope,
-    )
 
 
 @pytest.fixture
@@ -560,6 +559,12 @@ def test_config_use_subprocess(reload, workers, expected):
 
 
 def test_warn_when_using_reload_and_workers(caplog: pytest.LogCaptureFixture) -> None:
+    Config(app=asgi_app, reload=True, workers=2)
+    assert len(caplog.records) == 1
+    assert (
+        '"workers" flag is ignored when reloading is enabled.'
+        in caplog.records[0].message
+    )
     Config(app=asgi_app, reload=True, workers=2)
     assert len(caplog.records) == 1
     assert (

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,12 +1,10 @@
 import socket
-from typing import TYPE_CHECKING, List
+from typing import List
 from unittest.mock import patch
 
 from uvicorn._subprocess import SpawnProcess, get_subprocess, subprocess_started
+from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.config import Config
-
-if TYPE_CHECKING:
-    from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
 
 
 def server_run(sockets: List[socket.socket]):  # pragma: no cover

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -1,6 +1,8 @@
 import types
 import typing
 
+from typing_extensions import NotRequired
+
 # WSGI
 Environ = typing.MutableMapping[str, typing.Any]
 ExcInfo = typing.Tuple[
@@ -12,3 +14,233 @@ StartResponse = typing.Callable[
 WSGIApp = typing.Callable[
     [Environ, StartResponse], typing.Union[typing.Iterable[bytes], BaseException]
 ]
+
+# ASGI
+
+
+class ASGIVersions(typing.TypedDict):
+    spec_version: str
+    version: typing.Literal["2.0", "3.0"]
+
+
+class HTTPScope(typing.TypedDict):
+    type: typing.Literal["http"]
+    asgi: ASGIVersions
+    http_version: str
+    method: str
+    scheme: str
+    path: str
+    raw_path: bytes
+    query_string: bytes
+    root_path: str
+    headers: typing.Iterable[typing.Tuple[bytes, bytes]]
+    client: typing.Optional[typing.Tuple[str, int]]
+    server: typing.Optional[typing.Tuple[str, typing.Optional[int]]]
+    extensions: NotRequired[typing.Dict[str, typing.Dict[object, object]]]
+
+
+class WebSocketScope(typing.TypedDict):
+    type: typing.Literal["websocket"]
+    asgi: ASGIVersions
+    http_version: str
+    scheme: str
+    path: str
+    raw_path: bytes
+    query_string: bytes
+    root_path: str
+    headers: typing.Iterable[typing.Tuple[bytes, bytes]]
+    client: typing.Optional[typing.Tuple[str, int]]
+    server: typing.Optional[typing.Tuple[str, typing.Optional[int]]]
+    subprotocols: typing.Iterable[str]
+    extensions: NotRequired[typing.Dict[str, typing.Dict[object, object]]]
+
+
+class LifespanScope(typing.TypedDict):
+    type: typing.Literal["lifespan"]
+    asgi: ASGIVersions
+
+
+WWWScope = typing.Union[HTTPScope, WebSocketScope]
+Scope = typing.Union[HTTPScope, WebSocketScope, LifespanScope]
+
+
+class HTTPRequestEvent(typing.TypedDict):
+    type: typing.Literal["http.request"]
+    body: bytes
+    more_body: NotRequired[bool]  # TODO: Confirm this NotRequired.
+
+
+class HTTPResponseStartEvent(typing.TypedDict):
+    type: typing.Literal["http.response.start"]
+    status: int
+    headers: typing.Iterable[typing.Tuple[bytes, bytes]]  # TODO: Is this NotRequired?
+
+
+class HTTPResponseBodyEvent(typing.TypedDict):
+    type: typing.Literal["http.response.body"]
+    body: bytes
+    more_body: NotRequired[bool]  # TODO: Confirm this NotRequired.
+
+
+class HTTPDisconnectEvent(typing.TypedDict):
+    type: typing.Literal["http.disconnect"]
+
+
+class HTTPServerPushEvent(typing.TypedDict):
+    type: typing.Literal["http.response.push"]
+    path: str
+    headers: typing.Iterable[typing.Tuple[bytes, bytes]]  # TODO: Is this NotRequired?
+
+
+class WebSocketConnectEvent(typing.TypedDict):
+    type: typing.Literal["websocket.connect"]
+
+
+class WebSocketAcceptEvent(typing.TypedDict):
+    type: typing.Literal["websocket.accept"]
+    subprotocol: typing.Optional[str]  # TODO: Is it NotRequired?
+    headers: typing.Iterable[typing.Tuple[bytes, bytes]]  # TODO: Is it NotRequired?
+
+
+class _WSReceiveEventBytes(typing.TypedDict):
+    type: typing.Literal["websocket.receive"]
+    bytes: bytes
+
+
+class _WSReceiveEventText(typing.TypedDict):
+    type: typing.Literal["websocket.receive"]
+    text: str
+
+
+WebSocketReceiveEvent = typing.Union[_WSReceiveEventBytes, _WSReceiveEventText]
+
+
+class _WSSendEventBytes(typing.TypedDict):
+    type: typing.Literal["websocket.send"]
+    bytes: bytes
+
+
+class _WSSendEventText(typing.TypedDict):
+    type: typing.Literal["websocket.send"]
+    text: str
+
+
+WebSocketSendEvent = typing.Union[_WSSendEventBytes, _WSSendEventText]
+
+
+class WebSocketResponseStartEvent(typing.TypedDict):
+    type: typing.Literal["websocket.http.response.start"]
+    status: int
+    headers: typing.Iterable[typing.Tuple[bytes, bytes]]  # TODO: Is it NotRequired?
+
+
+class WebSocketResponseBodyEvent(typing.TypedDict):
+    type: typing.Literal["websocket.http.response.body"]
+    body: bytes
+    more_body: NotRequired[bool]  # TODO: Confirm the NotRequired.
+
+
+class WebSocketDisconnectEvent(typing.TypedDict):
+    type: typing.Literal["websocket.disconnect"]
+    code: int  # TODO: Is the code NotRequired?
+
+
+class WebSocketCloseEvent(typing.TypedDict):
+    type: typing.Literal["websocket.close"]
+    code: int
+    reason: NotRequired[str]  # TODO: Confirm that it is NotRequired.
+
+
+WebSocketEvent = typing.Union[
+    "WebSocketReceiveEvent",
+    "WebSocketDisconnectEvent",
+    "WebSocketConnectEvent",
+]
+
+
+class LifespanStartupEvent(typing.TypedDict):
+    type: typing.Literal["lifespan.startup"]
+
+
+class LifespanShutdownEvent(typing.TypedDict):
+    type: typing.Literal["lifespan.shutdown"]
+
+
+class LifespanStartupCompleteEvent(typing.TypedDict):
+    type: typing.Literal["lifespan.startup.complete"]
+
+
+class LifespanStartupFailedEvent(typing.TypedDict):
+    type: typing.Literal["lifespan.startup.failed"]
+    message: str
+
+
+class LifespanShutdownCompleteEvent(typing.TypedDict):
+    type: typing.Literal["lifespan.shutdown.complete"]
+
+
+class LifespanShutdownFailedEvent(typing.TypedDict):
+    type: typing.Literal["lifespan.shutdown.failed"]
+    message: str
+
+
+LifespanReceiveMessage = typing.Union[LifespanStartupEvent, LifespanShutdownEvent]
+LifespanSendMessage = typing.Union[
+    LifespanStartupFailedEvent,
+    LifespanShutdownFailedEvent,
+    LifespanStartupCompleteEvent,
+    LifespanShutdownCompleteEvent,
+]
+
+ASGIReceiveEvent = typing.Union[
+    HTTPRequestEvent,
+    HTTPDisconnectEvent,
+    WebSocketConnectEvent,
+    WebSocketReceiveEvent,
+    WebSocketDisconnectEvent,
+    LifespanStartupEvent,
+    LifespanShutdownEvent,
+]
+
+
+ASGISendEvent = typing.Union[
+    HTTPResponseStartEvent,
+    HTTPResponseBodyEvent,
+    HTTPServerPushEvent,
+    HTTPDisconnectEvent,
+    WebSocketAcceptEvent,
+    WebSocketSendEvent,
+    WebSocketResponseStartEvent,
+    WebSocketResponseBodyEvent,
+    WebSocketCloseEvent,
+    LifespanStartupCompleteEvent,
+    LifespanStartupFailedEvent,
+    LifespanShutdownCompleteEvent,
+    LifespanShutdownFailedEvent,
+]
+
+
+ASGIReceiveCallable = typing.Callable[[], typing.Awaitable[ASGIReceiveEvent]]
+ASGISendCallable = typing.Callable[[ASGISendEvent], typing.Awaitable[None]]
+
+
+class ASGI2Protocol(typing.Protocol):
+    def __init__(self, scope: Scope) -> None:
+        ...
+
+    async def __call__(
+        self, receive: ASGIReceiveCallable, send: ASGISendCallable
+    ) -> None:
+        ...
+
+
+ASGI2Application = typing.Type[ASGI2Protocol]
+ASGI3Application = typing.Callable[
+    [
+        Scope,
+        ASGIReceiveCallable,
+        ASGISendCallable,
+    ],
+    typing.Awaitable[None],
+]
+ASGIApplication = typing.Union[ASGI2Application, ASGI3Application]

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -8,18 +8,7 @@ import socket
 import ssl
 import sys
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from uvicorn.logging import TRACE_LOG_LEVEL
 
@@ -30,14 +19,12 @@ else:  # pragma: py-lt-38
 
 import click
 
+from uvicorn._types import ASGIApplication
 from uvicorn.importer import ImportFromStringError, import_from_string
 from uvicorn.middleware.asgi2 import ASGI2Middleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
-
-if TYPE_CHECKING:
-    from asgiref.typing import ASGIApplication
 
 HTTPProtocolType = Literal["auto", "h11", "httptools"]
 WSProtocolType = Literal["auto", "none", "websockets", "wsproto"]

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -1,29 +1,15 @@
 import asyncio
 import logging
 from asyncio import Queue
-from typing import TYPE_CHECKING, Union
 
 from uvicorn import Config
-
-if TYPE_CHECKING:
-    from asgiref.typing import (
-        LifespanScope,
-        LifespanShutdownCompleteEvent,
-        LifespanShutdownEvent,
-        LifespanShutdownFailedEvent,
-        LifespanStartupCompleteEvent,
-        LifespanStartupEvent,
-        LifespanStartupFailedEvent,
-    )
-
-    LifespanReceiveMessage = Union[LifespanStartupEvent, LifespanShutdownEvent]
-    LifespanSendMessage = Union[
-        LifespanStartupFailedEvent,
-        LifespanShutdownFailedEvent,
-        LifespanStartupCompleteEvent,
-        LifespanShutdownCompleteEvent,
-    ]
-
+from uvicorn._types import (
+    LifespanReceiveMessage,
+    LifespanScope,
+    LifespanSendMessage,
+    LifespanShutdownEvent,
+    LifespanStartupEvent,
+)
 
 STATE_TRANSITION_ERROR = "Got invalid state transition on lifespan protocol."
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -9,6 +9,7 @@ import typing
 import click
 
 import uvicorn
+from uvicorn._types import ASGIApplication
 from uvicorn.config import (
     HTTP_PROTOCOLS,
     INTERFACES,
@@ -27,9 +28,6 @@ from uvicorn.config import (
 )
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
-
-if typing.TYPE_CHECKING:
-    from asgiref.typing import ASGIApplication
 
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))

--- a/uvicorn/middleware/asgi2.py
+++ b/uvicorn/middleware/asgi2.py
@@ -1,12 +1,9 @@
-import typing
-
-if typing.TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGI2Application,
-        ASGIReceiveCallable,
-        ASGISendCallable,
-        Scope,
-    )
+from uvicorn._types import (
+    ASGI2Application,
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    Scope,
+)
 
 
 class ASGI2Middleware:

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -1,16 +1,14 @@
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGI3Application,
-        ASGIReceiveCallable,
-        ASGIReceiveEvent,
-        ASGISendCallable,
-        ASGISendEvent,
-        WWWScope,
-    )
-
+from uvicorn._types import (
+    ASGI3Application,
+    ASGIReceiveCallable,
+    ASGIReceiveEvent,
+    ASGISendCallable,
+    ASGISendEvent,
+    WWWScope,
+)
 from uvicorn.logging import TRACE_LOG_LEVEL
 
 PLACEHOLDER_FORMAT = {

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -8,17 +8,16 @@ the connecting client, rather that the connecting proxy.
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies
 """
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
-if TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGI3Application,
-        ASGIReceiveCallable,
-        ASGISendCallable,
-        HTTPScope,
-        Scope,
-        WebSocketScope,
-    )
+from uvicorn._types import (
+    ASGI3Application,
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    HTTPScope,
+    Scope,
+    WebSocketScope,
+)
 
 
 class ProxyHeadersMiddleware:

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -4,21 +4,22 @@ import io
 import sys
 import warnings
 from collections import deque
-from typing import TYPE_CHECKING, Deque, Iterable, Optional, Tuple
+from typing import Deque, Iterable, Optional, Tuple
 
-if TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGIReceiveCallable,
-        ASGIReceiveEvent,
-        ASGISendCallable,
-        ASGISendEvent,
-        HTTPRequestEvent,
-        HTTPResponseBodyEvent,
-        HTTPResponseStartEvent,
-        HTTPScope,
-    )
-
-from uvicorn._types import Environ, ExcInfo, StartResponse, WSGIApp
+from uvicorn._types import (
+    ASGIReceiveCallable,
+    ASGIReceiveEvent,
+    ASGISendCallable,
+    ASGISendEvent,
+    Environ,
+    ExcInfo,
+    HTTPRequestEvent,
+    HTTPResponseBodyEvent,
+    HTTPResponseStartEvent,
+    HTTPScope,
+    StartResponse,
+    WSGIApp,
+)
 
 
 def build_environ(
@@ -198,5 +199,7 @@ class WSGIResponder:
 
 try:
     from a2wsgi import WSGIMiddleware
+except ModuleNotFoundError:
+    WSGIMiddleware = _WSGIMiddleware  # type: ignore[misc, assignment]
 except ModuleNotFoundError:
     WSGIMiddleware = _WSGIMiddleware  # type: ignore[misc, assignment]

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,14 +1,12 @@
 import asyncio
-import typing
 
-if typing.TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGIReceiveCallable,
-        ASGISendCallable,
-        HTTPResponseBodyEvent,
-        HTTPResponseStartEvent,
-        Scope,
-    )
+from uvicorn._types import (
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    HTTPResponseBodyEvent,
+    HTTPResponseStartEvent,
+    Scope,
+)
 
 CLOSE_HEADER = (b"connection", b"close")
 
@@ -65,4 +63,5 @@ async def service_unavailable(
         "body": b"Service Unavailable",
         "more_body": False,
     }
+    await send(response_body)
     await send(response_body)

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -6,10 +6,20 @@ import sys
 import urllib
 from asyncio.events import TimerHandle
 from collections import deque
-from typing import TYPE_CHECKING, Callable, Deque, List, Optional, Tuple, Union, cast
+from typing import Callable, Deque, List, Optional, Tuple, Union, cast
 
 import httptools
 
+from uvicorn._types import (
+    ASGI3Application,
+    ASGIReceiveEvent,
+    ASGISendEvent,
+    HTTPDisconnectEvent,
+    HTTPRequestEvent,
+    HTTPResponseBodyEvent,
+    HTTPResponseStartEvent,
+    HTTPScope,
+)
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.http.flow_control import (
@@ -32,17 +42,6 @@ if sys.version_info < (3, 8):  # pragma: py-gte-38
 else:  # pragma: py-lt-38
     from typing import Literal
 
-if TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGI3Application,
-        ASGIReceiveEvent,
-        ASGISendEvent,
-        HTTPDisconnectEvent,
-        HTTPRequestEvent,
-        HTTPResponseBodyEvent,
-        HTTPResponseStartEvent,
-        HTTPScope,
-    )
 
 HEADER_RE = re.compile(b'[\x00-\x1F\x7F()<>@,;:[]={} \t\\"]')
 HEADER_VALUE_RE = re.compile(b"[\x00-\x1F\x7F]")

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -1,9 +1,8 @@
 import asyncio
 import urllib.parse
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import Optional, Tuple
 
-if TYPE_CHECKING:
-    from asgiref.typing import WWWScope
+from uvicorn._types import WWWScope
 
 
 def get_remote_addr(transport: asyncio.Transport) -> Optional[Tuple[str, int]]:

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -2,7 +2,7 @@ import asyncio
 import http
 import logging
 import sys
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union, cast
+from typing import Any, List, Optional, Sequence, Tuple, Union, cast
 from urllib.parse import unquote
 
 import websockets
@@ -13,6 +13,16 @@ from websockets.legacy.server import HTTPResponse
 from websockets.server import WebSocketServerProtocol
 from websockets.typing import Subprotocol
 
+from uvicorn._types import (
+    ASGISendEvent,
+    WebSocketAcceptEvent,
+    WebSocketCloseEvent,
+    WebSocketConnectEvent,
+    WebSocketDisconnectEvent,
+    WebSocketReceiveEvent,
+    WebSocketScope,
+    WebSocketSendEvent,
+)
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.utils import (
@@ -27,18 +37,6 @@ if sys.version_info < (3, 8):  # pragma: py-gte-38
     from typing_extensions import Literal
 else:  # pragma: py-lt-38
     from typing import Literal
-
-if TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGISendEvent,
-        WebSocketAcceptEvent,
-        WebSocketCloseEvent,
-        WebSocketConnectEvent,
-        WebSocketDisconnectEvent,
-        WebSocketReceiveEvent,
-        WebSocketScope,
-        WebSocketSendEvent,
-    )
 
 
 class Server:
@@ -358,13 +356,6 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 return {"type": "websocket.disconnect", "code": 1012}
             return {"type": "websocket.disconnect", "code": exc.code}
 
-        msg: WebSocketReceiveEvent = {  # type: ignore[typeddict-item]
-            "type": "websocket.receive"
-        }
-
         if isinstance(data, str):
-            msg["text"] = data
-        else:
-            msg["bytes"] = data
-
-        return msg
+            return {"type": "websocket.receive", "text": data}
+        return {"type": "websocket.receive", "bytes": data}

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -10,6 +10,15 @@ from wsproto.connection import ConnectionState
 from wsproto.extensions import Extension, PerMessageDeflate
 from wsproto.utilities import RemoteProtocolError
 
+from uvicorn._types import (
+    ASGISendEvent,
+    WebSocketAcceptEvent,
+    WebSocketCloseEvent,
+    WebSocketEvent,
+    WebSocketReceiveEvent,
+    WebSocketScope,
+    WebSocketSendEvent,
+)
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.utils import (
@@ -19,24 +28,6 @@ from uvicorn.protocols.utils import (
     is_ssl,
 )
 from uvicorn.server import ServerState
-
-if typing.TYPE_CHECKING:
-    from asgiref.typing import (
-        ASGISendEvent,
-        WebSocketAcceptEvent,
-        WebSocketCloseEvent,
-        WebSocketConnectEvent,
-        WebSocketDisconnectEvent,
-        WebSocketReceiveEvent,
-        WebSocketScope,
-        WebSocketSendEvent,
-    )
-
-    WebSocketEvent = typing.Union[
-        "WebSocketReceiveEvent",
-        "WebSocketDisconnectEvent",
-        "WebSocketConnectEvent",
-    ]
 
 if sys.version_info < (3, 8):  # pragma: py-gte-38
     from typing_extensions import Literal
@@ -183,7 +174,6 @@ class WSProtocol(asyncio.Protocol):
             "query_string": query_string.encode("ascii"),
             "headers": headers,
             "subprotocols": event.subprotocols,
-            "extensions": None,
         }
         self.queue.put_nowait({"type": "websocket.connect"})
         task = self.loop.create_task(self.run_asgi())
@@ -351,4 +341,5 @@ class WSProtocol(asyncio.Protocol):
         if self.read_paused and self.queue.empty():
             self.read_paused = False
             self.transport.resume_reading()
+        return message
         return message


### PR DESCRIPTION
It's too complicated to have `asgiref` as a dependency just for typing. Also, their typing module doesn't follow the spec strictly, e.g. `extensions` field is not optional, it's just not required.