### PR TITLE
Improve discoverability when `--port=0` is used

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -571,7 +571,7 @@ class Config:
                 + " (Press CTRL+C to quit)"
             )
             protocol_name = "https" if self.is_ssl else "http"
-            logger_args = [protocol_name, self.host, self.port]
+            logger_args = [protocol_name, self.host, sock.getsockname()[1]]
         logger.info(message, *logger_args, extra={"color_message": color_message})
         sock.set_inheritable(True)
         return sock


### PR DESCRIPTION
It is possible to request the server to run on any available port. This already works by using `--port 0`. However, the resulting logs show `Uvicorn running on http://127.0.0.1:0 (Press CTRL+C to quit)`, making it very difficult to determine what port was selected.

This change will read the port number directly from the socket to ensure the bound port is displayed in all cases.
