### PR TITLE
Support websocket.http.response ASGI extension

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -51,6 +51,21 @@ class WebSocketResponse:
                 break
 
 
+async def wsresponse(url):
+    """
+    A simple websocket connection request and response helper
+    """
+    url = url.replace("ws:", "http:")
+    headers = {
+        "connection": "upgrade",
+        "upgrade": "websocket",
+        "Sec-WebSocket-Key": "x3JJHMbDL1EzLkh9GBhXDw==",
+        "Sec-WebSocket-Version": "13",
+    }
+    async with httpx.AsyncClient() as client:
+        return await client.get(url, headers=headers)
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
@@ -967,11 +982,9 @@ async def test_server_reject_connection_with_response(
         disconnected_message = await receive()
 
     async def websocket_session(url):
-        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
-            async with websockets.client.connect(url):
-                pass  # pragma: no cover
-        assert exc_info.value.status_code == 400
-        # Websockets module currently does not read the response body from the socket.
+        response = await wsresponse(url)
+        assert response.status_code == 400
+        assert response.content == b"goodbye"
 
     config = Config(
         app=app,
@@ -1022,11 +1035,9 @@ async def test_server_reject_connection_with_multibody_response(
         disconnected_message = await receive()
 
     async def websocket_session(url):
-        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
-            async with websockets.client.connect(url):
-                pass  # pragma: no cover
-        assert exc_info.value.status_code == 400
-        # Websockets module currently does not read the response body from the socket.
+        response = await wsresponse(url)
+        assert response.status_code == 400
+        assert response.content == (b"x" * 10) + (b"y" * 10)
 
     config = Config(
         app=app,
@@ -1068,10 +1079,9 @@ async def test_server_reject_connection_with_invalid_status(
         await send(message)
 
     async def websocket_session(url):
-        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
-            async with websockets.client.connect(url):
-                pass  # pragma: no cover
-        assert exc_info.value.status_code == 500
+        response = await wsresponse(url)
+        assert response.status_code == 500
+        assert response.content == b"Internal Server Error"
 
     config = Config(
         app=app,

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1090,9 +1090,6 @@ async def test_server_reject_connection_with_invalid_status(
 async def test_server_reject_connection_with_invalid_msg(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
-    if ws_protocol_cls is WSProtocol:
-        pytest.skip("Cannot supporess asynchronously raised errors")
-
     async def app(scope, receive, send):
         assert scope["type"] == "websocket"
         assert "websocket.http.response" in scope["extensions"]
@@ -1107,12 +1104,8 @@ async def test_server_reject_connection_with_invalid_msg(
             "headers": [(b"Content-Length", b"0"), (b"Content-Type", b"text/plain")],
         }
         await send(message)
-        # send invalid message
-        try:
-            await send(message)
-        except Exception:
-            # swallow the invalid message error
-            pass
+        # send invalid message.  This will raise an exception here
+        await send(message)
 
     async def websocket_session(url):
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
@@ -1124,6 +1117,8 @@ async def test_server_reject_connection_with_invalid_msg(
             # undo that, we will get the initial 404 response
             assert exc_info.value.status_code == 404
         else:
+            # websockets protocol sends its response in one chunk
+            # and can override the already started response with a 500
             assert exc_info.value.status_code == 500
 
     config = Config(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -923,11 +923,48 @@ async def test_server_reject_connection(
         assert message["type"] == "websocket.disconnect"
 
     async def websocket_session(url):
-        try:
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
             async with websockets.client.connect(url):
                 pass  # pragma: no cover
-        except Exception:
-            pass
+        assert exc_info.value.status_code == 403
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+from tests.response import Response
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_response(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+
+        # Reject the connection with a response
+        response = Response(b"goodbye", status_code=400)
+        await response(scope, receive, send)
+        message = await receive()
+        assert message["type"] == "websocket.disconnect"
+
+    async def websocket_session(url):
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.client.connect(url):
+                pass  # pragma: no cover
+        assert exc_info.value.status_code == 400
 
     config = Config(
         app=app,

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1087,6 +1087,59 @@ async def test_server_reject_connection_with_invalid_status(
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_invalid_msg(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    if ws_protocol_cls is WSProtocol:
+        pytest.skip("Cannot supporess asynchronously raised errors")
+
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+
+        message = {
+            "type": "websocket.http.response.start",
+            "status": 404,
+            "headers": [(b"Content-Length", b"0"), (b"Content-Type", b"text/plain")],
+        }
+        await send(message)
+        # send invalid message
+        try:
+            await send(message)
+        except Exception:
+            # swallow the invalid message error
+            pass
+
+    async def websocket_session(url):
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.client.connect(url):
+                pass  # pragma: no cover
+        if ws_protocol_cls == WSProtocol:
+            # ws protocol has started to send the response when it
+            # fails with the subsequent invalid message so it cannot
+            # undo that, we will get the initial 404 response
+            assert exc_info.value.status_code == 404
+        else:
+            assert exc_info.value.status_code == 500
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -938,7 +938,9 @@ async def test_server_reject_connection(
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
+
 from tests.response import Response
+
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
@@ -965,6 +967,58 @@ async def test_server_reject_connection_with_response(
             async with websockets.client.connect(url):
                 pass  # pragma: no cover
         assert exc_info.value.status_code == 400
+        # Websockets module currently does not read the response body from the socket.
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_multibody_response(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+        message = {
+            "type": "websocket.http.response.start",
+            "status": 400,
+            "headers": [(b"Content-Length", b"20"), (b"Content-Type", b"text/plain")],
+        }
+        await send(message)
+        message = {
+            "type": "websocket.http.response.body",
+            "body": b"x" * 10,
+            "more_body": True,
+        }
+        await send(message)
+        message = {
+            "type": "websocket.http.response.body",
+            "body": b"y" * 10,
+        }
+        await send(message)
+        message = await receive()
+        assert message["type"] == "websocket.disconnect"
+
+    async def websocket_session(url):
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.client.connect(url):
+                pass  # pragma: no cover
+        assert exc_info.value.status_code == 400
+        # Websockets module currently does not read the response body from the socket.
 
     config = Config(
         app=app,

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from tests.protocols.test_http import HTTP_PROTOCOLS
+from tests.response import Response
 from tests.utils import run_server
 from uvicorn.config import Config
 from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
@@ -937,9 +938,6 @@ async def test_server_reject_connection(
     )
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
-
-
-from tests.response import Response
 
 
 @pytest.mark.anyio

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -946,7 +946,10 @@ async def test_server_reject_connection(
 async def test_server_reject_connection_with_response(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
+    disconnected_message = {}
+
     async def app(scope, receive, send):
+        nonlocal disconnected_message
         assert scope["type"] == "websocket"
         assert "websocket.http.response" in scope["extensions"]
 
@@ -957,8 +960,7 @@ async def test_server_reject_connection_with_response(
         # Reject the connection with a response
         response = Response(b"goodbye", status_code=400)
         await response(scope, receive, send)
-        message = await receive()
-        assert message["type"] == "websocket.disconnect"
+        disconnected_message = await receive()
 
     async def websocket_session(url):
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
@@ -977,6 +979,7 @@ async def test_server_reject_connection_with_response(
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
+    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006"}
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1097,6 +1097,55 @@ async def test_server_reject_connection_with_invalid_status(
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_body_nolength(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    # test that the server can send a response with a body but no content-length
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+
+        message = {
+            "type": "websocket.http.response.start",
+            "status": 403,
+            "headers": [],
+        }
+        await send(message)
+        message = {
+            "type": "websocket.http.response.body",
+            "body": b"hardbody",
+        }
+        await send(message)
+
+    async def websocket_session(url):
+        response = await wsresponse(url)
+        assert response.status_code == 403
+        assert response.content == b"hardbody"
+        if ws_protocol_cls == WSProtocol:
+            # wsproto automatically makes the message chunked
+            assert response.headers["transfer-encoding"] == "chunked"
+        else:
+            # websockets automatically adds a content-length
+            assert response.headers["content-length"] == "8"
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_invalid_msg(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1044,6 +1044,49 @@ async def test_server_reject_connection_with_multibody_response(
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_invalid_status(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+
+        message = {
+            "type": "websocket.http.response.start",
+            "status": 700,  # invalid status code
+            "headers": [(b"Content-Length", b"0"), (b"Content-Type", b"text/plain")],
+        }
+        await send(message)
+        message = {
+            "type": "websocket.http.response.body",
+            "body": b"",
+        }
+        await send(message)
+
+    async def websocket_session(url):
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.client.connect(url):
+                pass  # pragma: no cover
+        assert exc_info.value.status_code == 500
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1135,6 +1135,48 @@ async def test_server_reject_connection_with_invalid_msg(
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_missing_body(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+
+        message = {
+            "type": "websocket.http.response.start",
+            "status": 404,
+            "headers": [(b"Content-Length", b"0"), (b"Content-Type", b"text/plain")],
+        }
+        await send(message)
+        # no further message
+
+    async def websocket_session(url):
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.client.connect(url):
+                pass  # pragma: no cover
+        if ws_protocol_cls == WSProtocol:
+            assert exc_info.value.status_code == 404
+        else:
+            assert exc_info.value.status_code == 500
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -907,7 +907,10 @@ async def test_send_binary_data_to_server_bigger_than_default(
 async def test_server_reject_connection(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
+    disconnected_message = {}
+
     async def app(scope, receive, send):
+        nonlocal disconnected_message
         assert scope["type"] == "websocket"
 
         # Pull up first recv message.
@@ -920,8 +923,7 @@ async def test_server_reject_connection(
 
         # This doesn't raise `TypeError`:
         # See https://github.com/encode/uvicorn/issues/244
-        message = await receive()
-        assert message["type"] == "websocket.disconnect"
+        disconnected_message = await receive()
 
     async def websocket_session(url):
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
@@ -938,6 +940,8 @@ async def test_server_reject_connection(
     )
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
 
 
 @pytest.mark.anyio
@@ -979,7 +983,8 @@ async def test_server_reject_connection_with_response(
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
-    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006"}
+    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
+
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
@@ -987,7 +992,10 @@ async def test_server_reject_connection_with_response(
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
 ):
+    disconnected_message = {}
+
     async def app(scope, receive, send):
+        nonlocal disconnected_message
         assert scope["type"] == "websocket"
         assert "websocket.http.response" in scope["extensions"]
 
@@ -1011,8 +1019,7 @@ async def test_server_reject_connection_with_multibody_response(
             "body": b"y" * 10,
         }
         await send(message)
-        message = await receive()
-        assert message["type"] == "websocket.disconnect"
+        disconnected_message = await receive()
 
     async def websocket_session(url):
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
@@ -1030,6 +1037,8 @@ async def test_server_reject_connection_with_multibody_response(
     )
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
 
 
 @pytest.mark.anyio

--- a/tests/response.py
+++ b/tests/response.py
@@ -10,9 +10,10 @@ class Response:
         self.set_content_length()
 
     async def __call__(self, scope, receive, send) -> None:
+        prefix = "websocket." if scope["type"] == "websocket" else ""
         await send(
             {
-                "type": "http.response.start",
+                "type": prefix + "http.response.start",
                 "status": self.status_code,
                 "headers": [
                     [key.encode(), value.encode()]
@@ -20,7 +21,7 @@ class Response:
                 ],
             }
         )
-        await send({"type": "http.response.body", "body": self.body})
+        await send({"type": prefix + "http.response.body", "body": self.body})
 
     def render(self, content) -> bytes:
         if isinstance(content, bytes):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
         WebSocketConnectEvent,
         WebSocketDisconnectEvent,
         WebSocketReceiveEvent,
+        WebSocketResponseBodyEvent,
+        WebSocketResponseStartEvent,
         WebSocketScope,
         WebSocketSendEvent,
     )
@@ -102,6 +104,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
         self.connect_sent = False
         self.lost_connection_before_handshake = False
         self.accepted_subprotocol: Optional[Subprotocol] = None
+        self.response_body: Optional[List[bytes]] = None
 
         self.ws_server: Server = Server()  # type: ignore[assignment]
 
@@ -203,6 +206,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             "headers": asgi_headers,
             "subprotocols": subprotocols,
             "state": self.app_state.copy(),
+            "extensions": {"websocket.http.response": {}},
         }
         task = self.loop.create_task(self.run_asgi())
         task.add_done_callback(self.on_task_complete)
@@ -278,43 +282,83 @@ class WebSocketProtocol(WebSocketServerProtocol):
         message_type = message["type"]
 
         if not self.handshake_started_event.is_set():
-            if message_type == "websocket.accept":
-                message = cast("WebSocketAcceptEvent", message)
-                self.logger.info(
-                    '%s - "WebSocket %s" [accepted]',
-                    self.scope["client"],
-                    get_path_with_query_string(self.scope),
-                )
-                self.initial_response = None
-                self.accepted_subprotocol = cast(
-                    Optional[Subprotocol], message.get("subprotocol")
-                )
-                if "headers" in message:
-                    self.extra_headers.extend(
-                        # ASGI spec requires bytes
-                        # But for compatibility we need to convert it to strings
-                        (name.decode("latin-1"), value.decode("latin-1"))
-                        for name, value in message["headers"]
+            if self.response_body is None:
+                if message_type == "websocket.accept":
+                    message = cast("WebSocketAcceptEvent", message)
+                    self.logger.info(
+                        '%s - "WebSocket %s" [accepted]',
+                        self.scope["client"],
+                        get_path_with_query_string(self.scope),
                     )
-                self.handshake_started_event.set()
+                    self.initial_response = None
+                    self.accepted_subprotocol = cast(
+                        Optional[Subprotocol], message.get("subprotocol")
+                    )
+                    if "headers" in message:
+                        self.extra_headers.extend(
+                            # ASGI spec requires bytes
+                            # But for compatibility we need to convert it to strings
+                            (name.decode("latin-1"), value.decode("latin-1"))
+                            for name, value in message["headers"]
+                        )
+                    self.handshake_started_event.set()
 
-            elif message_type == "websocket.close":
-                message = cast("WebSocketCloseEvent", message)
-                self.logger.info(
-                    '%s - "WebSocket %s" 403',
-                    self.scope["client"],
-                    get_path_with_query_string(self.scope),
-                )
-                self.initial_response = (http.HTTPStatus.FORBIDDEN, [], b"")
-                self.handshake_started_event.set()
-                self.closed_event.set()
+                elif message_type == "websocket.close":
+                    message = cast("WebSocketCloseEvent", message)
+                    self.logger.info(
+                        '%s - "WebSocket %s" 403',
+                        self.scope["client"],
+                        get_path_with_query_string(self.scope),
+                    )
+                    self.initial_response = (http.HTTPStatus.FORBIDDEN, [], b"")
+                    self.handshake_started_event.set()
+                    self.closed_event.set()
 
+                elif message_type == "websocket.http.response.start":
+                    message = cast("WebSocketResponseStartEvent", message)
+                    try:
+                        status = http.HTTPStatus(message["status"])
+                    except AttributeError:
+                        status = http.HTTPStatus.FORBIDDEN
+                    headers = [
+                        (name.decode("latin-1"), value.decode("latin-1"))
+                        for name, value in message.get("headers", [])
+                    ]
+                    self.initial_response = (status, headers, b"")
+                    self.response_body = []
+
+                else:
+                    msg = (
+                        "Expected ASGI message 'websocket.accept', 'websocket.close', "
+                        "or 'websocket.http.response.start' "
+                        "but got '%s'."
+                    )
+                    raise RuntimeError(msg % message_type)
             else:
-                msg = (
-                    "Expected ASGI message 'websocket.accept' or 'websocket.close', "
-                    "but got '%s'."
-                )
-                raise RuntimeError(msg % message_type)
+                if message_type == "websocket.http.response.body":
+                    message = cast("WebSocketResponseBodyEvent", message)
+                    self.response_body.append(message["body"])
+
+                    if not message.get("more_body", False):
+                        self.logger.info(
+                            '%s - "WebSocket %s" %i',
+                            self.scope["client"],
+                            get_path_with_query_string(self.scope),
+                            self.initial_response[0],
+                        )
+
+                        self.initial_response = self.initial_response[:2] + (
+                            b"".join(self.response_body),
+                        )
+                        self.response_body = None
+                        self.handshake_started_event.set()
+                        self.closed_event.set()
+                else:
+                    msg = (
+                        "Expected ASGI message 'websocket.http.response.body' "
+                        "but got '%s'."
+                    )
+                    raise RuntimeError(msg % message_type)
 
         elif not self.closed_event.is_set():
             await self.handshake_completed_event.wait()

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -316,6 +316,12 @@ class WebSocketProtocol(WebSocketServerProtocol):
 
                 elif message_type == "websocket.http.response.start":
                     message = cast("WebSocketResponseStartEvent", message)
+                    self.logger.info(
+                        '%s - "WebSocket %s" %s',
+                        self.scope["client"],
+                        get_path_with_query_string(self.scope),
+                        message["status"],
+                    )
                     try:
                         status = http.HTTPStatus(message["status"])
                     except AttributeError:
@@ -340,13 +346,6 @@ class WebSocketProtocol(WebSocketServerProtocol):
                     self.response_body.append(message["body"])
 
                     if not message.get("more_body", False):
-                        self.logger.info(
-                            '%s - "WebSocket %s" %i',
-                            self.scope["client"],
-                            get_path_with_query_string(self.scope),
-                            self.initial_response[0],
-                        )
-
                         self.initial_response = self.initial_response[:2] + (
                             b"".join(self.response_body),
                         )

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -317,7 +317,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 elif message_type == "websocket.http.response.start":
                     message = cast("WebSocketResponseStartEvent", message)
                     self.logger.info(
-                        '%s - "WebSocket %s" %s',
+                        '%s - "WebSocket %s" %d',
                         self.scope["client"],
                         get_path_with_query_string(self.scope),
                         message["status"],

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -348,7 +348,6 @@ class WebSocketProtocol(WebSocketServerProtocol):
                         self.initial_response = self.initial_response[:2] + (
                             b"".join(self.response_body),
                         )
-                        self.response_body = None
                         self.handshake_started_event.set()
                         self.closed_event.set()
                 else:

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -322,10 +322,15 @@ class WebSocketProtocol(WebSocketServerProtocol):
                         get_path_with_query_string(self.scope),
                         message["status"],
                     )
+                    # websockets requires the status to be an enum. look it up.
                     try:
                         status = http.HTTPStatus(message["status"])
                     except AttributeError:
                         status = http.HTTPStatus.FORBIDDEN
+                        self.logger.info(
+                            "status code %d unknown, replaced with 403",
+                            message["status"],
+                        )
                     headers = [
                         (name.decode("latin-1"), value.decode("latin-1"))
                         for name, value in message.get("headers", [])

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -351,6 +351,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                     self.response_body.append(message["body"])
 
                     if not message.get("more_body", False):
+                        assert self.initial_response is not None
                         self.initial_response = self.initial_response[:2] + (
                             b"".join(self.response_body),
                         )

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -323,14 +323,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                         message["status"],
                     )
                     # websockets requires the status to be an enum. look it up.
-                    try:
-                        status = http.HTTPStatus(message["status"])
-                    except AttributeError:
-                        status = http.HTTPStatus.FORBIDDEN
-                        self.logger.info(
-                            "status code %d unknown, replaced with 403",
-                            message["status"],
-                        )
+                    status = http.HTTPStatus(message["status"])
                     headers = [
                         (name.decode("latin-1"), value.decode("latin-1"))
                         for name, value in message.get("headers", [])

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -316,7 +316,6 @@ class WSProtocol(asyncio.Protocol):
                     self.transport.close()
 
                 elif message_type == "websocket.http.response.start":
-                    self.response_started = True
                     message = typing.cast("WebSocketResponseStartEvent", message)
                     self.logger.info(
                         '%s - "WebSocket %s" %d',
@@ -331,6 +330,7 @@ class WSProtocol(asyncio.Protocol):
                     )
                     output = self.conn.send(event)
                     self.transport.write(output)
+                    self.response_started = True
 
                 else:
                     msg = (

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -354,6 +354,7 @@ class WSProtocol(asyncio.Protocol):
                         )
                         self.handshake_complete = True
                         self.close_sent = True
+                        self.transport.close()
 
                 else:
                     msg = (

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -28,6 +28,8 @@ if typing.TYPE_CHECKING:
         WebSocketConnectEvent,
         WebSocketDisconnectEvent,
         WebSocketReceiveEvent,
+        WebSocketResponseBodyEvent,
+        WebSocketResponseStartEvent,
         WebSocketScope,
         WebSocketSendEvent,
     )
@@ -77,6 +79,7 @@ class WSProtocol(asyncio.Protocol):
         self.queue: asyncio.Queue["WebSocketEvent"] = asyncio.Queue()
         self.handshake_complete = False
         self.close_sent = False
+        self.response_started = False
 
         self.conn = wsproto.WSConnection(connection_type=ConnectionType.SERVER)
 
@@ -187,6 +190,7 @@ class WSProtocol(asyncio.Protocol):
             "subprotocols": event.subprotocols,
             "extensions": None,
             "state": self.app_state.copy(),
+            "extensions": {"websocket.http.response": {}},
         }
         self.queue.put_nowait({"type": "websocket.connect"})
         task = self.loop.create_task(self.run_asgi())
@@ -269,49 +273,94 @@ class WSProtocol(asyncio.Protocol):
         message_type = message["type"]
 
         if not self.handshake_complete:
-            if message_type == "websocket.accept":
-                message = typing.cast("WebSocketAcceptEvent", message)
-                self.logger.info(
-                    '%s - "WebSocket %s" [accepted]',
-                    self.scope["client"],
-                    get_path_with_query_string(self.scope),
-                )
-                subprotocol = message.get("subprotocol")
-                extra_headers = self.default_headers + list(message.get("headers", []))
-                extensions: typing.List[Extension] = []
-                if self.config.ws_per_message_deflate:
-                    extensions.append(PerMessageDeflate())
-                if not self.transport.is_closing():
-                    self.handshake_complete = True
-                    output = self.conn.send(
-                        wsproto.events.AcceptConnection(
-                            subprotocol=subprotocol,
-                            extensions=extensions,
-                            extra_headers=extra_headers,
-                        )
+            if not self.response_started:
+                if message_type == "websocket.accept":
+                    message = typing.cast("WebSocketAcceptEvent", message)
+                    self.logger.info(
+                        '%s - "WebSocket %s" [accepted]',
+                        self.scope["client"],
+                        get_path_with_query_string(self.scope),
                     )
+                    subprotocol = message.get("subprotocol")
+                    extra_headers = self.default_headers + list(
+                        message.get("headers", [])
+                    )
+                    extensions: typing.List[Extension] = []
+                    if self.config.ws_per_message_deflate:
+                        extensions.append(PerMessageDeflate())
+                    if not self.transport.is_closing():
+                        self.handshake_complete = True
+                        output = self.conn.send(
+                            wsproto.events.AcceptConnection(
+                                subprotocol=subprotocol,
+                                extensions=extensions,
+                                extra_headers=extra_headers,
+                            )
+                        )
+                        self.transport.write(output)
+
+                elif message_type == "websocket.close":
+                    self.queue.put_nowait(
+                        {"type": "websocket.disconnect", "code": 1006}
+                    )
+                    self.logger.info(
+                        '%s - "WebSocket %s" 403',
+                        self.scope["client"],
+                        get_path_with_query_string(self.scope),
+                    )
+                    self.handshake_complete = True
+                    self.close_sent = True
+                    event = events.RejectConnection(status_code=403, headers=[])
+                    output = self.conn.send(event)
+                    self.transport.write(output)
+                    self.transport.close()
+
+                elif message_type == "websocket.http.response.start":
+                    self.response_started = True
+                    message = typing.cast("WebSocketResponseStartEvent", message)
+                    self.logger.info(
+                        '%s - "WebSocket %s" %i',
+                        self.scope["client"],
+                        get_path_with_query_string(self.scope),
+                        message["status"],
+                    )
+                    event = events.RejectConnection(
+                        status_code=message["status"],
+                        headers=message["headers"],
+                        has_body=True,
+                    )
+                    output = self.conn.send(event)
                     self.transport.write(output)
 
-            elif message_type == "websocket.close":
-                self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
-                self.logger.info(
-                    '%s - "WebSocket %s" 403',
-                    self.scope["client"],
-                    get_path_with_query_string(self.scope),
-                )
-                self.handshake_complete = True
-                self.close_sent = True
-                event = events.RejectConnection(status_code=403, headers=[])
-                output = self.conn.send(event)
-                self.transport.write(output)
-                self.transport.close()
-
+                else:
+                    msg = (
+                        "Expected ASGI message 'websocket.accept', 'websocket.close' "
+                        "or 'websocket.http.response.start' "
+                        "but got '%s'."
+                    )
+                    raise RuntimeError(msg % message_type)
             else:
-                msg = (
-                    "Expected ASGI message 'websocket.accept' or 'websocket.close', "
-                    "but got '%s'."
-                )
-                raise RuntimeError(msg % message_type)
+                if message_type == "websocket.http.response.body":
+                    message = typing.cast("WebSocketResponseBodyEvent", message)
+                    body_finished = not message.get("more_body", False)
+                    event = events.RejectData(
+                        data=message["body"], body_finished=body_finished
+                    )
+                    output = self.conn.send(event)
+                    self.transport.write(output)
+                    if body_finished:
+                        self.queue.put_nowait(
+                            {"type": "websocket.disconnect", "code": 1006}
+                        )
+                        self.handshake_complete = True
+                        self.close_sent = True
+
+                else:
+                    msg = (
+                        "Expected ASGI message 'websocket.http.response.body' "
+                        "but got '%s'."
+                    )
+                    raise RuntimeError(msg % message_type)
 
         elif not self.close_sent:
             if message_type == "websocket.send":

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -325,7 +325,7 @@ class WSProtocol(asyncio.Protocol):
                     )
                     event = events.RejectConnection(
                         status_code=message["status"],
-                        headers=message["headers"],
+                        headers=list(message["headers"]),
                         has_body=True,
                     )
                     output = self.conn.send(event)
@@ -342,10 +342,10 @@ class WSProtocol(asyncio.Protocol):
                 if message_type == "websocket.http.response.body":
                     message = typing.cast("WebSocketResponseBodyEvent", message)
                     body_finished = not message.get("more_body", False)
-                    event = events.RejectData(
+                    reject_data = events.RejectData(
                         data=message["body"], body_finished=body_finished
                     )
-                    output = self.conn.send(event)
+                    output = self.conn.send(reject_data)
                     self.transport.write(output)
                     if body_finished:
                         self.queue.put_nowait(

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -318,7 +318,7 @@ class WSProtocol(asyncio.Protocol):
                     self.response_started = True
                     message = typing.cast("WebSocketResponseStartEvent", message)
                     self.logger.info(
-                        '%s - "WebSocket %s" %i',
+                        '%s - "WebSocket %s" %d',
                         self.scope["client"],
                         get_path_with_query_string(self.scope),
                         message["status"],

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -188,7 +188,6 @@ class WSProtocol(asyncio.Protocol):
             "query_string": query_string.encode("ascii"),
             "headers": headers,
             "subprotocols": event.subprotocols,
-            "extensions": None,
             "state": self.app_state.copy(),
             "extensions": {"websocket.http.response": {}},
         }

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -252,14 +252,15 @@ class WSProtocol(asyncio.Protocol):
             result = await self.app(self.scope, self.receive, self.send)
         except BaseException:
             self.logger.exception("Exception in ASGI application\n")
-            if not self.handshake_complete:
+            if not self.response_started:
                 self.send_500_response()
             self.transport.close()
         else:
             if not self.handshake_complete:
                 msg = "ASGI callable returned without completing handshake."
                 self.logger.error(msg)
-                self.send_500_response()
+                if not self.response_started:
+                    self.send_500_response()
                 self.transport.close()
             elif result is not None:
                 msg = "ASGI callable should return None, but returned '%s'."


### PR DESCRIPTION
uvicorn now can return a response from websocket apps that choose to reject a connection with a custom response.
See https://github.com/encode/starlette/pull/2041/files for related work.

Note: The `websockets` module currently does not read the response body from a websockets upgrade requests, so we cannot effectively test that functionality, in the unittests.  The exception thrown at the client contains no body, only status code.