### PR TITLE
Handle `SIGBREAK` for Windows

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -28,6 +28,8 @@ HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
+if sys.platform == "win32":
+    HANDLED_SIGNALS += (signal.SIGBREAK,)  # Windows signal 21. Sent by Ctrl+Break.
 
 logger = logging.getLogger("uvicorn.error")
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -28,7 +28,7 @@ HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
-if sys.platform == "win32":
+if sys.platform == "win32":  # pragma py-linux pragma: py-darwin
     HANDLED_SIGNALS += (signal.SIGBREAK,)  # Windows signal 21. Sent by Ctrl+Break.
 
 logger = logging.getLogger("uvicorn.error")

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -28,7 +28,7 @@ HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
-if sys.platform == "win32":  # pragma py-linux pragma: py-darwin
+if sys.platform == "win32":  # pragma: py-not-win32
     HANDLED_SIGNALS += (signal.SIGBREAK,)  # Windows signal 21. Sent by Ctrl+Break.
 
 logger = logging.getLogger("uvicorn.error")


### PR DESCRIPTION
On Windows, `subprocess.CTRL_BREAK_EVENT` may be sent to subprocess using `os.kill` or [`process.send_signal`](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.send_signal) as `SIGBREAK` signal. This signal can be catched by subprocess to do a graceful shutdown instead of terminating the subprocess directly.  
And, this signal is also catched in `hypercorn`.