### PR TITLE
[`Docs`] : Hypercorn supports HTTP/3

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -500,7 +500,7 @@ $ daphne app:App
 [Hypercorn][hypercorn] was initially part of the Quart web framework, before
 being separated out into a standalone ASGI server.
 
-Hypercorn supports HTTP/1.1, HTTP/2, and WebSockets.
+Hypercorn supports HTTP/1.1, HTTP/2, HTTP/3 and WebSockets.
 
 ```
 $ pip install hypercorn


### PR DESCRIPTION
Hi there,

It seems that in the docs hypercorn is not listed as HTTP/3 compatible ( [but it is compatible](https://github.com/pgjones/hypercorn#hypercorn) 🤔 )

This Pull Request aims to fix that :D 