### PR TITLE
Fix instructions so they work in zsh as well as Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ pip install uvicorn
 This will install uvicorn with minimal (pure Python) dependencies.
 
 ```shell
-$ pip install uvicorn[standard]
+$ pip install 'uvicorn[standard]'
 ```
 
 This will install uvicorn with "Cython-based" dependencies (where possible) and other "optional extras".

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ $ pip install uvicorn
 This will install uvicorn with minimal (pure Python) dependencies.
 
 ```shell
-$ pip install uvicorn[standard]
+$ pip install 'uvicorn[standard]'
 ```
 
 This will install uvicorn with "Cython-based" dependencies (where possible) and other "optional extras".

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -768,7 +768,7 @@ async def test_unsupported_ws_upgrade_request_warn_on_auto(
         )
     ]
     assert "Unsupported upgrade request." in warnings
-    msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
+    msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
     assert msg in warnings
 
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -190,7 +190,7 @@ class H11Protocol(asyncio.Protocol):
             if self.config.ws == "auto":
                 msg = "Unsupported upgrade request."
                 self.logger.warning(msg)
-                msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
+                msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
                 self.logger.warning(msg)
             return False
         return True

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -180,7 +180,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         if self.config.ws == "auto":
             msg = "Unsupported upgrade request."
             self.logger.warning(msg)
-            msg = "No supported WebSocket library detected. Please use 'pip install uvicorn[standard]', or install 'websockets' or 'wsproto' manually."  # noqa: E501
+            msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
             self.logger.warning(msg)
         return False
 


### PR DESCRIPTION
The installation instructions in a few places currently tell the user to do this:

    pip install uvicorn[standard]

This works fine with Bash, but on zsh (the default these days on macOS) results in this confusing error:

    zsh: no matches found: uvicorn[standard]

The following works fine on both Bash and zsh:

    pip install 'uvicorn[standard]'