### PR TITLE
Support the WebSocket Denial Response ASGI extension

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1124,6 +1124,59 @@ async def test_server_reject_connection_with_invalid_status(
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_invalid_msg(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    if ws_protocol_cls is WSProtocol:
+        pytest.skip("Cannot supporess asynchronously raised errors")
+
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+
+        message = {
+            "type": "websocket.http.response.start",
+            "status": 404,
+            "headers": [(b"Content-Length", b"0"), (b"Content-Type", b"text/plain")],
+        }
+        await send(message)
+        # send invalid message
+        try:
+            await send(message)
+        except Exception:
+            # swallow the invalid message error
+            pass
+
+    async def websocket_session(url):
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.client.connect(url):
+                pass  # pragma: no cover
+        if ws_protocol_cls == WSProtocol:
+            # ws protocol has started to send the response when it
+            # fails with the subsequent invalid message so it cannot
+            # undo that, we will get the initial 404 response
+            assert exc_info.value.status_code == 404
+        else:
+            assert exc_info.value.status_code == 500
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1207,15 +1207,7 @@ async def test_server_reject_connection_with_invalid_msg(
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
             async with websockets.client.connect(url):
                 pass  # pragma: no cover
-        if ws_protocol_cls == WSProtocol:
-            # ws protocol has started to send the response when it
-            # fails with the subsequent invalid message so it cannot
-            # undo that, we will get the initial 404 response
-            assert exc_info.value.status_code == 404
-        else:
-            # websockets protocol sends its response in one chunk
-            # and can override the already started response with a 500
-            assert exc_info.value.status_code == 500
+        assert exc_info.value.status_code == 500
 
     config = Config(
         app=app,
@@ -1254,10 +1246,7 @@ async def test_server_reject_connection_with_missing_body(
         with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
             async with websockets.client.connect(url):
                 pass  # pragma: no cover
-        if ws_protocol_cls == WSProtocol:
-            assert exc_info.value.status_code == 404
-        else:
-            assert exc_info.value.status_code == 500
+        assert exc_info.value.status_code == 500
 
     config = Config(
         app=app,

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -10,11 +10,11 @@ import websockets.exceptions
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
 from websockets.typing import Subprotocol
 
-from tests.protocols.test_http import HTTP_PROTOCOLS
 from tests.response import Response
 from tests.utils import run_server
 from uvicorn._types import (
     ASGIReceiveCallable,
+    ASGIReceiveEvent,
     ASGISendCallable,
     Scope,
     WebSocketCloseEvent,
@@ -959,7 +959,7 @@ async def test_server_reject_connection(
     http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
 ):
-    disconnected_message = {}
+    disconnected_message: ASGIReceiveEvent = {}  # type: ignore
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         nonlocal disconnected_message
@@ -997,10 +997,9 @@ async def test_server_reject_connection(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_response(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
-    http_protocol_cls,
+    http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
 ):
     disconnected_message = {}
@@ -1038,10 +1037,9 @@ async def test_server_reject_connection_with_response(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
-    http_protocol_cls,
+    http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
 ):
     disconnected_message = {}
@@ -1092,10 +1090,9 @@ async def test_server_reject_connection_with_multibody_response(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_invalid_status(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
-    http_protocol_cls,
+    http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
 ):
     # this test checks that even if there is an error in the response, the server
@@ -1137,10 +1134,9 @@ async def test_server_reject_connection_with_invalid_status(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_body_nolength(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
-    http_protocol_cls,
+    http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
 ):
     # test that the server can send a response with a body but no content-length
@@ -1187,10 +1183,9 @@ async def test_server_reject_connection_with_body_nolength(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_invalid_msg(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
-    http_protocol_cls,
+    http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
 ):
     async def app(scope, receive, send):
@@ -1228,10 +1223,9 @@ async def test_server_reject_connection_with_invalid_msg(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_missing_body(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
-    http_protocol_cls,
+    http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
 ):
     async def app(scope, receive, send):
@@ -1268,8 +1262,6 @@ async def test_server_reject_connection_with_missing_body(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
-@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -997,10 +997,11 @@ async def test_server_reject_connection(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_response(
-    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     disconnected_message = {}
 
@@ -1037,10 +1038,11 @@ async def test_server_reject_connection_with_response(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_multibody_response(
-    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     disconnected_message = {}
 
@@ -1090,10 +1092,11 @@ async def test_server_reject_connection_with_multibody_response(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_invalid_status(
-    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     async def app(scope, receive, send):
         assert scope["type"] == "websocket"
@@ -1132,10 +1135,11 @@ async def test_server_reject_connection_with_invalid_status(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_body_nolength(
-    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     # test that the server can send a response with a body but no content-length
     async def app(scope, receive, send):
@@ -1181,10 +1185,11 @@ async def test_server_reject_connection_with_body_nolength(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_invalid_msg(
-    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     async def app(scope, receive, send):
         assert scope["type"] == "websocket"
@@ -1221,10 +1226,11 @@ async def test_server_reject_connection_with_invalid_msg(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection_with_missing_body(
-    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     async def app(scope, receive, send):
         assert scope["type"] == "websocket"

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1098,6 +1098,8 @@ async def test_server_reject_connection_with_invalid_status(
     http_protocol_cls,
     unused_tcp_port: int,
 ):
+    # this test checks that even if there is an error in the response, the server
+    # can successfully send a 500 error back to the client
     async def app(scope, receive, send):
         assert scope["type"] == "websocket"
         assert "websocket.http.response" in scope["extensions"]

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1079,6 +1079,51 @@ async def test_server_reject_connection_with_multibody_response(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
+async def test_server_reject_connection_with_invalid_status(
+    ws_protocol_cls, http_protocol_cls, unused_tcp_port: int
+):
+    async def app(scope, receive, send):
+        assert scope["type"] == "websocket"
+        assert "websocket.http.response" in scope["extensions"]
+
+        # Pull up first recv message.
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+
+        message = {
+            "type": "websocket.http.response.start",
+            "status": 700,  # invalid status code
+            "headers": [(b"Content-Length", b"0"), (b"Content-Type", b"text/plain")],
+        }
+        await send(message)
+        message = {
+            "type": "websocket.http.response.body",
+            "body": b"",
+        }
+        await send(message)
+
+    async def websocket_session(url):
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.client.connect(url):
+                pass  # pragma: no cover
+        assert exc_info.value.status_code == 500
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ws_protocol_cls", WS_PROTOCOLS)
+@pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
     ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls: "typing.Type[H11Protocol | HttpToolsProtocol]",

--- a/tests/response.py
+++ b/tests/response.py
@@ -10,9 +10,10 @@ class Response:
         self.set_content_length()
 
     async def __call__(self, scope, receive, send) -> None:
+        prefix = "websocket." if scope["type"] == "websocket" else ""
         await send(
             {
-                "type": "http.response.start",
+                "type": prefix + "http.response.start",
                 "status": self.status_code,
                 "headers": [
                     [key.encode(), value.encode()]
@@ -20,7 +21,7 @@ class Response:
                 ],
             }
         )
-        await send({"type": "http.response.body", "body": self.body})
+        await send({"type": prefix + "http.response.body", "body": self.body})
 
     def render(self, content) -> bytes:
         if isinstance(content, bytes):

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -199,7 +199,7 @@ class WebSocketResponseStartEvent(TypedDict):
 class WebSocketResponseBodyEvent(TypedDict):
     type: Literal["websocket.http.response.body"]
     body: bytes
-    more_body: bool
+    more_body: NotRequired[bool]
 
 
 class WebSocketDisconnectEvent(TypedDict):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -341,7 +341,6 @@ class WebSocketProtocol(WebSocketServerProtocol):
                         self.initial_response = self.initial_response[:2] + (
                             b"".join(self.response_body),
                         )
-                        self.response_body = None
                         self.handshake_started_event.set()
                         self.closed_event.set()
                 else:

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -353,7 +353,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 )
                 raise RuntimeError(msg % message_type)
 
-        elif not self.closed_event.is_set() and self.initial_response is not None:
+        elif self.initial_response is not None:
             if message_type == "websocket.http.response.body":
                 message = cast("WebSocketResponseBodyEvent", message)
                 body = self.initial_response[2] + message["body"]

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -344,6 +344,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                     self.response_body.append(message["body"])
 
                     if not message.get("more_body", False):
+                        assert self.initial_response is not None
                         self.initial_response = self.initial_response[:2] + (
                             b"".join(self.response_body),
                         )

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -325,8 +325,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             else:
                 msg = (
                     "Expected ASGI message 'websocket.accept', 'websocket.close', "
-                    "or 'websocket.http.response.start' "
-                    "but got '%s'."
+                    "or 'websocket.http.response.start' but got '%s'."
                 )
                 raise RuntimeError(msg % message_type)
 

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -316,14 +316,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
                         message["status"],
                     )
                     # websockets requires the status to be an enum. look it up.
-                    try:
-                        status = http.HTTPStatus(message["status"])
-                    except AttributeError:
-                        status = http.HTTPStatus.FORBIDDEN
-                        self.logger.info(
-                            "status code %d unknown, replaced with 403",
-                            message["status"],
-                        )
+                    status = http.HTTPStatus(message["status"])
                     headers = [
                         (name.decode("latin-1"), value.decode("latin-1"))
                         for name, value in message.get("headers", [])

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -229,14 +229,15 @@ class WSProtocol(asyncio.Protocol):
             result = await self.app(self.scope, self.receive, self.send)
         except BaseException:
             self.logger.exception("Exception in ASGI application\n")
-            if not self.handshake_complete:
+            if not self.response_started:
                 self.send_500_response()
             self.transport.close()
         else:
             if not self.handshake_complete:
                 msg = "ASGI callable returned without completing handshake."
                 self.logger.error(msg)
-                self.send_500_response()
+                if not self.response_started:
+                    self.send_500_response()
                 self.transport.close()
             elif result is not None:
                 msg = "ASGI callable should return None, but returned '%s'."

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -260,9 +260,7 @@ class WSProtocol(asyncio.Protocol):
                     get_path_with_query_string(self.scope),
                 )
                 subprotocol = message.get("subprotocol")
-                extra_headers = self.default_headers + list(
-                    message.get("headers", [])
-                )
+                extra_headers = self.default_headers + list(message.get("headers", []))
                 extensions: typing.List[Extension] = []
                 if self.config.ws_per_message_deflate:
                     extensions.append(PerMessageDeflate())
@@ -278,9 +276,7 @@ class WSProtocol(asyncio.Protocol):
                     self.transport.write(output)
 
             elif message_type == "websocket.close":
-                self.queue.put_nowait(
-                    {"type": "websocket.disconnect", "code": 1006}
-                )
+                self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     self.scope["client"],

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -364,7 +364,6 @@ class WSProtocol(asyncio.Protocol):
                     self.queue.put_nowait(
                         {"type": "websocket.disconnect", "code": 1006}
                     )
-                    self.handshake_complete = True
                     self.close_sent = True
                     self.transport.close()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -298,6 +298,10 @@ class WSProtocol(asyncio.Protocol):
 
                 elif message_type == "websocket.http.response.start":
                     message = typing.cast("WebSocketResponseStartEvent", message)
+                    # ensure status code is in the valid range
+                    if not (100 <= message["status"] < 600):
+                        msg = "Invalid HTTP status code '%d' in response."
+                        raise RuntimeError(msg % message["status"])
                     self.logger.info(
                         '%s - "WebSocket %s" %d',
                         self.scope["client"],

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -301,7 +301,7 @@ class WSProtocol(asyncio.Protocol):
                     )
                     event = events.RejectConnection(
                         status_code=message["status"],
-                        headers=message["headers"],
+                        headers=list(message["headers"]),
                         has_body=True,
                     )
                     output = self.conn.send(event)
@@ -319,10 +319,10 @@ class WSProtocol(asyncio.Protocol):
                 if message_type == "websocket.http.response.body":
                     message = typing.cast("WebSocketResponseBodyEvent", message)
                     body_finished = not message.get("more_body", False)
-                    event = events.RejectData(
+                    reject_data = events.RejectData(
                         data=message["body"], body_finished=body_finished
                     )
-                    output = self.conn.send(event)
+                    output = self.conn.send(reject_data)
                     self.transport.write(output)
                     if body_finished:
                         self.queue.put_nowait(


### PR DESCRIPTION
uvicorn now can return a response from websocket apps that choose to reject a connection with a custom response.
See https://github.com/encode/starlette/pull/2041/files for related work.

This is a re-submission of pr #1907 