### PR TITLE
Pin websockets to <11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ asgiref==3.5.2
 # Explicit optionals
 a2wsgi==1.7.0
 wsproto==1.2.0
+websockets==10.4
 
 # Packaging
 build==0.10.0


### PR DESCRIPTION
`websockets` 11.0 broke uvicorn test suite. This PR just pins it so we can run the pipeline. We still need to investigate what changed, see: https://github.com/encode/uvicorn/issues/1927