### PR TITLE
Handle missing trustme/cryptography gracefully in the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,15 @@ from time import sleep
 from uuid import uuid4
 
 import pytest
-import trustme
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
+
+try:
+    import trustme
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+
+    HAVE_TRUSTME = True
+except ImportError:  # pragma: nocover
+    HAVE_TRUSTME = False
 
 from uvicorn.config import LOGGING_CONFIG
 
@@ -30,12 +36,14 @@ LOGGING_CONFIG["loggers"]["uvicorn"]["propagate"] = True
 
 
 @pytest.fixture
-def tls_certificate_authority() -> trustme.CA:
+def tls_certificate_authority() -> "trustme.CA":
+    if not HAVE_TRUSTME:
+        pytest.skip("trustme not installed")
     return trustme.CA()
 
 
 @pytest.fixture
-def tls_certificate(tls_certificate_authority: trustme.CA) -> trustme.LeafCert:
+def tls_certificate(tls_certificate_authority: "trustme.CA") -> "trustme.LeafCert":
     return tls_certificate_authority.issue_cert(
         "localhost",
         "127.0.0.1",
@@ -44,13 +52,13 @@ def tls_certificate(tls_certificate_authority: trustme.CA) -> trustme.LeafCert:
 
 
 @pytest.fixture
-def tls_ca_certificate_pem_path(tls_certificate_authority: trustme.CA):
+def tls_ca_certificate_pem_path(tls_certificate_authority: "trustme.CA"):
     with tls_certificate_authority.cert_pem.tempfile() as ca_cert_pem:
         yield ca_cert_pem
 
 
 @pytest.fixture
-def tls_ca_certificate_private_key_path(tls_certificate_authority: trustme.CA):
+def tls_ca_certificate_private_key_path(tls_certificate_authority: "trustme.CA"):
     with tls_certificate_authority.private_key_pem.tempfile() as private_key:
         yield private_key
 
@@ -72,25 +80,25 @@ def tls_certificate_private_key_encrypted_path(tls_certificate):
 
 
 @pytest.fixture
-def tls_certificate_private_key_path(tls_certificate: trustme.CA):
+def tls_certificate_private_key_path(tls_certificate: "trustme.CA"):
     with tls_certificate.private_key_pem.tempfile() as private_key:
         yield private_key
 
 
 @pytest.fixture
-def tls_certificate_key_and_chain_path(tls_certificate: trustme.LeafCert):
+def tls_certificate_key_and_chain_path(tls_certificate: "trustme.LeafCert"):
     with tls_certificate.private_key_and_cert_chain_pem.tempfile() as cert_pem:
         yield cert_pem
 
 
 @pytest.fixture
-def tls_certificate_server_cert_path(tls_certificate: trustme.LeafCert):
+def tls_certificate_server_cert_path(tls_certificate: "trustme.LeafCert"):
     with tls_certificate.cert_chain_pems[0].tempfile() as cert_pem:
         yield cert_pem
 
 
 @pytest.fixture
-def tls_ca_ssl_context(tls_certificate_authority: trustme.CA) -> ssl.SSLContext:
+def tls_ca_ssl_context(tls_certificate_authority: "trustme.CA") -> ssl.SSLContext:
     ssl_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
     tls_certificate_authority.configure_trust(ssl_ctx)
     return ssl_ctx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ try:
     from cryptography.hazmat.primitives import serialization
 
     HAVE_TRUSTME = True
-except ImportError:  # pragma: nocover
+except ImportError:  # pragma: no cover
     HAVE_TRUSTME = False
 
 from uvicorn.config import LOGGING_CONFIG
@@ -38,7 +38,7 @@ LOGGING_CONFIG["loggers"]["uvicorn"]["propagate"] = True
 @pytest.fixture
 def tls_certificate_authority() -> "trustme.CA":
     if not HAVE_TRUSTME:
-        pytest.skip("trustme not installed")
+        pytest.skip("trustme not installed")  # pragma: no cover
     return trustme.CA()
 
 


### PR DESCRIPTION
Skip tests requiring trustme/cryptography if either of the packages are not installed.  This makes it possible to run most of the test suite on architectures that do not feature a working Rust toolchain at the time.