### PR TITLE
Simplified worker monitoring and restart, without gunicorn.

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -6,6 +6,7 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["master"]
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 98.68
+fail_under = 98.65
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 98.80
+fail_under = 98.68
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ plugins =
 
 [coverage:report]
 precision = 2
-fail_under = 98.65
+fail_under = 98.63
 show_missing = true
 skip_covered = true
 exclude_lines =

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -75,7 +75,10 @@ class Multiprocess:
         logger.info(message, extra={"color_message": color_message})
 
     def monitor(self) -> None:
-        while not self.should_exit.wait(0.5):
+        while not self.should_exit.is_set():
+            time.sleep(0.5)
+            if self.should_exit.is_set():
+                break
             # Restart expired workers.
             for process in self.processes:
                 if not process.is_alive():

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -75,10 +75,7 @@ class Multiprocess:
         logger.info(message, extra={"color_message": color_message})
 
     def monitor(self) -> None:
-        while not self.should_exit.is_set():
-            time.sleep(0.5)
-            if self.should_exit.is_set():
-                break
+        while not self.should_exit.wait(0.5):
             # Restart expired workers.
             for process in self.processes:
                 if not process.is_alive():

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import signal
-import time
 import threading
+import time
 from multiprocessing.context import SpawnProcess
 from socket import socket
 from types import FrameType


### PR DESCRIPTION
Drastically simplifies app deployment for Starlette and FastAPI for many users.



Survive worker crashes directly in Uvicorn- go ahead and run your ffmpeg and machine learning tasks. Uvicorn will auto restart your workers up to the desired `--workers` count, reliably, even under heavy load.

* For many users, this removes gunicorn as a dependency. @tomchristie @tiangolo
  * https://github.com/encode/uvicorn/issues/517#issuecomment-564090865 
  * Simplifies production documentation for many scenarios.
* Tested, benchmarked on both Windows 11 :window: and Linux! @euri10 @kludex
* **Under 20 lines**, backwards compatible, no effect on uvicorn performance.
* You can now "reload" your app by killing all of the child processes. :stuck_out_tongue: 

### Related issues

* Closes: https://github.com/encode/uvicorn/issues/517
* Good resolution for: https://github.com/encode/starlette/issues/671
* Many tangentially related FastAPI issues which would have never been reported if this was included in Uvicorn.

### Deployments right now...

caddy/nginx  ➡️  gunicorn  ➡️  uvicorn  ➡️  starlette/fastapi

### For many users can be simplified to...

caddy/nginx  ➡️  uvicorn  ➡️  starlette/fastapi

### Stress tested to 100,000's of r/s using using [hey](https://github.com/rakyll/hey).

Thoughts, feedback appreciated. 

I realise this isn't as "feature rich" as some may want (handling various signals, etc), but we're eliminating an entire dependency with only a few lines. It works well and is a relatively tiny change for big benefits, and can be easily re-factored out if something better is implemented in the future.
