### PR TITLE
Use a ChainMap for the lifespan state

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -264,7 +264,7 @@ def test_lifespan_state():
         lifespan = LifespanOn(config)
 
         await lifespan.startup()
-        assert lifespan.state == {"foo": 123}
+        assert lifespan.state.maps == [{"foo": 123}]
         await lifespan.shutdown()
 
     loop = asyncio.new_event_loop()

--- a/uvicorn/lifespan/off.py
+++ b/uvicorn/lifespan/off.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, ChainMap
 
 from uvicorn import Config
 
@@ -6,7 +6,7 @@ from uvicorn import Config
 class LifespanOff:
     def __init__(self, config: Config) -> None:
         self.should_exit = False
-        self.state: Dict[str, Any] = {}
+        self.state: ChainMap[str, Any] = ChainMap()
 
     async def startup(self) -> None:
         pass

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from asyncio import Queue
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, ChainMap, Union
 
 from uvicorn import Config
 
@@ -42,7 +42,7 @@ class LifespanOn:
         self.startup_failed = False
         self.shutdown_failed = False
         self.should_exit = False
-        self.state: Dict[str, Any] = {}
+        self.state: ChainMap[str, Any] = ChainMap()
 
     async def startup(self) -> None:
         self.logger.info("Waiting for application startup.")

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -6,7 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
+    ChainMap,
     List,
     Optional,
     Tuple,
@@ -80,7 +80,7 @@ class H11Protocol(asyncio.Protocol):
         self,
         config: Config,
         server_state: ServerState,
-        app_state: Dict[str, Any],
+        app_state: ChainMap[str, Any],
         _loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         if not config.loaded:
@@ -242,7 +242,7 @@ class H11Protocol(asyncio.Protocol):
                     "raw_path": raw_path,
                     "query_string": query_string,
                     "headers": self.headers,
-                    "state": self.app_state.copy(),
+                    "state": self.app_state.new_child(),
                 }
 
                 upgrade = self._get_upgrade()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -10,8 +10,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ChainMap,
     Deque,
-    Dict,
     List,
     Optional,
     Tuple,
@@ -78,7 +78,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self,
         config: Config,
         server_state: ServerState,
-        app_state: Dict[str, Any],
+        app_state: ChainMap[str, Any],
         _loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         if not config.loaded:
@@ -252,7 +252,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             "scheme": self.scheme,  # type: ignore[typeddict-item]
             "root_path": self.root_path,
             "headers": self.headers,
-            "state": self.app_state.copy(),
+            "state": self.app_state.new_child(),
         }
 
     # Parser callbacks

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -5,7 +5,7 @@ import sys
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
+    ChainMap,
     List,
     Optional,
     Sequence,
@@ -71,7 +71,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
         self,
         config: Config,
         server_state: ServerState,
-        app_state: Dict[str, Any],
+        app_state: ChainMap[str, Any],
         _loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         if not config.loaded:
@@ -202,7 +202,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             "query_string": query_string.encode("ascii"),
             "headers": asgi_headers,
             "subprotocols": subprotocols,
-            "state": self.app_state.copy(),
+            "state": self.app_state.new_child(),
         }
         task = self.loop.create_task(self.run_asgi())
         task.add_done_callback(self.on_task_complete)

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -49,7 +49,7 @@ class WSProtocol(asyncio.Protocol):
         self,
         config: Config,
         server_state: ServerState,
-        app_state: typing.Dict[str, typing.Any],
+        app_state: typing.ChainMap[str, typing.Any],
         _loop: typing.Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         if not config.loaded:
@@ -186,7 +186,7 @@ class WSProtocol(asyncio.Protocol):
             "headers": headers,
             "subprotocols": event.subprotocols,
             "extensions": None,
-            "state": self.app_state.copy(),
+            "state": self.app_state.new_child(),
         }
         self.queue.put_nowait({"type": "websocket.connect"})
         task = self.loop.create_task(self.run_asgi())


### PR DESCRIPTION
This lets applications differentiate between the lifespan and request states and even update the lifespan state from a request (previously not possible). For now let's keep this an implementation detail, but if it looks good we can advertise it and try to get it in the ASGI spec.