### PR TITLE
Log exception traceback in case of invalid HTTP request when using h11

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -205,9 +205,9 @@ class H11Protocol(asyncio.Protocol):
         while True:
             try:
                 event = self.conn.next_event()
-            except h11.RemoteProtocolError:
+            except h11.RemoteProtocolError as exc:
                 msg = "Invalid HTTP request received."
-                self.logger.warning(msg)
+                self.logger.warning(msg, exc_info=exc)
                 self.send_400_response(msg)
                 return
             event_type = type(event)


### PR DESCRIPTION
Author: florimondmanca (https://github.com/florimondmanca)
Source: https://github.com/encode/uvicorn/pull/889
Revert PR: https://github.com/encode/uvicorn/pull/1518

Motivation: I absolutely don't understand why this commit was reverted, if there are errors during execution you shouldn't keep quiet about them. Today I encountered the error `Invalid HTTP request received.` and I was stumped for hours because of it. After adding a traceback of the error it immediately became clear: `h11._util.RemoteProtocolError: Missing mandatory Host: header`. The funny thing about this error is that it appeared to me only if I used reverse proxy NGINX,