### PR TITLE
Load MessageLoggerMiddleware based on logger's effective level

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -504,7 +504,7 @@ class Config:
         elif self.interface == "asgi2":
             self.loaded_app = ASGI2Middleware(self.loaded_app)
 
-        if logger.level <= TRACE_LOG_LEVEL:
+        if logger.getEffectiveLevel() <= TRACE_LOG_LEVEL:
             self.loaded_app = MessageLoggerMiddleware(self.loaded_app)
         if self.proxy_headers:
             self.loaded_app = ProxyHeadersMiddleware(


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Fixes https://github.com/encode/uvicorn/issues/1958

I did an isolated test for this one, but if you think that I should merge this one with `test_config_log_level` and check there both (level and effective level) let me know.

I've not updated the documentation because I feel that it is not needed for this one.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
