### PR TITLE
Allow `ConfigParser` or a `io.IO[Any]` on `log_config`

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import configparser
+import io
 import json
 import logging
 import os
@@ -367,12 +371,10 @@ def test_log_config_yaml(
     mocked_logging_config_module.dictConfig.assert_called_once_with(logging_config)
 
 
-@pytest.mark.parametrize(
-    "config_file", ["log_config.ini", configparser.ConfigParser(), io.StringIO()]
-)
+@pytest.mark.parametrize("config_file", ["log_config.ini", configparser.ConfigParser(), io.StringIO()])
 def test_log_config_file(
     mocked_logging_config_module: MagicMock,
-    config_file: typing.Union[str, configparser.RawConfigParser, typing.IO],
+    config_file: str | configparser.RawConfigParser | typing.IO[Any],
 ) -> None:
     """
     Test that one can load a configparser config from disk.
@@ -380,9 +382,7 @@ def test_log_config_file(
     config = Config(app=asgi_app, log_config=config_file)
     config.load()
 
-    mocked_logging_config_module.fileConfig.assert_called_once_with(
-        "log_config", disable_existing_loggers=False
-    )
+    mocked_logging_config_module.fileConfig.assert_called_once_with(config_file, disable_existing_loggers=False)
 
 
 @pytest.fixture(params=[0, 1])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import logging
 import os
@@ -369,14 +367,22 @@ def test_log_config_yaml(
     mocked_logging_config_module.dictConfig.assert_called_once_with(logging_config)
 
 
-def test_log_config_file(mocked_logging_config_module: MagicMock) -> None:
+@pytest.mark.parametrize(
+    "config_file", ["log_config.ini", configparser.ConfigParser(), io.StringIO()]
+)
+def test_log_config_file(
+    mocked_logging_config_module: MagicMock,
+    config_file: typing.Union[str, configparser.RawConfigParser, typing.IO],
+) -> None:
     """
     Test that one can load a configparser config from disk.
     """
-    config = Config(app=asgi_app, log_config="log_config")
+    config = Config(app=asgi_app, log_config=config_file)
     config.load()
 
-    mocked_logging_config_module.fileConfig.assert_called_once_with("log_config", disable_existing_loggers=False)
+    mocked_logging_config_module.fileConfig.assert_called_once_with(
+        "log_config", disable_existing_loggers=False
+    )
 
 
 @pytest.fixture(params=[0, 1])

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -11,20 +11,7 @@ import ssl
 import sys
 from configparser import RawConfigParser
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Literal
-from typing import (
-    IO,
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import IO, Any, Awaitable, Callable, Literal
 
 import click
 
@@ -380,9 +367,7 @@ class Config:
                 with open(self.log_config) as file:
                     loaded_config = json.load(file)
                     logging.config.dictConfig(loaded_config)
-            elif isinstance(self.log_config, str) and self.log_config.endswith(
-                (".yaml", ".yml")
-            ):
+            elif isinstance(self.log_config, str) and self.log_config.endswith((".yaml", ".yml")):
                 # Install the PyYAML package or the uvicorn[standard] optional
                 # dependencies to enable this functionality.
                 import yaml

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -9,8 +9,22 @@ import os
 import socket
 import ssl
 import sys
+from configparser import RawConfigParser
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Literal
+from typing import (
+    IO,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import click
 
@@ -189,7 +203,7 @@ class Config:
         ws_per_message_deflate: bool = True,
         lifespan: LifespanType = "auto",
         env_file: str | os.PathLike[str] | None = None,
-        log_config: dict[str, Any] | str | None = LOGGING_CONFIG,
+        log_config: dict[str, Any] | str | RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
         log_level: str | int | None = None,
         access_log: bool = True,
         use_colors: bool | None = None,
@@ -362,11 +376,13 @@ class Config:
                     self.log_config["formatters"]["default"]["use_colors"] = self.use_colors
                     self.log_config["formatters"]["access"]["use_colors"] = self.use_colors
                 logging.config.dictConfig(self.log_config)
-            elif self.log_config.endswith(".json"):
+            elif isinstance(self.log_config, str) and self.log_config.endswith(".json"):
                 with open(self.log_config) as file:
                     loaded_config = json.load(file)
                     logging.config.dictConfig(loaded_config)
-            elif self.log_config.endswith((".yaml", ".yml")):
+            elif isinstance(self.log_config, str) and self.log_config.endswith(
+                (".yaml", ".yml")
+            ):
                 # Install the PyYAML package or the uvicorn[standard] optional
                 # dependencies to enable this functionality.
                 import yaml

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import configparser
 import logging
 import os
 import platform
 import ssl
 import sys
-from typing import Any, Callable
+from typing import Any, Callable, IO
 
 import click
 
@@ -481,7 +482,7 @@ def run(
     reload_delay: float = 0.25,
     workers: int | None = None,
     env_file: str | os.PathLike[str] | None = None,
-    log_config: dict[str, Any] | str | None = LOGGING_CONFIG,
+    log_config: dict[str, Any] | str | configparser.RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
     log_level: str | int | None = None,
     access_log: bool = True,
     proxy_headers: bool = True,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -7,7 +7,7 @@ import os
 import platform
 import ssl
 import sys
-from typing import Any, Callable, IO
+from typing import IO, Any, Callable
 
 import click
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import configparser
 import logging
 import os
 import platform
 import ssl
 import sys
+from configparser import RawConfigParser
 from typing import IO, Any, Callable
 
 import click
@@ -482,7 +482,7 @@ def run(
     reload_delay: float = 0.25,
     workers: int | None = None,
     env_file: str | os.PathLike[str] | None = None,
-    log_config: dict[str, Any] | str | configparser.RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
+    log_config: dict[str, Any] | str | RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
     log_level: str | int | None = None,
     access_log: bool = True,
     proxy_headers: bool = True,


### PR DESCRIPTION
This is a new instance of PR #1716 closed accidentally by deleting the forked repository.

Copy of the previous description:

> The existing logic for the `log_config` option accepts:
> * `dict` or `str` representing a JSON or YAML file name to be parsed using `logging.config.dictConfig`
> * `str` representing an INI file name to be parsed using `logging.config.fileConfig`
>
> The `logging.config.fileConfig`, however, accepts not only the file name, but possibly also an instance of `configparser.RawConfigParser` and even an open file object. Passing the instance of `configparser.RawConfigParser` (or its subclass) would be especially useful as this can accumulate configs from multiple files (`cp.read()` can be called repeatedly on different files updating its config values) instead of just a single one.
> 
> I am proposing this trivial change to allow the `log_config` option to also accept the `*ConfigParser` instance or a general file object.