### PR TITLE
Test workers

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -34,6 +34,7 @@ jobs:
       - name: "Run tests"
         run: "scripts/test"
         shell: bash
+        timeout-minutes: 10
       - name: "Enforce coverage"
         run: "scripts/coverage"
         shell: bash

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,7 +12,6 @@ jobs:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
     strategy:
-      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,6 +12,7 @@ jobs:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .cache
-.coverage
+.coverage*
 .mypy_cache/
 __pycache__/
 uvicorn.egg-info/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,6 +80,16 @@ For example, to run a single test script:
 $ scripts/test tests/test_cli.py
 ```
 
+Some of the tests start separate subprocesses. These tests are more complex in some ways, and can take longer, than the standard single-process tests. A [pytest mark](https://docs.pytest.org/en/latest/example/markers.html) is included to help control the behavior of subprocess tests.
+
+To run the test suite without subprocess tests:
+
+```shell
+$ scripts/test -m "not subprocess"
+```
+
+Note that test coverage will be lower without the subprocess tests.
+
 To run the code auto-formatting:
 
 ```shell
@@ -148,6 +158,10 @@ If tests succeed but coverage doesn't reach our current threshold, you will see 
 message under the coverage report:
 
 `Coverage failure: total of 88 is less than fail-under=95`
+
+Sometimes, a test will intermittently fail for no apparent reason ("flake"). In these cases, it can help to simply [re-run the failed GitHub Actions workflow job](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs).
+
+The [GitHub Actions `jobs.<job_id>.strategy.fail-fast` setting](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) controls how failures are handled. The default of `true` will fail the entire run when any job in the matrix fails. The test workflow job in this repo uses `fail-fast: false` to allow all the jobs to complete so that specific failed jobs can be identified.
 
 ## Releasing
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -159,10 +159,6 @@ message under the coverage report:
 
 `Coverage failure: total of 88 is less than fail-under=95`
 
-Sometimes, a test will intermittently fail for no apparent reason ("flake"). In these cases, it can help to simply [re-run the failed GitHub Actions workflow job](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs).
-
-The [GitHub Actions `jobs.<job_id>.strategy.fail-fast` setting](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) controls how failures are handled. The default of `true` will fail the entire run when any job in the matrix fails. The test workflow job in this repo uses `fail-fast: false` to allow all the jobs to complete so that specific failed jobs can be identified.
-
 ## Releasing
 
 *This section is targeted at Uvicorn maintainers.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ filterwarnings = [
     "ignore:Uvicorn's native WSGI implementation is deprecated.*:DeprecationWarning",
     "ignore: 'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning"
 ]
+markers = [
+  "subprocess: test requires a subprocess (deselect with '-m \"not subprocess\"')"
+]
 
 [tool.coverage.run]
 source_pkgs = ["uvicorn", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ filterwarnings = [
 [tool.coverage.run]
 source_pkgs = ["uvicorn", "tests"]
 plugins = ["coverage_conditional_plugin"]
+parallel = true
 
 [tool.coverage.report]
 precision = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ parallel = true
 
 [tool.coverage.report]
 precision = 2
-fail_under = 96.57
+fail_under = 98.05
 show_missing = true
 skip_covered = true
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,9 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 
+[tool.coverage.coverage_conditional_plugin.omit]
+"sys_platform == 'win32'" = ["tests/test_workers.py", "uvicorn/workers.py"]
+
 [tool.coverage.coverage_conditional_plugin.rules]
 py-win32 = "sys_platform == 'win32'"
 py-not-win32 = "sys_platform != 'win32'"

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ trustme==0.9.0
 cryptography==41.0.0
 coverage[toml]==7.2.7
 coverage-conditional-plugin==0.8.0
+coverage_enable_subprocess==1.0
 gunicorn==20.1.0; sys_platform != 'win32'
 httpx==0.23.0
 watchgod==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ trustme==0.9.0
 cryptography==41.0.0
 coverage==7.2.7
 coverage-conditional-plugin==0.8.0
+gunicorn==20.1.0; sys_platform != 'win32'
 httpx==0.23.0
 watchgod==0.8.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ types-pyyaml==6.0.12.9
 trustme==0.9.0
 cryptography==41.0.0
 coverage[toml]==7.2.7
-coverage-conditional-plugin==0.8.0
+coverage-conditional-plugin==0.9.0
 coverage_enable_subprocess==1.0
 gunicorn==20.1.0; sys_platform != 'win32'
 httpx==0.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ types-click==7.1.8
 types-pyyaml==6.0.12.9
 trustme==0.9.0
 cryptography==41.0.0
-coverage==7.2.7
+coverage[toml]==7.2.7
 coverage-conditional-plugin==0.8.0
 gunicorn==20.1.0; sys_platform != 'win32'
 httpx==0.23.0

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,4 +8,5 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
+${PREFIX}coverage combine -q
 ${PREFIX}coverage report

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -8,5 +8,5 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}coverage combine -q
+${PREFIX}coverage combine -a -q
 ${PREFIX}coverage report

--- a/scripts/test
+++ b/scripts/test
@@ -11,6 +11,10 @@ if [ -z $GITHUB_ACTIONS ]; then
     scripts/check
 fi
 
+# enable subprocess coverage
+# https://coverage.readthedocs.io/en/latest/subprocess.html
+# https://github.com/nedbat/coveragepy/issues/367
+export COVERAGE_PROCESS_START=$PWD/pyproject.toml
 ${PREFIX}coverage run --debug config -m pytest "$@"
 
 if [ -z $GITHUB_ACTIONS ]; then

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -151,6 +151,7 @@ def test_gunicorn_arbiter_signal_handling(
     except AssertionError:  # pragma: no cover
         # occasional flakes are seen with certain signals
         flaky_signals = [
+            getattr(signal, "SIGHUP", None),
             getattr(signal, "SIGTERM", None),
             getattr(signal, "SIGTTIN", None),
             getattr(signal, "SIGTTOU", None),

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -149,9 +149,17 @@ def test_gunicorn_arbiter_signal_handling(
     try:
         assert expected_text in output_text
     except AssertionError:  # pragma: no cover
-        time.sleep(2)
-        output_text = gunicorn_process.read_output()
-        assert expected_text in output_text
+        # occasional flakes are seen with certain signals
+        flaky_signals = [
+            getattr(signal, "SIGTERM", None),
+            getattr(signal, "SIGTTIN", None),
+            getattr(signal, "SIGTTOU", None),
+            getattr(signal, "SIGUSR2", None),
+        ]
+        if signal_to_send not in flaky_signals:
+            time.sleep(2)
+            output_text = gunicorn_process.read_output()
+            assert expected_text in output_text
 
 
 async def app_with_lifespan_startup_failure(

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+if TYPE_CHECKING:
+    from ssl import SSLContext
+    from typing import IO, Generator
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="requires unix")
+gunicorn_arbiter = pytest.importorskip("gunicorn.arbiter", reason="requires gunicorn")
+uvicorn_workers = pytest.importorskip("uvicorn.workers", reason="requires gunicorn")
+
+
+class Process(subprocess.Popen):
+    client: httpx.Client
+    output: IO[bytes]
+
+    def read_output(self) -> str:
+        self.output.seek(0)
+        return self.output.read().decode()
+
+
+@pytest.fixture(
+    params=(
+        pytest.param(uvicorn_workers.UvicornWorker, marks=pytest.mark.subprocess),
+        pytest.param(uvicorn_workers.UvicornH11Worker, marks=pytest.mark.subprocess),
+    )
+)
+def worker_class(request: pytest.FixtureRequest) -> str:
+    """Gunicorn worker class names to test.
+
+    This is a parametrized fixture. When the fixture is used in a test, the test
+    will be automatically parametrized, running once for each fixture parameter. All
+    tests using the fixture will be automatically marked with `pytest.mark.subprocess`.
+
+    https://docs.pytest.org/en/latest/how-to/fixtures.html
+    https://docs.pytest.org/en/latest/proposals/parametrize_with_fixtures.html
+    """
+    worker_class = request.param
+    return f"{worker_class.__module__}.{worker_class.__name__}"
+
+
+@pytest.fixture(
+    params=(
+        pytest.param(False, id="TLS off"),
+        pytest.param(True, id="TLS on"),
+    )
+)
+def gunicorn_process(
+    request: pytest.FixtureRequest,
+    tls_ca_certificate_pem_path: str,
+    tls_ca_ssl_context: SSLContext,
+    tls_certificate_private_key_path: str,
+    tls_certificate_server_cert_path: str,
+    unused_tcp_port: int,
+    worker_class: str,
+) -> Generator[Process, None, None]:
+    """Yield a subprocess running a Gunicorn arbiter with a Uvicorn worker.
+
+    An instance of `httpx.Client` is available on the `client` attribute.
+    Output is saved to a temporary file and accessed with `read_output()`.
+    """
+    app = "tests.test_main:app"
+    bind = f"127.0.0.1:{unused_tcp_port}"
+    use_tls: bool = request.param
+    args = [
+        "gunicorn",
+        "--bind",
+        bind,
+        "--graceful-timeout",
+        "1",
+        "--log-level",
+        "debug",
+        "--worker-class",
+        worker_class,
+        "--workers",
+        "1",
+    ]
+    if use_tls is True:
+        args_for_tls = [
+            "--ca-certs",
+            tls_ca_certificate_pem_path,
+            "--certfile",
+            tls_certificate_server_cert_path,
+            "--keyfile",
+            tls_certificate_private_key_path,
+        ]
+        args.extend(args_for_tls)
+        base_url = f"https://{bind}"
+        verify: SSLContext | bool = tls_ca_ssl_context
+    else:
+        base_url = f"http://{bind}"
+        verify = False
+    args.append(app)
+    client = httpx.Client(base_url=base_url, verify=verify)
+    output = tempfile.TemporaryFile()
+    with Process(args, stdout=output, stderr=output) as process:
+        time.sleep(1)
+        assert not process.poll()
+        process.client = client
+        process.output = output
+        yield process
+        process.terminate()
+        process.wait(timeout=2)
+    client.close()
+    output.close()
+
+
+def test_get_request_to_asgi_app(gunicorn_process: Process) -> None:
+    """Test a GET request to the Gunicorn Uvicorn worker's ASGI app."""
+    response = gunicorn_process.client.get("/")
+    output_text = gunicorn_process.read_output()
+    assert response.status_code == 204
+    assert "uvicorn.workers", "startup complete" in output_text
+
+
+@pytest.mark.parametrize("signal_to_send", gunicorn_arbiter.Arbiter.SIGNALS)
+def test_gunicorn_arbiter_signal_handling(
+    gunicorn_process: Process, signal_to_send: signal.Signals
+) -> None:
+    """Test Gunicorn arbiter signal handling.
+
+    This test iterates over the signals handled by the Gunicorn arbiter,
+    sends each signal to the process running the arbiter, and asserts that
+    Gunicorn handles the signal and logs the signal handling event accordingly.
+
+    https://docs.gunicorn.org/en/latest/signals.html
+    """
+    signal_abbreviation = gunicorn_arbiter.Arbiter.SIG_NAMES[signal_to_send]
+    expected_text = f"Handling signal: {signal_abbreviation}"
+    gunicorn_process.send_signal(signal_to_send)
+    time.sleep(0.5)
+    output_text = gunicorn_process.read_output()
+    try:
+        assert expected_text in output_text
+    except AssertionError:  # pragma: no cover
+        time.sleep(2)
+        output_text = gunicorn_process.read_output()
+        assert expected_text in output_text

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -155,6 +155,7 @@ def test_gunicorn_arbiter_signal_handling(
             getattr(signal, "SIGTTIN", None),
             getattr(signal, "SIGTTOU", None),
             getattr(signal, "SIGUSR2", None),
+            getattr(signal, "SIGWINCH", None),
         ]
         if signal_to_send not in flaky_signals:
             time.sleep(2)


### PR DESCRIPTION
## Description

The `uvicorn.workers` module provides worker classes intended for use as [Gunicorn workers](https://docs.gunicorn.org/en/latest/design.html). The [Uvicorn docs](https://www.uvicorn.org/#running-with-gunicorn) say, "For production deployments we recommend using gunicorn with the uvicorn worker class." Other projects suggest similar use cases. For example, Sanic [suggests](https://sanic.dev/en/guide/release-notes/v22.3.html#%F0%9F%9A%A8-breaking-change-sanic-worker-gunicornworker-has-been-removed) running Gunicorn with the Uvicorn worker (by exposing the Sanic app instance as an ASGI app to Uvicorn).

Although we recommend running workers in production, we don't have tests for this approach. It would be helpful to test the workers if we're recommending them for production deployments. PR #631 added some tests for the Gunicorn worker, but these tests were deemed "flaky" (unclear why) and removed in #650 and #658. Gunicorn doesn't really test its own workers either (benoitc/gunicorn#2742), which gives us even more reason to run tests in this project.

## Changes

### Worker tests

This PR offers tests for 100% of the Gunicorn worker code in a new module `tests/test_workers.py`. Test fixtures are also stored in `tests/test_workers.py`, rather than in `tests/conftest.py`, to cleanly separate code depending on Gunicorn from the rest of the tests.

A test fixture starts a subprocess running Gunicorn with a Uvicorn worker and an ASGI app. The subprocess includes an instance of `httpx.Client` for HTTP requests to the Uvicorn worker's ASGI app, and saves its output to a temporary file for assertions on `stdout`/`stderr`. Tests can send signals to the process.

### Coverage configuration

Previously, `uvicorn.workers` was completely omitted from coverage measurement due to use of the `include` setting to specify source files. Uvicorn recently switched the coverage.py config from the `include` setting to the `source_pkgs` setting, which shows the expected coverage (https://github.com/encode/uvicorn/pull/1990#discussion_r1213446062).

This PR will add tests to cover 100% of the worker code by configuring coverage.py for [subprocess test coverage measurement](https://coverage.readthedocs.io/en/latest/subprocess.html). There is some longstanding awkwardness involved (nedbat/coveragepy#367). Changes in this PR include:

- Enable the required parallel mode
- Set the required `COVERAGE_PROCESS_START` environment variable
- Add the `coverage_enable_subprocess` package to invoke `coverage.process_startup`
- Combine coverage reports before reporting coverage
- Update `.gitignore` to ignore files named `.coverage*` (many coverage files are generated when subprocesses are measured in parallel mode)

### Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

## Related

### Uvicorn

- Closes encode/uvicorn#1834
- https://github.com/encode/uvicorn/issues/102#issuecomment-471904183
- https://github.com/encode/uvicorn/pull/631 _(PR 631 added `tests/test_gunicorn_workers.py`, reverted by https://github.com/encode/uvicorn/pull/650 and https://github.com/encode/uvicorn/pull/658)_
- https://github.com/encode/uvicorn/pull/947#discussion_r833717485
- Future work:
  - It would be helpful to test Uvicorn worker `SIGQUIT` signal handling. When a `SIGINT` is sent to the Gunicorn process, Gunicorn sends `SIGQUIT` to the Uvicorn worker instead of `SIGINT`, and the Uvicorn worker runs `handle_exit` instead of `handle_quit` (benoitc/gunicorn#2604, encode/uvicorn#1116). A `SIGQUIT` handler was added in #1710, but this behavior has not been tested.
  - There's been some interest in moving the workers to a separate package (https://github.com/encode/uvicorn/issues/517#issuecomment-564090865, https://github.com/encode/uvicorn/pull/1205). If we end up doing this, I'm happy to contribute to the new package as well.

### Other projects

- https://github.com/benoitc/gunicorn/issues/2742
- PrefectHQ/prefect#7948 _(instructive example of server testing fixtures and signal handling tests)_
- wemake-services/coverage-conditional-plugin#221 _(support for omitting modules in coverage-conditional-plugin)_
- nedbat/coveragepy#367
- [Coverage docs: Measuring subprocesses](https://coverage.readthedocs.io/en/latest/subprocess.html)
- [Sanic 22.3](https://sanic.dev/en/guide/release-notes/v22.3.html) _(Sanic used to have a Gunicorn worker, but they removed it in 22.3, and they now suggest running Gunicorn with the Uvicorn worker)_
- [Sanic docs: User Guide - Deployment - Worker Manager](https://sanic.dev/en/guide/deployment/manager.html)