### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "actions/setup-python@v4"
         with:
-          python-version: 3.7
+          python-version: "3.8"
       - name: "Install dependencies"
         run: "scripts/install"
       - name: "Build package & docs"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: "actions/checkout@v3"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **Documentation**: [https://www.uvicorn.org](https://www.uvicorn.org)
 
-**Requirements**: Python 3.7+ (For Python 3.6 support, install version 0.16.0.)
+**Requirements**: Python 3.8+
 
 Uvicorn is an ASGI web server implementation for Python.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "The lightning-fast ASGI server."
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Tom Christie", email = "tom@tomchristie.com" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -31,7 +30,6 @@ classifiers = [
 dependencies = [
     "click>=7.0",
     "h11>=0.8",
-    "typing-extensions;python_version < '3.8'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import socket
 import sys
 import typing
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,11 +25,6 @@ from uvicorn.config import Config
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
-
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
 
 
 @pytest.fixture

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -14,23 +14,18 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
     Union,
 )
 
-from uvicorn.logging import TRACE_LOG_LEVEL
-
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
-
 import click
 
 from uvicorn._types import ASGIApplication
 from uvicorn.importer import ImportFromStringError, import_from_string
+from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.middleware.asgi2 import ASGI2Middleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -2,14 +2,9 @@ import http
 import logging
 import sys
 from copy import copy
-from typing import Optional
+from typing import Literal, Optional
 
 import click
-
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
 
 TRACE_LOG_LEVEL = 5
 

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -6,5 +6,5 @@ logger = logging.getLogger("uvicorn.error")
 
 
 def asyncio_setup(use_subprocess: bool = False) -> None:  # pragma: no cover
-    if sys.version_info >= (3, 8) and sys.platform == "win32" and use_subprocess:
+    if sys.platform == "win32" and use_subprocess:
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -1,12 +1,12 @@
 import asyncio
 import http
 import logging
-import sys
 from typing import (
     Any,
     Callable,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -43,12 +43,6 @@ from uvicorn.protocols.utils import (
     is_ssl,
 )
 from uvicorn.server import ServerState
-
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
-
 
 H11Event = Union[
     h11.Request,

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -2,7 +2,6 @@ import asyncio
 import http
 import logging
 import re
-import sys
 import urllib
 from asyncio.events import TimerHandle
 from collections import deque
@@ -12,6 +11,7 @@ from typing import (
     Deque,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -46,12 +46,6 @@ from uvicorn.protocols.utils import (
     is_ssl,
 )
 from uvicorn.server import ServerState
-
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
-
 
 HEADER_RE = re.compile(b'[\x00-\x1F\x7F()<>@,;:[]={} \t\\"]')
 HEADER_VALUE_RE = re.compile(b"[\x00-\x1F\x7F]")

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -1,11 +1,11 @@
 import asyncio
 import http
 import logging
-import sys
 from typing import (
     Any,
     Dict,
     List,
+    Literal,
     Optional,
     Sequence,
     Tuple,
@@ -41,11 +41,6 @@ from uvicorn.protocols.utils import (
     is_ssl,
 )
 from uvicorn.server import ServerState
-
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
 
 
 class Server:

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
-import sys
 import typing
+from typing import Literal
 from urllib.parse import unquote
 
 import wsproto
@@ -28,11 +28,6 @@ from uvicorn.protocols.utils import (
     is_ssl,
 )
 from uvicorn.server import ServerState
-
-if sys.version_info < (3, 8):  # pragma: py-gte-38
-    from typing_extensions import Literal
-else:  # pragma: py-lt-38
-    from typing import Literal
 
 
 class WSProtocol(asyncio.Protocol):


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Python 3.7 EOL is approaching: https://endoflife.date/python.

This PR drops support for Python 3.7.
