### PR TITLE
Revert #1804

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
-import contextlib
 import os
-import socket
 import ssl
 from copy import deepcopy
 from hashlib import md5
@@ -225,17 +223,3 @@ def touch_soon():
 
     for t in threads:
         t.join()
-
-
-def _unused_port(socket_type: int) -> int:
-    """Find an unused localhost port from 1024-65535 and return it."""
-    with contextlib.closing(socket.socket(type=socket_type)) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
-
-
-# This was copied from pytest-asyncio.
-# Ref.: https://github.com/pytest-dev/pytest-asyncio/blob/25d9592286682bc6dbfbf291028ff7a9594cf283/pytest_asyncio/plugin.py#L525-L527  # noqa: E501
-@pytest.fixture
-def unused_tcp_port() -> int:
-    return _unused_port(socket.SOCK_STREAM)

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -39,18 +39,14 @@ async def app(scope, receive, send):
 
 
 @pytest.mark.anyio
-async def test_trace_logging(caplog, logging_config, unused_tcp_port: int):
+async def test_trace_logging(caplog, logging_config):
     config = Config(
-        app=app,
-        log_level="trace",
-        log_config=logging_config,
-        lifespan="auto",
-        port=unused_tcp_port,
+        app=app, log_level="trace", log_config=logging_config, lifespan="auto"
     )
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
-                response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+                response = await client.get("http://127.0.0.1:8000")
         assert response.status_code == 204
         messages = [
             record.message for record in caplog.records if record.name == "uvicorn.asgi"
@@ -65,20 +61,17 @@ async def test_trace_logging(caplog, logging_config, unused_tcp_port: int):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol", HTTP_PROTOCOLS)
-async def test_trace_logging_on_http_protocol(
-    http_protocol, caplog, logging_config, unused_tcp_port: int
-):
+async def test_trace_logging_on_http_protocol(http_protocol, caplog, logging_config):
     config = Config(
         app=app,
         log_level="trace",
         http=http_protocol,
         log_config=logging_config,
-        port=unused_tcp_port,
     )
     with caplog_for_logger(caplog, "uvicorn.error"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
-                response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+                response = await client.get("http://127.0.0.1:8000")
         assert response.status_code == 204
         messages = [
             record.message
@@ -91,9 +84,7 @@ async def test_trace_logging_on_http_protocol(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("ws_protocol", [("websockets"), ("wsproto")])
-async def test_trace_logging_on_ws_protocol(
-    ws_protocol, caplog, logging_config, unused_tcp_port: int
-):
+async def test_trace_logging_on_ws_protocol(ws_protocol, caplog, logging_config):
     async def websocket_app(scope, receive, send):
         assert scope["type"] == "websocket"
         while True:
@@ -112,11 +103,10 @@ async def test_trace_logging_on_ws_protocol(
         log_level="trace",
         log_config=logging_config,
         ws=ws_protocol,
-        port=unused_tcp_port,
     )
     with caplog_for_logger(caplog, "uvicorn.error"):
         async with run_server(config):
-            is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
+            is_open = await open_connection("ws://127.0.0.1:8000")
         assert is_open
         messages = [
             record.message
@@ -130,14 +120,12 @@ async def test_trace_logging_on_ws_protocol(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("use_colors", [(True), (False), (None)])
-async def test_access_logging(use_colors, caplog, logging_config, unused_tcp_port: int):
-    config = Config(
-        app=app, use_colors=use_colors, log_config=logging_config, port=unused_tcp_port
-    )
+async def test_access_logging(use_colors, caplog, logging_config):
+    config = Config(app=app, use_colors=use_colors, log_config=logging_config)
     with caplog_for_logger(caplog, "uvicorn.access"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
-                response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+                response = await client.get("http://127.0.0.1:8000")
 
         assert response.status_code == 204
         messages = [
@@ -150,16 +138,12 @@ async def test_access_logging(use_colors, caplog, logging_config, unused_tcp_por
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("use_colors", [(True), (False)])
-async def test_default_logging(
-    use_colors, caplog, logging_config, unused_tcp_port: int
-):
-    config = Config(
-        app=app, use_colors=use_colors, log_config=logging_config, port=unused_tcp_port
-    )
+async def test_default_logging(use_colors, caplog, logging_config):
+    config = Config(app=app, use_colors=use_colors, log_config=logging_config)
     with caplog_for_logger(caplog, "uvicorn.access"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
-                response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+                response = await client.get("http://127.0.0.1:8000")
         assert response.status_code == 204
         messages = [
             record.message for record in caplog.records if "uvicorn" in record.name
@@ -168,17 +152,15 @@ async def test_default_logging(
         assert "Waiting for application startup" in messages.pop(0)
         assert "ASGI 'lifespan' protocol appears unsupported" in messages.pop(0)
         assert "Application startup complete" in messages.pop(0)
-        assert "Uvicorn running on http://127.0.0.1" in messages.pop(0)
+        assert "Uvicorn running on http://127.0.0.1:8000" in messages.pop(0)
         assert '"GET / HTTP/1.1" 204' in messages.pop(0)
         assert "Shutting down" in messages.pop(0)
 
 
 @pytest.mark.anyio
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
-async def test_running_log_using_uds(
-    caplog, short_socket_name, unused_tcp_port: int
-):  # pragma: py-win32
-    config = Config(app=app, uds=short_socket_name, port=unused_tcp_port)
+async def test_running_log_using_uds(caplog, short_socket_name):  # pragma: py-win32
+    config = Config(app=app, uds=short_socket_name)
     with caplog_for_logger(caplog, "uvicorn.access"):
         async with run_server(config):
             ...
@@ -192,10 +174,10 @@ async def test_running_log_using_uds(
 
 @pytest.mark.anyio
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
-async def test_running_log_using_fd(caplog, unused_tcp_port: int):  # pragma: py-win32
+async def test_running_log_using_fd(caplog):  # pragma: py-win32
     with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
         fd = sock.fileno()
-        config = Config(app=app, fd=fd, port=unused_tcp_port)
+        config = Config(app=app, fd=fd)
         with caplog_for_logger(caplog, "uvicorn.access"):
             async with run_server(config):
                 ...
@@ -205,17 +187,17 @@ async def test_running_log_using_fd(caplog, unused_tcp_port: int):  # pragma: py
 
 
 @pytest.mark.anyio
-async def test_unknown_status_code(caplog, unused_tcp_port: int):
+async def test_unknown_status_code(caplog):
     async def app(scope, receive, send):
         assert scope["type"] == "http"
         await send({"type": "http.response.start", "status": 599, "headers": []})
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
-    config = Config(app=app, port=unused_tcp_port)
+    config = Config(app=app)
     with caplog_for_logger(caplog, "uvicorn.access"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
-                response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+                response = await client.get("http://127.0.0.1:8000")
 
         assert response.status_code == 599
         messages = [

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -836,7 +836,7 @@ async def test_invalid_http_request(request_line, protocol_cls, caplog):
 
 
 @pytest.mark.skipif(HttpToolsProtocol is None, reason="httptools is not installed")
-def test_fragmentation(unused_tcp_port: int):
+def test_fragmentation():
     def receive_all(sock):
         chunks = []
         while True:
@@ -850,7 +850,7 @@ def test_fragmentation(unused_tcp_port: int):
 
     def send_fragmented_req(path):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect(("127.0.0.1", unused_tcp_port))
+        sock.connect(("127.0.0.1", 8000))
         d = (
             f"GET {path} HTTP/1.1\r\n" "Host: localhost\r\n" "Connection: close\r\n\r\n"
         ).encode()
@@ -868,7 +868,7 @@ def test_fragmentation(unused_tcp_port: int):
         sock.close()
         return resp
 
-    config = Config(app=app, http="httptools", port=unused_tcp_port)
+    config = Config(app=app, http="httptools")
     server = Server(config=config)
     t = threading.Thread(target=server.run)
     t.daemon = True

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -12,58 +12,55 @@ async def app(scope, receive, send):
 
 
 @pytest.mark.anyio
-async def test_default_default_headers(unused_tcp_port: int):
-    config = Config(app=app, loop="asyncio", limit_max_requests=1, port=unused_tcp_port)
+async def test_default_default_headers():
+    config = Config(app=app, loop="asyncio", limit_max_requests=1)
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
             assert response.headers["server"] == "uvicorn" and response.headers["date"]
 
 
 @pytest.mark.anyio
-async def test_override_server_header(unused_tcp_port: int):
+async def test_override_server_header():
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden")],
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
             assert (
                 response.headers["server"] == "over-ridden" and response.headers["date"]
             )
 
 
 @pytest.mark.anyio
-async def test_disable_default_server_header(unused_tcp_port: int):
+async def test_disable_default_server_header():
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         server_header=False,
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
             assert "server" not in response.headers
 
 
 @pytest.mark.anyio
-async def test_override_server_header_multiple_times(unused_tcp_port: int):
+async def test_override_server_header_multiple_times():
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("Server", "over-ridden"), ("Server", "another-value")],
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
             assert (
                 response.headers["server"] == "over-ridden, another-value"
                 and response.headers["date"]
@@ -71,17 +68,16 @@ async def test_override_server_header_multiple_times(unused_tcp_port: int):
 
 
 @pytest.mark.anyio
-async def test_add_additional_header(unused_tcp_port: int):
+async def test_add_additional_header():
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         headers=[("X-Additional", "new-value")],
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
             assert (
                 response.headers["x-additional"] == "new-value"
                 and response.headers["server"] == "uvicorn"
@@ -90,15 +86,14 @@ async def test_add_additional_header(unused_tcp_port: int):
 
 
 @pytest.mark.anyio
-async def test_disable_default_date_header(unused_tcp_port: int):
+async def test_disable_default_date_header():
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         date_header=False,
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
             assert "date" not in response.headers

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,45 +36,39 @@ def _has_ipv6(host):
 @pytest.mark.parametrize(
     "host, url",
     [
-        pytest.param(None, "http://127.0.0.1", id="default"),
-        pytest.param("localhost", "http://127.0.0.1", id="hostname"),
+        pytest.param(None, "http://127.0.0.1:8000", id="default"),
+        pytest.param("localhost", "http://127.0.0.1:8000", id="hostname"),
         pytest.param(
             "::1",
-            "http://[::1]",
+            "http://[::1]:8000",
             id="ipv6",
             marks=pytest.mark.skipif(not _has_ipv6("::1"), reason="IPV6 not enabled"),
         ),
     ],
 )
-async def test_run(host, url: str, unused_tcp_port: int):
-    config = Config(
-        app=app, host=host, loop="asyncio", limit_max_requests=1, port=unused_tcp_port
-    )
+async def test_run(host, url):
+    config = Config(app=app, host=host, loop="asyncio", limit_max_requests=1)
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"{url}:{unused_tcp_port}")
+            response = await client.get(url)
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
-async def test_run_multiprocess(unused_tcp_port: int):
-    config = Config(
-        app=app, loop="asyncio", workers=2, limit_max_requests=1, port=unused_tcp_port
-    )
+async def test_run_multiprocess():
+    config = Config(app=app, loop="asyncio", workers=2, limit_max_requests=1)
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
-async def test_run_reload(unused_tcp_port: int):
-    config = Config(
-        app=app, loop="asyncio", reload=True, limit_max_requests=1, port=unused_tcp_port
-    )
+async def test_run_reload():
+    config = Config(app=app, loop="asyncio", reload=True, limit_max_requests=1)
     async with run_server(config):
         async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("http://127.0.0.1:8000")
     assert response.status_code == 204
 
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -17,7 +17,6 @@ async def test_run(
     tls_certificate_server_cert_path,
     tls_certificate_private_key_path,
     tls_ca_certificate_pem_path,
-    unused_tcp_port: int,
 ):
     config = Config(
         app=app,
@@ -26,20 +25,16 @@ async def test_run(
         ssl_keyfile=tls_certificate_private_key_path,
         ssl_certfile=tls_certificate_server_cert_path,
         ssl_ca_certs=tls_ca_certificate_pem_path,
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("https://127.0.0.1:8000")
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
 async def test_run_chain(
-    tls_ca_ssl_context,
-    tls_certificate_key_and_chain_path,
-    tls_ca_certificate_pem_path,
-    unused_tcp_port: int,
+    tls_ca_ssl_context, tls_certificate_key_and_chain_path, tls_ca_certificate_pem_path
 ):
     config = Config(
         app=app,
@@ -47,28 +42,24 @@ async def test_run_chain(
         limit_max_requests=1,
         ssl_certfile=tls_certificate_key_and_chain_path,
         ssl_ca_certs=tls_ca_certificate_pem_path,
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("https://127.0.0.1:8000")
     assert response.status_code == 204
 
 
 @pytest.mark.anyio
-async def test_run_chain_only(
-    tls_ca_ssl_context, tls_certificate_key_and_chain_path, unused_tcp_port: int
-):
+async def test_run_chain_only(tls_ca_ssl_context, tls_certificate_key_and_chain_path):
     config = Config(
         app=app,
         loop="asyncio",
         limit_max_requests=1,
         ssl_certfile=tls_certificate_key_and_chain_path,
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("https://127.0.0.1:8000")
     assert response.status_code == 204
 
 
@@ -78,7 +69,6 @@ async def test_run_password(
     tls_certificate_server_cert_path,
     tls_ca_certificate_pem_path,
     tls_certificate_private_key_encrypted_path,
-    unused_tcp_port: int,
 ):
     config = Config(
         app=app,
@@ -88,9 +78,8 @@ async def test_run_password(
         ssl_certfile=tls_certificate_server_cert_path,
         ssl_keyfile_password="uvicorn password for the win",
         ssl_ca_certs=tls_ca_certificate_pem_path,
-        port=unused_tcp_port,
     )
     async with run_server(config):
         async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
-            response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
+            response = await client.get("https://127.0.0.1:8000")
     assert response.status_code == 204


### PR DESCRIPTION
This PR reverts #1804.

The idea there was to make sure you could run the test suite on another port besides 8000, but it's a flaky setup - I'm unsure why, but it fails too much, it's better to revert and then if someone wants, they can try to find out the reason.