### PR TITLE
Handle malformed HTTP request with multiple Connection headers

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -175,7 +175,7 @@ class H11Protocol(asyncio.Protocol):
         upgrade = None
         for name, value in self.headers:
             if name == b"connection":
-                connection = [token.lower().strip() for token in value.split(b",")]
+                connection += [token.lower().strip() for token in value.split(b",")]
             if name == b"upgrade":
                 upgrade = value.lower()
         if b"upgrade" in connection:


### PR DESCRIPTION
This PR fixes a problem with Websockets when running Uvicorn on GitHub Codespaces

Detailed discussion:
https://github.com/orgs/community/discussions/57596

# Summary

Please do not merge quickly, I am not sure if this is a Uvicorn bug or a problem with the GitHub codespaces reverse proxy sending a malformed HTTP requests.

According to [RFC7230](https://datatracker.ietf.org/doc/html/rfc7230) there should not be duplicated Connection headers.

> A sender MUST NOT generate multiple header fields with the same field
name in a message unless either the entire field value for that
header field is defined as a comma-separated list [i.e., #(values)]
or the header field is a well-known exception (as noted below).


I am running Uvicorn in GitHub Codespaces. I am forwarding a port with visibility public and port protocol HTTP.
My first Websocket connection works, but after a few seconds the Websocket endpoint starts returning HTTP 404.

I captured traffic at the Uvicorn server with tcpdump and I figured out that when I receive a HTTP 404 the HTTP request has a duplicated `Connection` header.

<img width="1236" alt="Screenshot 2023-06-09 at 08 46 22" src="https://github.com/encode/uvicorn/assets/789701/bd624e77-0cae-4385-a8a5-79d9255e232b">

This is a problem and looking at the Uvicorn implementation it will make the Websockets connection fail to upgrade randomly depending on which one of the duplicated `Connection` header is read first.

https://github.com/encode/uvicorn/blob/1cb58c707ae7203f3b24e714947e7ab025b20895/uvicorn/protocols/http/h11_impl.py#L173-L183

I confirm that with the patch proposed in this PR fixes the problem completely because `connection` will be a list with the values `['upgrade', 'keep-alive']`. However it could be that the request is just malformed and Uvicorn should not implement anything to cope with malformed HTTP requests.

Please review.

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [X] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
