### PR TITLE
Fix coverage-conditional-plugin syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 98.10
+fail_under = 98.28
 show_missing = true
 skip_covered = true
 exclude_lines = [
@@ -112,7 +112,7 @@ exclude_lines = [
 ]
 
 [tool.coverage.coverage_conditional_plugin.omit]
-"uvicorn/loops/uvloop.py" = "sys_platform == 'win32'"
+"sys_platform == 'win32'" = ["uvicorn/loops/uvloop.py"]
 
 [tool.coverage.coverage_conditional_plugin.rules]
 py-win32 = "sys_platform == 'win32'"
@@ -121,5 +121,5 @@ py-linux = "sys_platform == 'linux'"
 py-darwin = "sys_platform == 'darwin'"
 py-gte-38 = "sys_version_info >= (3, 8)"
 py-lt-38 =  "sys_version_info < (3, 8)"
-py-gte-39 = "sys_version_info < (3, 9)"
+py-gte-39 = "sys_version_info >= (3, 9)"
 py-lt-39 = "sys_version_info < (3, 9)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ types-pyyaml==6.0.12.9
 trustme==0.9.0
 cryptography==41.0.0
 coverage==7.2.7
-coverage-conditional-plugin==0.8.0
+coverage-conditional-plugin==0.9.0
 httpx==0.23.0
 watchgod==0.8.2
 


### PR DESCRIPTION
## Summary

The coverage-conditional-plugin allows code to be conditionally omitted from test coverage reports. The syntax can be confusing (wemake-services/coverage-conditional-plugin#188).

The `py-gte-39` rule is backwards.

https://github.com/encode/uvicorn/blob/3737d66d7d28ea139345410bf2dad4433d8fc81e/pyproject.toml#L124-L125

The omit added in #2001 is backwards and isn't supported on version 0.8.0.

https://github.com/encode/uvicorn/blob/3737d66d7d28ea139345410bf2dad4433d8fc81e/pyproject.toml#L114-L115

https://github.com/encode/uvicorn/blob/3737d66d7d28ea139345410bf2dad4433d8fc81e/requirements.txt#L23

Coverage reports demonstrate this.

![encode-uvicorn-3217-incorrect-conditional-pragma](https://github.com/encode/uvicorn/assets/26674818/eb1ad676-ef90-4fa9-8c23-9c3c3ed81165)

## Changes

- Fix `py-gte-39` rule
- Fix omit syntax
- Update to `coverage-conditional-plugin==0.9.0` to support omit syntax

## Related

- #1995
- #2001
- wemake-services/coverage-conditional-plugin#188
- wemake-services/coverage-conditional-plugin#221

## Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
