### PR TITLE
Fix `x_forwarded_proto` for websockets in `proxy_headers.py`

### DIFF
--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -59,8 +59,15 @@ class ProxyHeadersMiddleware:
                 if b"x-forwarded-proto" in headers:
                     # Determine if the incoming request was http or https based on
                     # the X-Forwarded-Proto header.
-                    x_forwarded_proto = headers[b"x-forwarded-proto"].decode("latin1")
-                    scope["scheme"] = x_forwarded_proto.strip()
+                    x_forwarded_proto = (
+                        headers[b"x-forwarded-proto"].decode("latin1").strip()
+                    )
+                    if scope["type"] == "websocket":
+                        scope["scheme"] = (
+                            "wss" if x_forwarded_proto == "https" else "ws"
+                        )
+                    else:
+                        scope["scheme"] = x_forwarded_proto
 
                 if b"x-forwarded-for" in headers:
                     # Determine the client address from the last trusted IP in the


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

As discussed in https://github.com/encode/uvicorn/discussions/1933, the upstream proxies (i.e., Caddy) will always pass http or https in x_forwarded_proto, even if it is a WebSocket Upgrade request. However, storing the http or https in a WebSocket scope is not correct. In this pull request, I added some if statements to solve this issue.

I know there are no unit tests, because I don't know how to write, and help wanted.

This PR is based on #1934 based on suggestions from @Kludex and @aminalaee 

# Checklist

- [ x ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [  ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ x ] I've updated the documentation accordingly.
