### PR TITLE
Add worker process guard.

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,6 +57,9 @@ Options:
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
+  --guard BOOLEAN                 Guard of worker processes.
+  --guard-check-time INTEGER      Protect the check time of the working
+                                  process. Time unit: second
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,9 @@ Options:
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
+  --guard BOOLEAN                 Guard of worker processes.
+  --guard-check-time INTEGER      Protect the check time of the working
+                                  process. Time unit: second
   --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -212,6 +212,8 @@ class Config:
         reload_includes: Optional[Union[List[str], str]] = None,
         reload_excludes: Optional[Union[List[str], str]] = None,
         workers: Optional[int] = None,
+        guard: bool = True,
+        guard_check_time: int = 1,
         proxy_headers: bool = True,
         server_header: bool = True,
         date_header: bool = True,
@@ -256,6 +258,8 @@ class Config:
         self.reload = reload
         self.reload_delay = reload_delay
         self.workers = workers or 1
+        self.guard = guard
+        self.guard_check_time = guard_check_time
         self.proxy_headers = proxy_headers
         self.server_header = server_header
         self.date_header = date_header

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -118,6 +118,18 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     " variable if available, or 1. Not valid with --reload.",
 )
 @click.option(
+    "--guard",
+    default=True,
+    type=bool,
+    help="Guard of worker processes.",
+)
+@click.option(
+    "--guard-check-time",
+    default=1,
+    type=int,
+    help="Protect the check time of the working process. Time unit: second",
+)
+@click.option(
     "--loop",
     type=LOOP_CHOICES,
     default="auto",
@@ -378,6 +390,8 @@ def main(
     reload_excludes: typing.List[str],
     reload_delay: float,
     workers: int,
+    guard: bool,
+    guard_check_time: int,
     env_file: str,
     log_config: str,
     log_level: str,
@@ -430,6 +444,8 @@ def main(
         reload_excludes=reload_excludes or None,
         reload_delay=reload_delay,
         workers=workers,
+        guard=guard,
+        guard_check_time=guard_check_time,
         proxy_headers=proxy_headers,
         server_header=server_header,
         date_header=date_header,
@@ -477,6 +493,8 @@ def run(
     reload_excludes: typing.Optional[typing.Union[typing.List[str], str]] = None,
     reload_delay: float = 0.25,
     workers: typing.Optional[int] = None,
+    guard: bool = True,
+    guard_check_time: int = 1,
     env_file: typing.Optional[typing.Union[str, os.PathLike]] = None,
     log_config: typing.Optional[
         typing.Union[typing.Dict[str, typing.Any], str]
@@ -530,6 +548,8 @@ def run(
         reload_excludes=reload_excludes,
         reload_delay=reload_delay,
         workers=workers,
+        guard=guard,
+        guard_check_time=guard_check_time,
         env_file=env_file,
         log_config=log_config,
         log_level=log_level,

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import time
 import signal
+import time
 import threading
 from multiprocessing.context import SpawnProcess
 from socket import socket

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -41,14 +41,14 @@ class Multiprocess:
         """
         self.should_exit.set()
 
-    def start_worker_process(self):
+    def start_worker_process(self) -> None:
         process = get_subprocess(
             config=self.config, target=self.target, sockets=self.sockets
         )
         process.start()
         self.processes.append(process)
 
-    def guard_check(self):
+    def guard_check(self) -> None:
         while not self.should_exit.isSet():
             for item in self.processes:
                 if item.is_alive():

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -23,10 +23,10 @@ logger = logging.getLogger("uvicorn.error")
 
 class Multiprocess:
     def __init__(
-            self,
-            config: Config,
-            target: Callable[[Optional[List[socket]]], None],
-            sockets: List[socket],
+        self,
+        config: Config,
+        target: Callable[[Optional[List[socket]]], None],
+        sockets: List[socket],
     ) -> None:
         self.config = config
         self.target = target
@@ -56,8 +56,8 @@ class Multiprocess:
                 else:
                     self.processes.remove(item)
                     logger.error(
-                        f'Worker process is die [{item.pid}]. '
-                        f'Will restart in {self.config.guard_check_time} second'
+                        f"Worker process is die [{item.pid}]. "
+                        f"Will restart in {self.config.guard_check_time} second"
                     )
 
                     self.start_worker_process()

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -23,10 +23,10 @@ logger = logging.getLogger("uvicorn.error")
 
 class Multiprocess:
     def __init__(
-        self,
-        config: Config,
-        target: Callable[[Optional[List[socket]]], None],
-        sockets: List[socket],
+            self,
+            config: Config,
+            target: Callable[[Optional[List[socket]]], None],
+            sockets: List[socket],
     ) -> None:
         self.config = config
         self.target = target
@@ -55,8 +55,10 @@ class Multiprocess:
                     continue
                 else:
                     self.processes.remove(item)
-                    logger.error(f'Worker process is die [{item.pid}]. '
-                                 f'Will restart in {self.config.guard_check_time} second')
+                    logger.error(
+                        f'Worker process is die [{item.pid}]. '
+                        f'Will restart in {self.config.guard_check_time} second'
+                    )
 
                     self.start_worker_process()
                     break

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import signal
-import time
 import threading
+import time
 from multiprocessing.context import SpawnProcess
 from socket import socket
 from types import FrameType


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In some cases, the worker thread cannot be automatically restarted after the exception ends, resulting in the inability to provide services normally. You need to end the main process each time and restart it. To solve this problem, add worker process state detection to the main thread. If the worker process is dead, a new worker process is recreated.

# Checklist

- [*] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
