### PR TITLE
Add `--ws-max-queue` parameter

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,6 +65,8 @@ Options:
                                   [default: auto]
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
+  --ws-max-queue INTEGER          WebSocket maximum length of the queue that
+                                  holds incoming messages  [default: 32]
   --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
   --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
   --ws-per-message-deflate BOOLEAN

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,8 +65,8 @@ Options:
                                   [default: auto]
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
-  --ws-max-queue INTEGER          WebSocket maximum length of the queue that
-                                  holds incoming messages  [default: 32]
+  --ws-max-queue INTEGER          The maximum length of the WebSocket message
+                                  queue.  [default: 32]
   --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
   --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
   --ws-per-message-deflate BOOLEAN

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,8 +132,8 @@ Options:
                                   [default: auto]
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
-  --ws-max-queue INTEGER          WebSocket maximum length of the queue that
-                                  holds incoming messages  [default: 32]
+  --ws-max-queue INTEGER          The maximum length of the WebSocket message
+                                  queue.  [default: 32]
   --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
   --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
   --ws-per-message-deflate BOOLEAN

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,6 +132,8 @@ Options:
                                   [default: auto]
   --ws-max-size INTEGER           WebSocket max size message in bytes
                                   [default: 16777216]
+  --ws-max-queue INTEGER          WebSocket maximum length of the queue that
+                                  holds incoming messages  [default: 32]
   --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
   --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
   --ws-per-message-deflate BOOLEAN

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -69,7 +69,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 * `--http <str>` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy. **Options:** *'auto', 'h11', 'httptools'.* **Default:** *'auto'*.
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to ignore all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
 * `--ws-max-size <int>` - Set the WebSockets max message size, in bytes. Please note that this can be used only with the default `websockets` protocol.
-* `--ws-max-queue <int>` - Set the WebSockets maximum length of the queue that holds incoming messages size. Please note that this can be used only with the default `websockets` protocol.
+* `--ws-max-queue <int>` - Set the maximum length of the WebSocket incoming messages queue. Please note that this can be used only with the default `websockets` protocol.
 * `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Please note that this can be used only with the default `websockets` protocol.
 * `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Please note that this can be used only with the default `websockets` protocol.
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -69,6 +69,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 * `--http <str>` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy. **Options:** *'auto', 'h11', 'httptools'.* **Default:** *'auto'*.
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to ignore all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
 * `--ws-max-size <int>` - Set the WebSockets max message size, in bytes. Please note that this can be used only with the default `websockets` protocol.
+* `--ws-max-queue <int>` - Set the WebSockets maximum length of the queue that holds incoming messages size. Please note that this can be used only with the default `websockets` protocol.
 * `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Please note that this can be used only with the default `websockets` protocol.
 * `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Please note that this can be used only with the default `websockets` protocol.
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -69,7 +69,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 * `--http <str>` - Set the HTTP protocol implementation. The httptools implementation provides greater performance, but it not compatible with PyPy. **Options:** *'auto', 'h11', 'httptools'.* **Default:** *'auto'*.
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to ignore all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
 * `--ws-max-size <int>` - Set the WebSockets max message size, in bytes. Please note that this can be used only with the default `websockets` protocol.
-* `--ws-max-queue <int>` - Set the maximum length of the WebSocket incoming messages queue. Please note that this can be used only with the default `websockets` protocol.
+* `--ws-max-queue <int>` - Set the maximum length of the WebSocket incoming message queue. Please note that this can be used only with the default `websockets` protocol.
 * `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Please note that this can be used only with the default `websockets` protocol.
 * `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Please note that this can be used only with the default `websockets` protocol.
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -514,6 +514,12 @@ def test_ws_max_size() -> None:
     assert config.ws_max_size == 1000
 
 
+def test_ws_max_queue() -> None:
+    config = Config(app=asgi_app, ws_max_queue=64)
+    config.load()
+    assert config.ws_max_queue == 64
+
+
 @pytest.mark.parametrize(
     "reload, workers",
     [

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -196,6 +196,7 @@ class Config:
         http: Union[Type[asyncio.Protocol], HTTPProtocolType] = "auto",
         ws: Union[Type[asyncio.Protocol], WSProtocolType] = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
+        ws_max_queue: int = 32,
         ws_ping_interval: Optional[float] = 20.0,
         ws_ping_timeout: Optional[float] = 20.0,
         ws_per_message_deflate: bool = True,
@@ -244,6 +245,7 @@ class Config:
         self.http = http
         self.ws = ws
         self.ws_max_size = ws_max_size
+        self.ws_max_queue = ws_max_queue
         self.ws_ping_interval = ws_ping_interval
         self.ws_ping_timeout = ws_ping_timeout
         self.ws_per_message_deflate = ws_per_message_deflate

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -149,7 +149,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--ws-max-queue",
     type=int,
     default=32,
-    help="WebSocket maximum length of the queue that holds incoming messages",
+    help="The maximum length of the WebSocket message queue.",
     show_default=True,
 )
 @click.option(

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -146,6 +146,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     show_default=True,
 )
 @click.option(
+    "--ws-max-queue",
+    type=int,
+    default=32,
+    help="WebSocket maximum length of the queue that holds incoming messages",
+    show_default=True,
+)
+@click.option(
     "--ws-ping-interval",
     type=float,
     default=20.0,
@@ -367,6 +374,7 @@ def main(
     http: HTTPProtocolType,
     ws: WSProtocolType,
     ws_max_size: int,
+    ws_max_queue: int,
     ws_ping_interval: float,
     ws_ping_timeout: float,
     ws_per_message_deflate: bool,
@@ -415,6 +423,7 @@ def main(
         http=http,
         ws=ws,
         ws_max_size=ws_max_size,
+        ws_max_queue=ws_max_queue,
         ws_ping_interval=ws_ping_interval,
         ws_ping_timeout=ws_ping_timeout,
         ws_per_message_deflate=ws_per_message_deflate,
@@ -466,6 +475,7 @@ def run(
     http: typing.Union[typing.Type[asyncio.Protocol], HTTPProtocolType] = "auto",
     ws: typing.Union[typing.Type[asyncio.Protocol], WSProtocolType] = "auto",
     ws_max_size: int = 16777216,
+    ws_max_queue: int = 32,
     ws_ping_interval: typing.Optional[float] = 20.0,
     ws_ping_timeout: typing.Optional[float] = 20.0,
     ws_per_message_deflate: bool = True,
@@ -519,6 +529,7 @@ def run(
         http=http,
         ws=ws,
         ws_max_size=ws_max_size,
+        ws_max_queue=ws_max_queue,
         ws_ping_interval=ws_ping_interval,
         ws_ping_timeout=ws_ping_timeout,
         ws_per_message_deflate=ws_per_message_deflate,

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -105,6 +105,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             ws_handler=self.ws_handler,
             ws_server=self.ws_server,  # type: ignore[arg-type]
             max_size=self.config.ws_max_size,
+            max_queue=self.config.ws_max_queue,
             ping_interval=self.config.ws_ping_interval,
             ping_timeout=self.config.ws_ping_timeout,
             extensions=extensions,


### PR DESCRIPTION
allows configuring implementation detail of "websocket": maximum length of the queue that holds incoming messages

<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

draft implementation for https://github.com/encode/uvicorn/discussions/2032

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
