### PR TITLE
Raise `ImportError` on circular import

### DIFF
--- a/tests/importer/circular_import_a.py
+++ b/tests/importer/circular_import_a.py
@@ -1,0 +1,4 @@
+# Used by test_importer.py
+from .circular_import_b import foo  # noqa
+
+bar = 123

--- a/tests/importer/circular_import_b.py
+++ b/tests/importer/circular_import_b.py
@@ -1,0 +1,4 @@
+# Used by test_importer.py
+from .circular_import_a import bar  # noqa
+
+foo = 123

--- a/tests/importer/test_importer.py
+++ b/tests/importer/test_importer.py
@@ -41,3 +41,13 @@ def test_no_import_needed() -> None:
 
     instance = import_from_string(TemporaryFile)
     assert instance == TemporaryFile
+
+
+def test_circular_import_error() -> None:
+    with pytest.raises(ImportError) as exc_info:
+        import_from_string("tests.importer.circular_import_a:bar")
+    expected = (
+        "cannot import name 'bar' from partially initialized module "
+        "'tests.importer.circular_import_a' (most likely due to a circular import)"
+    )
+    assert expected in str(exc_info.value)

--- a/uvicorn/importer.py
+++ b/uvicorn/importer.py
@@ -19,7 +19,7 @@ def import_from_string(import_str: Any) -> Any:
 
     try:
         module = importlib.import_module(module_str)
-    except ImportError as exc:
+    except ModuleNotFoundError as exc:
         if exc.name != module_str:
             raise exc from None
         message = 'Could not import module "{module_str}".'


### PR DESCRIPTION
- Replaces/Closes #2038
- Closes #2034 

Let's _not_ try to improve the error message when we have a circular import. :)