### PR TITLE
Bump `httpx` and `h11`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ trustme==0.9.0
 cryptography==41.0.2
 coverage==7.2.7
 coverage-conditional-plugin==0.9.0
-httpx==0.23.0
+httpx==0.24.1
+h11 @ git+https://github.com/python-hyper/h11.git@master
 watchgod==0.8.2
 
 # Documentation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 -e .[standard]
 
+# TODO: Remove this after h11 makes a release. By this writing, h11 was on 0.14.0.
+# Core dependencies
+h11 @ git+https://github.com/python-hyper/h11.git@master
+
 # Explicit optionals
 a2wsgi==1.7.0
 wsproto==1.2.0
@@ -22,7 +26,6 @@ cryptography==41.0.2
 coverage==7.2.7
 coverage-conditional-plugin==0.9.0
 httpx==0.24.1
-h11 @ git+https://github.com/python-hyper/h11.git@master
 watchgod==0.8.2
 
 # Documentation

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -9,7 +9,6 @@ from typing import (
     Literal,
     Optional,
     Tuple,
-    Union,
     cast,
 )
 from urllib.parse import unquote
@@ -21,7 +20,6 @@ from uvicorn._types import (
     ASGI3Application,
     ASGIReceiveEvent,
     ASGISendEvent,
-    HTTPDisconnectEvent,
     HTTPRequestEvent,
     HTTPResponseBodyEvent,
     HTTPResponseStartEvent,
@@ -192,12 +190,11 @@ class H11Protocol(asyncio.Protocol):
                 self.logger.warning(msg)
                 self.send_400_response(msg)
                 return
-            event_type = type(event)
 
-            if event_type is h11.NEED_DATA:
+            if event is h11.NEED_DATA:
                 break
 
-            elif event_type is h11.PAUSED:
+            elif event is h11.PAUSED:
                 # This case can occur in HTTP pipelining, so we need to
                 # stop reading any more data, and ensure that at the end
                 # of the active request/response cycle we handle any
@@ -267,7 +264,7 @@ class H11Protocol(asyncio.Protocol):
                     self.flow.pause_reading()
                 self.cycle.message_event.set()
 
-            elif event_type is h11.EndOfMessage:
+            elif isinstance(event, h11.EndOfMessage):
                 if self.conn.our_state is h11.DONE:
                     self.transport.resume_reading()
                     self.conn.start_next_cycle()
@@ -296,7 +293,7 @@ class H11Protocol(asyncio.Protocol):
 
     def send_400_response(self, msg: str) -> None:
         reason = STATUS_PHRASES[400]
-        headers = [
+        headers: List[Tuple[bytes, bytes]] = [
             (b"content-type", b"text/plain; charset=utf-8"),
             (b"connection", b"close"),
         ]
@@ -471,7 +468,7 @@ class RequestResponseCycle:
             self.response_started = True
             self.waiting_for_100_continue = False
 
-            status_code = message["status"]
+            status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
             if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
@@ -484,15 +481,13 @@ class RequestResponseCycle:
                     self.scope["method"],
                     get_path_with_query_string(self.scope),
                     self.scope["http_version"],
-                    status_code,
+                    status,
                 )
 
             # Write response status line and headers
-            reason = STATUS_PHRASES[status_code]
-            # fmt: off
-            response = h11.Response(status_code=status_code, headers=headers, reason=reason) # noqa: E501
+            reason = STATUS_PHRASES[status]
+            response = h11.Response(status_code=status, headers=headers, reason=reason)
             output = self.conn.send(event=response)
-            # fmt: on
             self.transport.write(output)
 
         elif not self.response_complete:
@@ -514,8 +509,7 @@ class RequestResponseCycle:
             if not more_body:
                 self.response_complete = True
                 self.message_event.set()
-                eom_event = h11.EndOfMessage()
-                output = self.conn.send(eom_event)
+                output = self.conn.send(event=h11.EndOfMessage())
                 self.transport.write(output)
 
         else:
@@ -525,18 +519,17 @@ class RequestResponseCycle:
 
         if self.response_complete:
             if self.conn.our_state is h11.MUST_CLOSE or not self.keep_alive:
-                event = h11.ConnectionClosed()
-                self.conn.send(event)
+                self.conn.send(event=h11.ConnectionClosed())
                 self.transport.close()
             self.on_response()
 
     async def receive(self) -> "ASGIReceiveEvent":
         if self.waiting_for_100_continue and not self.transport.is_closing():
-            # fmt: off
             headers: List[Tuple[str, str]] = []
-            informational_response = h11.InformationalResponse(status_code=100, headers=headers, reason="Continue") # noqa: E501
-            output = self.conn.send(event=informational_response)
-            # fmt: on
+            event = h11.InformationalResponse(
+                status_code=100, headers=headers, reason="Continue"
+            )
+            output = self.conn.send(event=event)
             self.transport.write(output)
             self.waiting_for_100_continue = False
 
@@ -545,11 +538,13 @@ class RequestResponseCycle:
             await self.message_event.wait()
             self.message_event.clear()
 
-        message: "Union[HTTPDisconnectEvent, HTTPRequestEvent]"
         if self.disconnected or self.response_complete:
             return {"type": "http.disconnect"}
-        # fmt: off
-        message = {"type": "http.request", "body": self.body, "more_body": self.more_body}  # noqa: E501
-        # fmt: on
+
+        message: "HTTPRequestEvent" = {
+            "type": "http.request",
+            "body": self.body,
+            "more_body": self.more_body,
+        }
         self.body = b""
         return message


### PR DESCRIPTION
`httpx` is limiting `h11` - and `h11` is a mandatory dependency of `uvicorn`.

I'm using the main branch of `h11` because we need the type improvements I've suggested there: https://github.com/python-hyper/h11/pull/161.