### PR TITLE
Create `ws_protocol_cls` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import contextlib
+import importlib.util
 import os
 import socket
 import ssl
@@ -22,6 +23,7 @@ except ImportError:  # pragma: no cover
     HAVE_TRUSTME = False
 
 from uvicorn.config import LOGGING_CONFIG
+from uvicorn.importer import import_from_string
 
 # Note: We explicitly turn the propagate on just for tests, because pytest
 # caplog not able to capture no-propagate loggers.
@@ -239,3 +241,18 @@ def _unused_port(socket_type: int) -> int:
 @pytest.fixture
 def unused_tcp_port() -> int:
     return _unused_port(socket.SOCK_STREAM)
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            "uvicorn.protocols.websockets.wsproto_impl:WSProtocol",
+            marks=pytest.mark.skipif(
+                not importlib.util.find_spec("wsproto"), reason="wsproto not installed."
+            ),
+        ),
+        "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
+    ]
+)
+def ws_protocol(request: pytest.FixtureRequest):
+    return import_from_string(request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,5 +254,5 @@ def unused_tcp_port() -> int:
         "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
     ]
 )
-def ws_protocol(request: pytest.FixtureRequest):
+def ws_protocol_cls(request: pytest.FixtureRequest):
     return import_from_string(request.param)

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -96,7 +96,7 @@ async def test_trace_logging_on_http_protocol(
 
 @pytest.mark.anyio
 async def test_trace_logging_on_ws_protocol(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     caplog,
     logging_config,
     unused_tcp_port: int,
@@ -118,7 +118,7 @@ async def test_trace_logging_on_ws_protocol(
         app=websocket_app,
         log_level="trace",
         log_config=logging_config,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         port=unused_tcp_port,
     )
     with caplog_for_logger(caplog, "uvicorn.error"):

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -96,7 +96,7 @@ async def test_trace_logging_on_http_protocol(
 
 @pytest.mark.anyio
 async def test_trace_logging_on_ws_protocol(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     caplog,
     logging_config,
     unused_tcp_port: int,

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -2,6 +2,7 @@ import contextlib
 import logging
 import socket
 import sys
+import typing
 
 import httpx
 import pytest
@@ -18,6 +19,10 @@ try:
     HTTP_PROTOCOLS = [H11Protocol, HttpToolsProtocol]
 except ImportError:  # pragma: nocover
     HTTP_PROTOCOLS = [H11Protocol]
+
+if typing.TYPE_CHECKING:
+    from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
+    from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
 
 
 @contextlib.contextmanager
@@ -90,9 +95,11 @@ async def test_trace_logging_on_http_protocol(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("ws_protocol", [("websockets"), ("wsproto")])
 async def test_trace_logging_on_ws_protocol(
-    ws_protocol, caplog, logging_config, unused_tcp_port: int
+    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    caplog,
+    logging_config,
+    unused_tcp_port: int,
 ):
     async def websocket_app(scope, receive, send):
         assert scope["type"] == "websocket"

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Type, Union
 
 import httpx
 import pytest
@@ -116,7 +116,7 @@ async def test_proxy_headers_invalid_x_forwarded_for() -> None:
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_proxy_headers_websocket_x_forwarded_proto(
-    ws_protocol_cls: "type[WSProtocol] | type[WebSocketProtocol]",
+    ws_protocol_cls: "Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ) -> None:

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -1,8 +1,8 @@
-import contextlib
 from typing import TYPE_CHECKING, List, Union
 
 import httpx
 import pytest
+import websockets.client
 
 from tests.protocols.test_http import HTTP_PROTOCOLS
 from tests.response import Response
@@ -10,9 +10,6 @@ from tests.utils import run_server
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.config import Config
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
-
-with contextlib.suppress(ModuleNotFoundError):
-    import websockets.client
 
 if TYPE_CHECKING:
     from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -116,7 +116,7 @@ async def test_proxy_headers_invalid_x_forwarded_for() -> None:
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_proxy_headers_websocket_x_forwarded_proto(
-    ws_protocol: "type[WSProtocol] | type[WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol] | type[WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ) -> None:
@@ -130,7 +130,7 @@ async def test_proxy_headers_websocket_x_forwarded_proto(
     app_with_middleware = ProxyHeadersMiddleware(websocket_app, trusted_hosts="*")
     config = Config(
         app=app_with_middleware,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -160,11 +160,6 @@ class MockTransport:
     def set_protocol(self, protocol):
         pass
 
-    def set_write_buffer_limits(
-        self, high: Union[None, int] = None, low: Union[None, int] = None
-    ):
-        pass
-
 
 class MockLoop:
     def __init__(self):

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -2,7 +2,7 @@ import logging
 import socket
 import threading
 import time
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Type, Union
 
 import pytest
 
@@ -781,7 +781,7 @@ async def test_unsupported_ws_upgrade_request_warn_on_auto(
 @pytest.mark.anyio
 @pytest.mark.parametrize("protocol_cls", HTTP_PROTOCOLS)
 async def test_http2_upgrade_request(
-    protocol_cls, ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]"
+    protocol_cls, ws_protocol_cls: "Type[WSProtocol | WebSocketProtocol]"
 ):
     app = Response("Hello, world", media_type="text/plain")
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -21,7 +21,9 @@ from websockets.typing import Subprotocol
 
 from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
 
-skip_if_no_wsproto = pytest.mark.skipif("WSProtocol" not in globals(), reason="wsproto is not installed.")
+skip_if_no_wsproto = pytest.mark.skipif(
+    "WSProtocol" not in globals(), reason="wsproto is not installed."
+)
 
 
 class WebSocketResponse:
@@ -47,7 +49,7 @@ class WebSocketResponse:
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_invalid_upgrade(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -55,7 +57,7 @@ async def test_invalid_upgrade(
         return None
 
     config = Config(
-        app=app, ws=ws_protocol, http=http_protocol_cls, port=unused_tcp_port
+        app=app, ws=ws_protocol_cls, http=http_protocol_cls, port=unused_tcp_port
     )
     async with run_server(config):
         async with httpx.AsyncClient() as client:
@@ -86,7 +88,7 @@ async def test_invalid_upgrade(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_accept_connection(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -100,7 +102,7 @@ async def test_accept_connection(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -113,7 +115,7 @@ async def test_accept_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_supports_permessage_deflate_extension(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -130,7 +132,7 @@ async def test_supports_permessage_deflate_extension(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -143,7 +145,7 @@ async def test_supports_permessage_deflate_extension(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_can_disable_permessage_deflate_extension(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -162,7 +164,7 @@ async def test_can_disable_permessage_deflate_extension(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         ws_per_message_deflate=False,
@@ -176,7 +178,7 @@ async def test_can_disable_permessage_deflate_extension(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_close_connection(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -193,7 +195,7 @@ async def test_close_connection(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -206,7 +208,7 @@ async def test_close_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_headers(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -226,7 +228,7 @@ async def test_headers(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -239,7 +241,7 @@ async def test_headers(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_extra_headers(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -255,7 +257,7 @@ async def test_extra_headers(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -268,7 +270,7 @@ async def test_extra_headers(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_path_and_raw_path(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -286,7 +288,7 @@ async def test_path_and_raw_path(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -299,7 +301,7 @@ async def test_path_and_raw_path(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_text_data_to_client(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -314,7 +316,7 @@ async def test_send_text_data_to_client(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -327,7 +329,7 @@ async def test_send_text_data_to_client(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_binary_data_to_client(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -342,7 +344,7 @@ async def test_send_binary_data_to_client(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -355,7 +357,7 @@ async def test_send_binary_data_to_client(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_and_close_connection(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -377,7 +379,7 @@ async def test_send_and_close_connection(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -391,7 +393,7 @@ async def test_send_and_close_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_text_data_to_server(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -410,7 +412,7 @@ async def test_send_text_data_to_server(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -423,7 +425,7 @@ async def test_send_text_data_to_server(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_binary_data_to_server(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -442,7 +444,7 @@ async def test_send_binary_data_to_server(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -455,7 +457,9 @@ async def test_send_binary_data_to_server(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_after_protocol_close(
-    ws_protocol, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
@@ -477,7 +481,7 @@ async def test_send_after_protocol_close(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -490,7 +494,11 @@ async def test_send_after_protocol_close(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_missing_handshake(ws_protocol, http_protocol_cls, unused_tcp_port: int):
+async def test_missing_handshake(
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
+):
     async def app(app, receive, send):
         pass
 
@@ -499,7 +507,7 @@ async def test_missing_handshake(ws_protocol, http_protocol_cls, unused_tcp_port
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -513,7 +521,9 @@ async def test_missing_handshake(ws_protocol, http_protocol_cls, unused_tcp_port
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_before_handshake(
-    ws_protocol, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     async def app(scope, receive, send):
         await send({"type": "websocket.send", "text": "123"})
@@ -523,7 +533,7 @@ async def test_send_before_handshake(
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -537,7 +547,9 @@ async def test_send_before_handshake(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_duplicate_handshake(
-    ws_protocol, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     async def app(scope, receive, send):
         await send({"type": "websocket.accept"})
@@ -549,7 +561,7 @@ async def test_duplicate_handshake(
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -562,7 +574,11 @@ async def test_duplicate_handshake(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_asgi_return_value(ws_protocol, http_protocol_cls, unused_tcp_port: int):
+async def test_asgi_return_value(
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
+):
     """
     The ASGI callable should return 'None'. If it doesn't make sure that
     the connection is closed with an error condition.
@@ -578,7 +594,7 @@ async def test_asgi_return_value(ws_protocol, http_protocol_cls, unused_tcp_port
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -598,7 +614,11 @@ async def test_asgi_return_value(ws_protocol, http_protocol_cls, unused_tcp_port
     ids=["none_as_reason", "normal_reason", "without_reason"],
 )
 async def test_app_close(
-    ws_protocol, http_protocol_cls, code, reason, unused_tcp_port: int
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
+    code: typing.Optional[int],
+    reason: "str | bool | None",
 ):
     async def app(scope, receive, send):
         while True:
@@ -626,7 +646,7 @@ async def test_app_close(
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -640,7 +660,11 @@ async def test_app_close(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
-async def test_client_close(ws_protocol, http_protocol_cls, unused_tcp_port: int):
+async def test_client_close(
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
+):
     async def app(scope, receive, send):
         while True:
             message = await receive()
@@ -658,7 +682,7 @@ async def test_client_close(ws_protocol, http_protocol_cls, unused_tcp_port: int
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -670,7 +694,9 @@ async def test_client_close(ws_protocol, http_protocol_cls, unused_tcp_port: int
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_client_connection_lost(
-    ws_protocol, http_protocol_cls, unused_tcp_port: int
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    http_protocol_cls,
+    unused_tcp_port: int,
 ):
     got_disconnect_event = False
 
@@ -687,7 +713,7 @@ async def test_client_connection_lost(
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         ws_ping_interval=0.0,
@@ -707,7 +733,7 @@ async def test_client_connection_lost(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_connection_lost_before_handshake_complete(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -738,7 +764,7 @@ async def test_connection_lost_before_handshake_complete(
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -761,7 +787,7 @@ async def test_connection_lost_before_handshake_complete(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_close_on_server_shutdown(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -788,7 +814,7 @@ async def test_send_close_on_server_shutdown(
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -812,7 +838,7 @@ async def test_send_close_on_server_shutdown(
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 @pytest.mark.parametrize("subprotocol", ["proto1", "proto2"])
 async def test_subprotocols(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     subprotocol,
     unused_tcp_port: int,
@@ -829,7 +855,7 @@ async def test_subprotocols(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -905,7 +931,7 @@ async def test_send_binary_data_to_server_bigger_than_default_on_websockets(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -934,7 +960,7 @@ async def test_server_reject_connection(
 
     config = Config(
         app=app,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -946,7 +972,7 @@ async def test_server_reject_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -976,7 +1002,7 @@ async def test_server_can_read_messages_in_buffer_after_close(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -991,7 +1017,7 @@ async def test_server_can_read_messages_in_buffer_after_close(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_default_server_headers(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1005,7 +1031,7 @@ async def test_default_server_headers(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -1018,7 +1044,7 @@ async def test_default_server_headers(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_no_server_headers(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1032,7 +1058,7 @@ async def test_no_server_headers(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         server_header=False,
@@ -1074,7 +1100,7 @@ async def test_no_date_header_on_wsproto(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_multiple_server_header(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1096,7 +1122,7 @@ async def test_multiple_server_header(
 
     config = Config(
         app=App,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         port=unused_tcp_port,
@@ -1109,7 +1135,7 @@ async def test_multiple_server_header(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_lifespan_state(
-    ws_protocol: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1149,7 +1175,7 @@ async def test_lifespan_state(
 
     config = Config(
         app=app_wrapper,
-        ws=ws_protocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="on",
         port=unused_tcp_port,

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -46,7 +46,7 @@ class WebSocketResponse:
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_invalid_upgrade(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -85,7 +85,7 @@ async def test_invalid_upgrade(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_accept_connection(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -112,7 +112,7 @@ async def test_accept_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_supports_permessage_deflate_extension(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -142,7 +142,7 @@ async def test_supports_permessage_deflate_extension(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_can_disable_permessage_deflate_extension(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -175,7 +175,7 @@ async def test_can_disable_permessage_deflate_extension(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_close_connection(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -205,7 +205,7 @@ async def test_close_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_headers(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -238,7 +238,7 @@ async def test_headers(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_extra_headers(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -267,7 +267,7 @@ async def test_extra_headers(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_path_and_raw_path(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -298,7 +298,7 @@ async def test_path_and_raw_path(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_text_data_to_client(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -326,7 +326,7 @@ async def test_send_text_data_to_client(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_binary_data_to_client(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -354,7 +354,7 @@ async def test_send_binary_data_to_client(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_and_close_connection(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -390,7 +390,7 @@ async def test_send_and_close_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_text_data_to_server(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -422,7 +422,7 @@ async def test_send_text_data_to_server(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_binary_data_to_server(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -454,7 +454,7 @@ async def test_send_binary_data_to_server(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_after_protocol_close(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -492,7 +492,7 @@ async def test_send_after_protocol_close(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_missing_handshake(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -518,7 +518,7 @@ async def test_missing_handshake(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_before_handshake(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -544,7 +544,7 @@ async def test_send_before_handshake(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_duplicate_handshake(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -572,7 +572,7 @@ async def test_duplicate_handshake(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_asgi_return_value(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -611,7 +611,7 @@ async def test_asgi_return_value(
     ids=["none_as_reason", "normal_reason", "without_reason"],
 )
 async def test_app_close(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
     code,
@@ -658,7 +658,7 @@ async def test_app_close(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_client_close(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -691,7 +691,7 @@ async def test_client_close(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_client_connection_lost(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -730,7 +730,7 @@ async def test_client_connection_lost(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_connection_lost_before_handshake_complete(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -784,7 +784,7 @@ async def test_connection_lost_before_handshake_complete(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_send_close_on_server_shutdown(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -835,7 +835,7 @@ async def test_send_close_on_server_shutdown(
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 @pytest.mark.parametrize("subprotocol", ["proto1", "proto2"])
 async def test_subprotocols(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     subprotocol,
     unused_tcp_port: int,
@@ -928,7 +928,7 @@ async def test_send_binary_data_to_server_bigger_than_default_on_websockets(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_reject_connection(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -969,7 +969,7 @@ async def test_server_reject_connection(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_server_can_read_messages_in_buffer_after_close(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1014,7 +1014,7 @@ async def test_server_can_read_messages_in_buffer_after_close(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_default_server_headers(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1041,7 +1041,7 @@ async def test_default_server_headers(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_no_server_headers(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1097,7 +1097,7 @@ async def test_no_date_header_on_wsproto(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_multiple_server_header(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):
@@ -1132,7 +1132,7 @@ async def test_multiple_server_header(
 @pytest.mark.anyio
 @pytest.mark.parametrize("http_protocol_cls", HTTP_PROTOCOLS)
 async def test_lifespan_state(
-    ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
+    ws_protocol_cls: "typing.Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -614,8 +614,8 @@ async def test_app_close(
     ws_protocol_cls: "type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls,
     unused_tcp_port: int,
-    code: typing.Optional[int],
-    reason: "str | bool | None",
+    code,
+    reason,
 ):
     async def app(scope, receive, send):
         while True:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1,29 +1,26 @@
 import asyncio
-import contextlib
 import typing
 from copy import deepcopy
 
 import httpx
 import pytest
-
-from tests.protocols.test_http import HTTP_PROTOCOLS
-from tests.utils import run_server
-from uvicorn.config import Config
-
-with contextlib.suppress(ModuleNotFoundError):
-    from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
-
 import websockets
 import websockets.client
 import websockets.exceptions
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
 from websockets.typing import Subprotocol
 
+from tests.protocols.test_http import HTTP_PROTOCOLS
+from tests.utils import run_server
+from uvicorn.config import Config
 from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
 
-skip_if_no_wsproto = pytest.mark.skipif(
-    "WSProtocol" not in globals(), reason="wsproto is not installed."
-)
+try:
+    from uvicorn.protocols.websockets.wsproto_impl import WSProtocol
+
+    skip_if_no_wsproto = pytest.mark.skipif(False, reason="wsproto is installed.")
+except ModuleNotFoundError:
+    skip_if_no_wsproto = pytest.mark.skipif(True, reason="wsproto is not installed.")
 
 
 class WebSocketResponse:

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -1,4 +1,5 @@
 import logging
+import platform
 import signal
 import socket
 import sys
@@ -22,6 +23,13 @@ try:
     from uvicorn.supervisors.watchgodreload import WatchGodReload
 except ImportError:  # pragma: no cover
     WatchGodReload = None  # type: ignore[misc,assignment]
+
+
+# TODO: Investigate why this is flaky on MacOS M1.
+skip_if_m1 = pytest.mark.skipif(
+    sys.platform == "darwin" and platform.processor() == "arm",
+    reason="Flaky on MacOS M1",
+)
 
 
 def run(sockets):
@@ -152,12 +160,7 @@ class TestBaseReload:
     @pytest.mark.parametrize(
         "reloader_class",
         [
-            pytest.param(
-                WatchFilesReload,
-                marks=pytest.mark.skipif(
-                    sys.platform == "darwin", reason="Flaky on MacOS"
-                ),
-            ),
+            pytest.param(WatchFilesReload, marks=skip_if_m1),
             WatchGodReload,
         ],
     )
@@ -224,12 +227,7 @@ class TestBaseReload:
         [
             StatReload,
             WatchGodReload,
-            pytest.param(
-                WatchFilesReload,
-                marks=pytest.mark.skipif(
-                    sys.platform == "darwin", reason="Flaky on MacOS"
-                ),
-            ),
+            pytest.param(WatchFilesReload, marks=skip_if_m1),
         ],
     )
     def test_should_not_reload_when_only_subdirectory_is_watched(
@@ -256,12 +254,7 @@ class TestBaseReload:
     @pytest.mark.parametrize(
         "reloader_class",
         [
-            pytest.param(
-                WatchFilesReload,
-                marks=pytest.mark.skipif(
-                    sys.platform == "darwin", reason="Flaky on MacOS"
-                ),
-            ),
+            pytest.param(WatchFilesReload, marks=skip_if_m1),
             WatchGodReload,
         ],
     )

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -149,7 +149,18 @@ class TestBaseReload:
 
             reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchFilesReload, WatchGodReload])
+    @pytest.mark.parametrize(
+        "reloader_class",
+        [
+            pytest.param(
+                WatchFilesReload,
+                marks=pytest.mark.skipif(
+                    sys.platform == "darwin", reason="Flaky on MacOS"
+                ),
+            ),
+            WatchGodReload,
+        ],
+    )
     def test_should_not_reload_when_exclude_pattern_match_file_is_changed(
         self, touch_soon
     ) -> None:
@@ -209,7 +220,17 @@ class TestBaseReload:
             reloader.shutdown()
 
     @pytest.mark.parametrize(
-        "reloader_class", [StatReload, WatchGodReload, WatchFilesReload]
+        "reloader_class",
+        [
+            StatReload,
+            WatchGodReload,
+            pytest.param(
+                WatchFilesReload,
+                marks=pytest.mark.skipif(
+                    sys.platform == "darwin", reason="Flaky on MacOS"
+                ),
+            ),
+        ],
     )
     def test_should_not_reload_when_only_subdirectory_is_watched(
         self, touch_soon
@@ -232,7 +253,18 @@ class TestBaseReload:
 
         reloader.shutdown()
 
-    @pytest.mark.parametrize("reloader_class", [WatchFilesReload, WatchGodReload])
+    @pytest.mark.parametrize(
+        "reloader_class",
+        [
+            pytest.param(
+                WatchFilesReload,
+                marks=pytest.mark.skipif(
+                    sys.platform == "darwin", reason="Flaky on MacOS"
+                ),
+            ),
+            WatchGodReload,
+        ],
+    )
     def test_override_defaults(self, touch_soon) -> None:
         dotted_file = self.reload_path / ".dotted"
         dotted_dir_file = self.reload_path / ".dotted_dir" / "file.txt"


### PR DESCRIPTION
This PR aims to remove the `WS_PROTOCOLS` "constant" that we have on the `test_websockets.py`.