### PR TITLE
Add `typing_extensions` dependency for Python 3.10 and lower

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
     "click>=7.0",
     "h11>=0.8",
+    "typing_extensions>=4.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Fixes #2052