### PR TITLE
Update scope structure in docs to match what is actually returned by the server

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -343,9 +343,9 @@ An incoming HTTP request might have a connection `scope` like this:
     'method': 'GET',
     'path': '/',
     'headers': [
-        [b'host', b'127.0.0.1:8000'],
-        [b'user-agent', b'curl/7.51.0'],
-        [b'accept', b'*/*']
+        (b'host', b'127.0.0.1:8000'),
+        (b'user-agent', b'curl/7.51.0'),
+        (b'accept', b'*/*')
     ]
 }
 ```


### PR DESCRIPTION
# Summary
This PR addresses the previous discussion #2072 

The documentation specifies that the scope returns headers of structure a list of lists but the actual implementation returns a list of tuples. This PR is to address that inconsistency.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
