### PR TITLE
change should_reload to reload

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -577,7 +577,7 @@ def run(
         )
         sys.exit(1)
 
-    if config.should_reload:
+    if config.reload:
         sock = config.bind_socket()
         ChangeReload(config, target=server.run, sockets=[sock]).run()
     elif config.workers > 1:
@@ -588,7 +588,7 @@ def run(
     if config.uds and os.path.exists(config.uds):
         os.remove(config.uds)  # pragma: py-win32
 
-    if not server.started and not config.should_reload and config.workers == 1:
+    if not server.started and not config.reload and config.workers == 1:
         sys.exit(STARTUP_FAILURE)
 
 


### PR DESCRIPTION
# Summary 

Starting the server using below
```
config = {
"api.main:app",
      host=HOST,
      port=PORT,
      log_level=log_level,
      reload=reload,
      reload_dirs=reload_dirs,
      use_colors=use_colors,
      log_config=log_config,
}
server = uvicorn.Server(config)
server.run()
```
This doesn't start the server with the reload flag even when set to true that is because in the `main.py` it gets initiated by the should_reload variable that is not declared anywhere, we should check instead for the config.reload variable. 
