### PR TITLE
UvicornWorker: respect the gunicorn graceful shutdown timeout

### DIFF
--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -40,6 +40,7 @@ class UvicornWorker(Worker):
             "callback_notify": self.callback_notify,
             "limit_max_requests": self.max_requests,
             "forwarded_allow_ips": self.cfg.forwarded_allow_ips,
+            "timeout_graceful_shutdown": self.cfg.graceful_timeout,
         }
 
         if self.cfg.is_ssl:


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This change propagates Gunicorn's `graceful_timeout` parameter to `Uvicorn`'s `timeout_graceful_shutdown` configuration when running `Uvicorn` as a Gunicorn worker process.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- Not sure if a test is necessary here? In any case it looks like `UvicornWorker` doesn't have any tests currently.
- [x] I've updated the documentation accordingly.
