### PR TITLE
Allow setting APP with envvar UVICORN_APP

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -10,7 +10,7 @@ export SOURCE_FILES="uvicorn tests"
 set -x
 
 ./scripts/sync-version
-${PREFIX}black --check --diff --target-version=py37 $SOURCE_FILES
+${PREFIX}black --check --diff --target-version=py38 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 ${PREFIX}ruff check $SOURCE_FILES
 ${PREFIX}python -m tools.cli_usage --check

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,6 +9,6 @@ export SOURCE_FILES="uvicorn tests"
 
 set -x
 
-${PREFIX}black --target-version=py37 $SOURCE_FILES
+${PREFIX}black --target-version=py38 $SOURCE_FILES
 ${PREFIX}ruff --fix $SOURCE_FILES
 ${PREFIX}python -m tools.cli_usage

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -57,7 +57,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
 
 
 @click.command(context_settings={"auto_envvar_prefix": "UVICORN"})
-@click.argument("app")
+@click.argument("app", envvar="UVICORN_APP")
 @click.option(
     "--host",
     type=str,


### PR DESCRIPTION
# Summary

Allows configuring the `APP` setting using the environment variable `UVICORN_APP`. Currently environment variables can be used for all other settings thanks to click's `auto_envvar_prefix`, but this applies only to options and not to arguments.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

I'm not sure if a new test is needed for this change. Additionally, I believe no documentation changes are needed. The docs currently state that env vars can be used for configuration but doesn't call out the caveat that `APP` can not.