### PR TITLE
:bug: Fixed --reload-dir option not working as expected.

### DIFF
--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -68,7 +68,7 @@ class WatchFilesReload(BaseReload):
         for directory in config.reload_dirs:
             if Path.cwd() not in directory.parents:
                 self.reload_dirs.append(directory)
-        if Path.cwd() not in self.reload_dirs:
+        if (len(self.reload_dirs) == 0) and (Path.cwd() not in self.reload_dirs):
             self.reload_dirs.append(Path.cwd())
 
         self.watch_filter = FileFilter(config)

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -142,7 +142,7 @@ class WatchGodReload(BaseReload):
         for directory in config.reload_dirs:
             if Path.cwd() not in directory.parents:
                 reload_dirs.append(directory)
-        if Path.cwd() not in reload_dirs:
+        if (len(reload_dirs) == 0) and (Path.cwd() not in reload_dirs):
             reload_dirs.append(Path.cwd())
         for w in reload_dirs:
             self.watchers.append(CustomWatcher(w.resolve(), self.config))


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# --reload-dir specified, but default dir(cwd) still been watching

Not working as cli help explained:

txt
```
uvicorn --help:
--reload-dir PATH   Set reload directories explicitly, instead
                    of using the current working directory.
```

So, I tried to fix it by counting `self.reload_dirs`, and if it's not provided by arguments, then it will add the default current directory as the watching directory.

Previous discussion: <https://github.com/encode/uvicorn/discussions/1833>

And also: <https://github.com/encode/uvicorn/issues/1326>

<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
