### PR TITLE
use asyncio.run(..., loop_factory) to avoid asyncio.set_event_loop_policy

### DIFF
--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -1,10 +1,11 @@
 import asyncio
+import contextlib
 import importlib
 
 import pytest
 
 from uvicorn.config import Config
-from uvicorn.loops.auto import auto_loop_setup
+from uvicorn.loops.auto import auto_loop_factory
 from uvicorn.main import ServerState
 from uvicorn.protocols.http.auto import AutoHTTPProtocol
 from uvicorn.protocols.websockets.auto import AutoWebSocketsProtocol
@@ -33,10 +34,10 @@ async def app(scope, receive, send):
 
 
 def test_loop_auto():
-    auto_loop_setup()
-    policy = asyncio.get_event_loop_policy()
-    assert isinstance(policy, asyncio.events.BaseDefaultEventLoopPolicy)
-    assert type(policy).__module__.startswith(expected_loop)
+    loop_factory = auto_loop_factory()
+    with contextlib.closing(loop_factory()) as loop:
+        assert isinstance(loop, asyncio.AbstractEventLoop)
+        assert type(loop).__module__.startswith(expected_loop)
 
 
 @pytest.mark.anyio

--- a/uvicorn/_compat.py
+++ b/uvicorn/_compat.py
@@ -36,9 +36,7 @@ else:
         except RuntimeError:
             pass
         else:
-            raise RuntimeError(
-                "asyncio.run() cannot be called from a running event loop"
-            )
+            raise RuntimeError("asyncio.run() cannot be called from a running event loop")
 
         if not asyncio.iscoroutine(main):
             raise ValueError(f"a coroutine was expected, got {main!r}")

--- a/uvicorn/_compat.py
+++ b/uvicorn/_compat.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
+
+if sys.version_info >= (3, 12):
+    asyncio_run = asyncio.run
+elif sys.version_info >= (3, 11):
+
+    def asyncio_run(
+        main: Coroutine[Any, Any, _T],
+        *,
+        debug: bool = False,
+        loop_factory: Callable[[], asyncio.AbstractEventLoop] | None = None,
+    ) -> _T:
+        # asyncio.run from Python 3.12
+        # https://docs.python.org/3/license.html#psf-license
+        with asyncio.Runner(debug=debug, loop_factory=loop_factory) as runner:
+            return runner.run(main)
+
+else:
+    # modified version of asyncio.run from Python 3.10 to add loop_factory kwarg
+    # https://docs.python.org/3/license.html#psf-license
+    def asyncio_run(
+        main: Coroutine[Any, Any, _T],
+        *,
+        debug: bool = False,
+        loop_factory: Callable[[], asyncio.AbstractEventLoop] | None = None,
+    ) -> _T:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "asyncio.run() cannot be called from a running event loop"
+            )
+
+        if not asyncio.iscoroutine(main):
+            raise ValueError(f"a coroutine was expected, got {main!r}")
+
+        if loop_factory is None:
+            loop = asyncio.new_event_loop()
+        else:
+            loop = loop_factory()
+        try:
+            if loop_factory is None:
+                asyncio.set_event_loop(loop)
+            if debug is not None:
+                loop.set_debug(debug)
+            return loop.run_until_complete(main)
+        finally:
+            try:
+                _cancel_all_tasks(loop)
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.run_until_complete(loop.shutdown_default_executor())
+            finally:
+                if loop_factory is None:
+                    asyncio.set_event_loop(None)
+                loop.close()
+
+    def _cancel_all_tasks(loop: asyncio.AbstractEventLoop) -> None:
+        to_cancel = asyncio.all_tasks(loop)
+        if not to_cancel:
+            return
+
+        for task in to_cancel:
+            task.cancel()
+
+        loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
+
+        for task in to_cancel:
+            if task.cancelled():
+                continue
+            if task.exception() is not None:
+                loop.call_exception_handler(
+                    {
+                        "message": "unhandled exception during asyncio.run() shutdown",
+                        "exception": task.exception(),
+                        "task": task,
+                    }
+                )

--- a/uvicorn/_compat.py
+++ b/uvicorn/_compat.py
@@ -57,7 +57,8 @@ else:
             try:
                 _cancel_all_tasks(loop)
                 loop.run_until_complete(loop.shutdown_asyncgens())
-                loop.run_until_complete(loop.shutdown_default_executor())
+                if sys.version_info >= (3, 9):
+                    loop.run_until_complete(loop.shutdown_default_executor())
             finally:
                 if loop_factory is None:
                     asyncio.set_event_loop(None)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -26,7 +26,7 @@ from uvicorn.middleware.wsgi import WSGIMiddleware
 HTTPProtocolType = Literal["auto", "h11", "httptools"]
 WSProtocolType = Literal["auto", "none", "websockets", "wsproto"]
 LifespanType = Literal["auto", "on", "off"]
-LoopSetupType = Literal["none", "auto", "asyncio", "uvloop"]
+LoopFactoryType = Literal["none", "auto", "asyncio", "uvloop"]
 InterfaceType = Literal["auto", "asgi3", "asgi2", "wsgi"]
 
 LOG_LEVELS: dict[str, int] = {
@@ -53,7 +53,7 @@ LIFESPAN: dict[LifespanType, str] = {
     "on": "uvicorn.lifespan.on:LifespanOn",
     "off": "uvicorn.lifespan.off:LifespanOff",
 }
-LOOP_FACTORIES: dict[LoopSetupType, str | None] = {
+LOOP_FACTORIES: dict[LoopFactoryType, str | None] = {
     "none": None,
     "auto": "uvicorn.loops.auto:auto_loop_factory",
     "asyncio": "uvicorn.loops.asyncio:asyncio_loop_factory",
@@ -180,7 +180,7 @@ class Config:
         port: int = 8000,
         uds: str | None = None,
         fd: int | None = None,
-        loop: LoopSetupType = "auto",
+        loop: LoopFactoryType = "auto",
         http: type[asyncio.Protocol] | HTTPProtocolType = "auto",
         ws: type[asyncio.Protocol] | WSProtocolType = "auto",
         ws_max_size: int = 16 * 1024 * 1024,

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import sys
+from collections.abc import Callable
+from typing import TypeVar
+
+_T = TypeVar("_T")
 
 logger = logging.getLogger("uvicorn.error")
 
 
-def asyncio_setup(use_subprocess: bool = False) -> None:
-    if sys.platform == "win32" and use_subprocess:
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # pragma: full coverage
+def asyncio_loop_factory(use_subprocess: bool = False) -> Callable[[], asyncio.AbstractEventLoop]:
+    if sys.platform == "win32" and not use_subprocess:
+        return asyncio.ProactorEventLoop
+    return asyncio.SelectorEventLoop

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import sys
 from collections.abc import Callable
-from typing import TypeVar
-
-_T = TypeVar("_T")
-
-logger = logging.getLogger("uvicorn.error")
 
 
 def asyncio_loop_factory(use_subprocess: bool = False) -> Callable[[], asyncio.AbstractEventLoop]:

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -4,9 +4,7 @@ import asyncio
 from collections.abc import Callable
 
 
-def auto_loop_factory(
-    use_subprocess: bool = False,
-) -> Callable[[], asyncio.AbstractEventLoop]:
+def auto_loop_factory(use_subprocess: bool = False) -> Callable[[], asyncio.AbstractEventLoop]:
     try:
         import uvloop  # noqa
     except ImportError:  # pragma: no cover

--- a/uvicorn/loops/auto.py
+++ b/uvicorn/loops/auto.py
@@ -1,11 +1,19 @@
-def auto_loop_setup(use_subprocess: bool = False) -> None:
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+
+def auto_loop_factory(
+    use_subprocess: bool = False,
+) -> Callable[[], asyncio.AbstractEventLoop]:
     try:
         import uvloop  # noqa
     except ImportError:  # pragma: no cover
-        from uvicorn.loops.asyncio import asyncio_setup as loop_setup
+        from uvicorn.loops.asyncio import asyncio_loop_factory as loop_factory
 
-        loop_setup(use_subprocess=use_subprocess)
+        return loop_factory(use_subprocess=use_subprocess)
     else:  # pragma: no cover
-        from uvicorn.loops.uvloop import uvloop_setup
+        from uvicorn.loops.uvloop import uvloop_loop_factory
 
-        uvloop_setup(use_subprocess=use_subprocess)
+        return uvloop_loop_factory(use_subprocess=use_subprocess)

--- a/uvicorn/loops/uvloop.py
+++ b/uvicorn/loops/uvloop.py
@@ -6,7 +6,5 @@ from collections.abc import Callable
 import uvloop
 
 
-def uvloop_loop_factory(
-    use_subprocess: bool = False,
-) -> Callable[[], asyncio.AbstractEventLoop]:
+def uvloop_loop_factory(use_subprocess: bool = False) -> Callable[[], asyncio.AbstractEventLoop]:
     return uvloop.new_event_loop

--- a/uvicorn/loops/uvloop.py
+++ b/uvicorn/loops/uvloop.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import asyncio
+from collections.abc import Callable
 
 import uvloop
 
 
-def uvloop_setup(use_subprocess: bool = False) -> None:
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+def uvloop_loop_factory(
+    use_subprocess: bool = False,
+) -> Callable[[], asyncio.AbstractEventLoop]:
+    return uvloop.new_event_loop

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -19,7 +19,7 @@ from uvicorn.config import (
     LIFESPAN,
     LOG_LEVELS,
     LOGGING_CONFIG,
-    LOOP_SETUPS,
+    LOOP_FACTORIES,
     SSL_PROTOCOL_VERSION,
     WS_PROTOCOLS,
     Config,
@@ -36,7 +36,7 @@ LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))
 WS_CHOICES = click.Choice(list(WS_PROTOCOLS.keys()))
 LIFESPAN_CHOICES = click.Choice(list(LIFESPAN.keys()))
-LOOP_CHOICES = click.Choice([key for key in LOOP_SETUPS.keys() if key != "none"])
+LOOP_CHOICES = click.Choice([key for key in LOOP_FACTORIES.keys() if key != "none"])
 INTERFACE_CHOICES = click.Choice(INTERFACES)
 
 STARTUP_FAILURE = 3

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -26,7 +26,7 @@ from uvicorn.config import (
     HTTPProtocolType,
     InterfaceType,
     LifespanType,
-    LoopSetupType,
+    LoopFactoryType,
     WSProtocolType,
 )
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
@@ -364,7 +364,7 @@ def main(
     port: int,
     uds: str,
     fd: int,
-    loop: LoopSetupType,
+    loop: LoopFactoryType,
     http: HTTPProtocolType,
     ws: WSProtocolType,
     ws_max_size: int,
@@ -465,7 +465,7 @@ def run(
     port: int = 8000,
     uds: str | None = None,
     fd: int | None = None,
-    loop: LoopSetupType = "auto",
+    loop: LoopFactoryType = "auto",
     http: type[asyncio.Protocol] | HTTPProtocolType = "auto",
     ws: type[asyncio.Protocol] | WSProtocolType = "auto",
     ws_max_size: int = 16777216,

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Generator, Sequence, Union
 
 import click
 
+from uvicorn._compat import asyncio_run
 from uvicorn.config import Config
 
 if TYPE_CHECKING:
@@ -61,8 +62,7 @@ class Server:
         self._captured_signals: list[int] = []
 
     def run(self, sockets: list[socket.socket] | None = None) -> None:
-        self.config.setup_event_loop()
-        return asyncio.run(self.serve(sockets=sockets))
+        return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
 
     async def serve(self, sockets: list[socket.socket] | None = None) -> None:
         with self.capture_signals():

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -10,6 +10,7 @@ from typing import Any
 from gunicorn.arbiter import Arbiter
 from gunicorn.workers.base import Worker
 
+from uvicorn._compat import asyncio_run
 from uvicorn.config import Config
 from uvicorn.main import Server
 
@@ -71,8 +72,7 @@ class UvicornWorker(Worker):
         self.config = Config(**config_kwargs)
 
     def init_process(self) -> None:
-        self.config.setup_event_loop()
-        super().init_process()
+        super(UvicornWorker, self).init_process()
 
     def init_signals(self) -> None:
         # Reset signals so Gunicorn doesn't swallow subprocess return codes
@@ -104,7 +104,7 @@ class UvicornWorker(Worker):
             sys.exit(Arbiter.WORKER_BOOT_ERROR)
 
     def run(self) -> None:
-        return asyncio.run(self._serve())
+        return asyncio_run(self._serve(), loop_factory=self.config.get_loop_factory())
 
     async def callback_notify(self) -> None:
         self.notify()

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -71,9 +71,6 @@ class UvicornWorker(Worker):
 
         self.config = Config(**config_kwargs)
 
-    def init_process(self) -> None:
-        super(UvicornWorker, self).init_process()
-
     def init_signals(self) -> None:
         # Reset signals so Gunicorn doesn't swallow subprocess return codes
         # other signals are set up by Server.install_signal_handlers()


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
set_event_loop_policy will be deprecated in python 3.13 and uvloop.EventLoopPolicy is deprecated already, this backports and uses the preferred `loop_factory` keyword to configure asyncio.run
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
