### PR TITLE
Fix Ctrl+C hang on Python 3.12 when connections are open

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - uses: "actions/checkout@v4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Internet :: WWW/HTTP",

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -310,20 +310,8 @@ class Server:
             while self.server_state.tasks and not self.force_exit:
                 await asyncio.sleep(0.1)
 
-        # Wait for servers to close. They won't do so until all connections are
-        # closed, which we've already waited for above, so this should be quick.
-        servers_closed = asyncio.gather(
-            *[server.wait_closed() for server in self.servers]
-        )
-        # Give the servers_closed future a chance to complete so we don't
-        # spuriously log about this operation.
-        await asyncio.sleep(0.1)
-        if not servers_closed.done() and not self.force_exit:
-            msg = "Waiting for servers to close. (CTRL+C to force quit)"
-            logger.info(msg)
-            while not servers_closed.done() and not self.force_exit:
-                await asyncio.sleep(0.1)
-
+        for server in self.servers:
+            await server.wait_closed()
     def install_signal_handlers(self) -> None:
         if threading.current_thread() is not threading.main_thread():
             # Signals can only be listened to from the main thread.

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -312,6 +312,7 @@ class Server:
 
         for server in self.servers:
             await server.wait_closed()
+
     def install_signal_handlers(self) -> None:
         if threading.current_thread() is not threading.main_thread():
             # Signals can only be listened to from the main thread.


### PR DESCRIPTION
# Summary

The asyncio.Server.wait_closed() method was a no-op in versions of Python earlier than 3.12. The intention of this method was to block until all existing connections are closed, but due to a bug in its implementation, it wouldn't actually wait. This bug was fixed in Python 3.12, which exposed uvicorn's dependence on the buggy behavior: the implementation of uvicorn.Server.shutdown() called wait_closed() before asking existing connections to close. As a result, attempting to stop a Uvicorn server with an open connection would result in a blocked process, with further attempts to Ctrl+C having no effect.

See discussion at https://github.com/encode/uvicorn/discussions/2122

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
