### PR TITLE
Revert "Bump mkdocs-material from 9.1.21 to 9.2.6 (#2090)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,5 @@ httpx==0.25.0
 watchgod==0.8.2
 
 # Documentation
-mkdocs==1.5.3
-mkdocs-material==9.4.2
+mkdocs==1.5.2
+mkdocs-material==9.1.21


### PR DESCRIPTION
This commit broke our documentation: https://github.com/encode/uvicorn/pull/2086.