### PR TITLE
fix[docs]: specify units and defaults for ws_* args in docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,8 +67,8 @@ Options:
                                   [default: 16777216]
   --ws-max-queue INTEGER          The maximum length of the WebSocket message
                                   queue.  [default: 32]
-  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
+  --ws-ping-interval FLOAT        WebSocket ping interval, in seconds  [default: 20.0]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout, in seconds  [default: 20.0]
   --ws-per-message-deflate BOOLEAN
                                   WebSocket per-message-deflate compression
                                   [default: True]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,8 +67,10 @@ Options:
                                   [default: 16777216]
   --ws-max-queue INTEGER          The maximum length of the WebSocket message
                                   queue.  [default: 32]
-  --ws-ping-interval FLOAT        WebSocket ping interval, in seconds  [default: 20.0]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout, in seconds  [default: 20.0]
+  --ws-ping-interval FLOAT        WebSocket ping interval in seconds.
+                                  [default: 20.0]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout in seconds.
+                                  [default: 20.0]
   --ws-per-message-deflate BOOLEAN
                                   WebSocket per-message-deflate compression
                                   [default: True]

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,8 +137,10 @@ Options:
                                   [default: 16777216]
   --ws-max-queue INTEGER          The maximum length of the WebSocket message
                                   queue.  [default: 32]
-  --ws-ping-interval FLOAT        WebSocket ping interval, in seconds  [default: 20.0]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout, in seconds  [default: 20.0]
+  --ws-ping-interval FLOAT        WebSocket ping interval in seconds.
+                                  [default: 20.0]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout in seconds.
+                                  [default: 20.0]
   --ws-per-message-deflate BOOLEAN
                                   WebSocket per-message-deflate compression
                                   [default: True]

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,8 +137,8 @@ Options:
                                   [default: 16777216]
   --ws-max-queue INTEGER          The maximum length of the WebSocket message
                                   queue.  [default: 32]
-  --ws-ping-interval FLOAT        WebSocket ping interval  [default: 20.0]
-  --ws-ping-timeout FLOAT         WebSocket ping timeout  [default: 20.0]
+  --ws-ping-interval FLOAT        WebSocket ping interval, in seconds  [default: 20.0]
+  --ws-ping-timeout FLOAT         WebSocket ping timeout, in seconds  [default: 20.0]
   --ws-per-message-deflate BOOLEAN
                                   WebSocket per-message-deflate compression
                                   [default: True]

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -70,8 +70,8 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. Use `'none'` to ignore all websocket requests. **Options:** *'auto', 'none', 'websockets', 'wsproto'.* **Default:** *'auto'*.
 * `--ws-max-size <int>` - Set the WebSockets max message size, in bytes. Please note that this can be used only with the default `websockets` protocol.
 * `--ws-max-queue <int>` - Set the maximum length of the WebSocket incoming message queue. Please note that this can be used only with the default `websockets` protocol.
-* `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Please note that this can be used only with the default `websockets` protocol.
-* `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Please note that this can be used only with the default `websockets` protocol.
+* `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Please note that this can be used only with the default `websockets` protocol. **Default:** *20.0*
+* `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Please note that this can be used only with the default `websockets` protocol. **Default:** *20.0*
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.
 * `--h11-max-incomplete-event-size <int>` - Set the maximum number of bytes to buffer of an incomplete event. Only available for `h11` HTTP protocol implementation. **Default:** *'16384'* (16 KB).
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -8,7 +8,6 @@ import typing
 
 import click
 
-import uvicorn
 from uvicorn._types import ASGIApplication
 from uvicorn.config import (
     HTTP_PROTOCOLS,
@@ -28,6 +27,7 @@ from uvicorn.config import (
 )
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
+import uvicorn
 
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))
@@ -156,14 +156,14 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--ws-ping-interval",
     type=float,
     default=20.0,
-    help="WebSocket ping interval",
+    help="WebSocket ping interval, in seconds",
     show_default=True,
 )
 @click.option(
     "--ws-ping-timeout",
     type=float,
     default=20.0,
-    help="WebSocket ping timeout",
+    help="WebSocket ping timeout, in seconds",
     show_default=True,
 )
 @click.option(

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -163,7 +163,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--ws-ping-timeout",
     type=float,
     default=20.0,
-    help="WebSocket ping timeout, in seconds",
+    help="WebSocket ping timeout in seconds.",
     show_default=True,
 )
 @click.option(

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -156,7 +156,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--ws-ping-interval",
     type=float,
     default=20.0,
-    help="WebSocket ping interval, in seconds",
+    help="WebSocket ping interval in seconds.",
     show_default=True,
 )
 @click.option(

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -8,6 +8,7 @@ import typing
 
 import click
 
+import uvicorn
 from uvicorn._types import ASGIApplication
 from uvicorn.config import (
     HTTP_PROTOCOLS,
@@ -27,7 +28,6 @@ from uvicorn.config import (
 )
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
-import uvicorn
 
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))


### PR DESCRIPTION
# Summary

Small updates for adding time units and default values for the ws-ping-interval and ws-ping-timeout in documentation

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
