### PR TITLE
Properly annotate `uvicorn.run()`

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -9,7 +9,6 @@ import ssl
 import sys
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -31,11 +30,6 @@ from uvicorn.middleware.asgi2 import ASGI2Middleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
-
-if TYPE_CHECKING:
-    PathLike = os.PathLike[str]
-else:
-    PathLike = os.PathLike
 
 HTTPProtocolType = Literal["auto", "h11", "httptools"]
 WSProtocolType = Literal["auto", "none", "websockets", "wsproto"]
@@ -207,7 +201,7 @@ class Config:
         ws_ping_timeout: Optional[float] = 20.0,
         ws_per_message_deflate: bool = True,
         lifespan: LifespanType = "auto",
-        env_file: "str | PathLike | None" = None,
+        env_file: "str | os.PathLike[str] | None" = None,
         log_config: Optional[Union[Dict[str, Any], str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
@@ -232,7 +226,7 @@ class Config:
         timeout_graceful_shutdown: Optional[int] = None,
         callback_notify: Optional[Callable[..., Awaitable[None]]] = None,
         ssl_keyfile: Optional[str] = None,
-        ssl_certfile: "str | PathLike | None" = None,
+        ssl_certfile: "str | os.PathLike[str] | None" = None,
         ssl_keyfile_password: Optional[str] = None,
         ssl_version: int = SSL_PROTOCOL_VERSION,
         ssl_cert_reqs: int = ssl.CERT_NONE,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -9,6 +9,7 @@ import ssl
 import sys
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -30,6 +31,11 @@ from uvicorn.middleware.asgi2 import ASGI2Middleware
 from uvicorn.middleware.message_logger import MessageLoggerMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
+
+if TYPE_CHECKING:
+    PathLike = os.PathLike[str]
+else:
+    PathLike = os.PathLike
 
 HTTPProtocolType = Literal["auto", "h11", "httptools"]
 WSProtocolType = Literal["auto", "none", "websockets", "wsproto"]
@@ -187,7 +193,7 @@ def _normalize_dirs(dirs: Union[List[str], str, None]) -> List[str]:
 class Config:
     def __init__(
         self,
-        app: Union["ASGIApplication", Callable, str],
+        app: Union["ASGIApplication", Callable[..., Any], str],
         host: str = "127.0.0.1",
         port: int = 8000,
         uds: Optional[str] = None,
@@ -201,7 +207,7 @@ class Config:
         ws_ping_timeout: Optional[float] = 20.0,
         ws_per_message_deflate: bool = True,
         lifespan: LifespanType = "auto",
-        env_file: Optional[Union[str, os.PathLike]] = None,
+        env_file: "str | PathLike | None" = None,
         log_config: Optional[Union[Dict[str, Any], str]] = LOGGING_CONFIG,
         log_level: Optional[Union[str, int]] = None,
         access_log: bool = True,
@@ -226,7 +232,7 @@ class Config:
         timeout_graceful_shutdown: Optional[int] = None,
         callback_notify: Optional[Callable[..., Awaitable[None]]] = None,
         ssl_keyfile: Optional[str] = None,
-        ssl_certfile: Optional[Union[str, os.PathLike]] = None,
+        ssl_certfile: "str | PathLike | None" = None,
         ssl_keyfile_password: Optional[str] = None,
         ssl_version: int = SSL_PROTOCOL_VERSION,
         ssl_cert_reqs: int = ssl.CERT_NONE,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -30,7 +30,7 @@ from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defin
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
 if typing.TYPE_CHECKING:
-    PathLike: typing.TypeAlias = "os.PathLike[str]"
+    PathLike = os.PathLike[str]
 else:
     PathLike = os.PathLike
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -29,11 +29,6 @@ from uvicorn.config import (
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
-if typing.TYPE_CHECKING:
-    PathLike = os.PathLike[str]
-else:
-    PathLike = os.PathLike
-
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))
 WS_CHOICES = click.Choice(list(WS_PROTOCOLS.keys()))
@@ -492,7 +487,7 @@ def run(
     reload_excludes: typing.Optional[typing.Union[typing.List[str], str]] = None,
     reload_delay: float = 0.25,
     workers: typing.Optional[int] = None,
-    env_file: "str | PathLike | None" = None,
+    env_file: "str | os.PathLike[str] | None" = None,
     log_config: typing.Optional[
         typing.Union[typing.Dict[str, typing.Any], str]
     ] = LOGGING_CONFIG,
@@ -509,7 +504,7 @@ def run(
     timeout_keep_alive: int = 5,
     timeout_graceful_shutdown: typing.Optional[int] = None,
     ssl_keyfile: typing.Optional[str] = None,
-    ssl_certfile: "str | PathLike | None" = None,
+    ssl_certfile: "str | os.PathLike[str] | None" = None,
     ssl_keyfile_password: typing.Optional[str] = None,
     ssl_version: int = SSL_PROTOCOL_VERSION,
     ssl_cert_reqs: int = ssl.CERT_NONE,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -29,6 +29,11 @@ from uvicorn.config import (
 from uvicorn.server import Server, ServerState  # noqa: F401  # Used to be defined here.
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
+if typing.TYPE_CHECKING:
+    PathLike: typing.TypeAlias = "os.PathLike[str]"
+else:
+    PathLike = os.PathLike
+
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
 HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))
 WS_CHOICES = click.Choice(list(WS_PROTOCOLS.keys()))
@@ -465,7 +470,7 @@ def main(
 
 
 def run(
-    app: typing.Union["ASGIApplication", typing.Callable, str],
+    app: typing.Union["ASGIApplication", typing.Callable[..., typing.Any], str],
     *,
     host: str = "127.0.0.1",
     port: int = 8000,
@@ -487,7 +492,7 @@ def run(
     reload_excludes: typing.Optional[typing.Union[typing.List[str], str]] = None,
     reload_delay: float = 0.25,
     workers: typing.Optional[int] = None,
-    env_file: typing.Optional[typing.Union[str, os.PathLike]] = None,
+    env_file: "str | PathLike | None" = None,
     log_config: typing.Optional[
         typing.Union[typing.Dict[str, typing.Any], str]
     ] = LOGGING_CONFIG,
@@ -504,7 +509,7 @@ def run(
     timeout_keep_alive: int = 5,
     timeout_graceful_shutdown: typing.Optional[int] = None,
     ssl_keyfile: typing.Optional[str] = None,
-    ssl_certfile: typing.Optional[typing.Union[str, os.PathLike]] = None,
+    ssl_certfile: "str | PathLike | None" = None,
     ssl_keyfile_password: typing.Optional[str] = None,
     ssl_version: int = SSL_PROTOCOL_VERSION,
     ssl_cert_reqs: int = ssl.CERT_NONE,


### PR DESCRIPTION
I know I closed this https://github.com/encode/uvicorn/issues/1855, but I don't think another type check for the `run()` function.