### PR TITLE
Fixed the issue of unable to reload using pycharm

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -87,14 +87,8 @@ class BaseReload:
         self.process.start()
 
     def restart(self) -> None:
-        if sys.platform == "win32":  # pragma: py-not-win32
-            self.is_restarting = True
-            assert self.process.pid is not None
-            os.kill(self.process.pid, signal.CTRL_C_EVENT)
-        else:  # pragma: py-win32
-            self.process.terminate()
+        self.process.terminate()
         self.process.join()
-
         self.process = get_subprocess(
             config=self.config, target=self.target, sockets=self.sockets
         )


### PR DESCRIPTION
# Summary
Unfortunately, starting from uvicorn 0.21.1, when developing with PyCharm, reload cannot terminate the process properly.

The os.kill and signal.CTRL_C_EVENT used in the previous function are based on UNIX system signals, which may not work as expected on Windows. On Windows, the signal mechanism is significantly different from UNIX systems, which might be the reason why it cannot be reloaded normally.
```
    def restart(self) -> None:
        if sys.platform == "win32":  # pragma: py-not-win32
            self.is_restarting = True
            assert self.process.pid is not None
            os.kill(self.process.pid, signal.CTRL_C_EVENT)
        else:  # pragma: py-win32
            self.process.terminate()
        self.process.join()

        self.process = get_subprocess(
            config=self.config, target=self.target, sockets=self.sockets
        )
        self.process.start()
```
Many versions can't reload properly anymore, I have modified the restart function as:
```
    def restart(self) -> None:
        self.process.terminate()
        self.process.join()
        self.process = get_subprocess(
            config=self.config, target=self.target, sockets=self.sockets
        )
        self.process.start()
```