### PR TITLE
♻️ Update `root_path` handling (from `--root-path` CLI option) to include the root path prefix in the full ASGI `path` as per the ASGI spec

### DIFF
--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -122,11 +122,11 @@ def test_build_environ_encoding() -> None:
     scope: "HTTPScope" = {
         "asgi": {"version": "3.0", "spec_version": "2.0"},
         "scheme": "http",
-        "raw_path": b"/\xe6\x96\x87",
+        "raw_path": b"/\xe6\x96\x87%2Fall",
         "type": "http",
         "http_version": "1.1",
         "method": "GET",
-        "path": "/文",
+        "path": "/文/all",
         "root_path": "/文",
         "client": None,
         "server": None,
@@ -140,5 +140,6 @@ def test_build_environ_encoding() -> None:
         "more_body": False,
     }
     environ = wsgi.build_environ(scope, message, io.BytesIO(b""))
-    assert environ["PATH_INFO"] == "/文".encode("utf8").decode("latin-1")
+    assert environ["SCRIPT_NAME"] == "/文".encode("utf8").decode("latin-1")
+    assert environ["PATH_INFO"] == "/all".encode("utf8").decode("latin-1")
     assert environ["HTTP_KEY"] == "value1,value2"

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -641,7 +641,6 @@ async def test_root_path(http_protocol_cls: "Type[HttpToolsProtocol | H11Protoco
     protocol.data_received(SIMPLE_GET_REQUEST)
     await protocol.loop.run_one()
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
-    # assert b"Path: /app/" in protocol.transport.buffer
     assert b"root_path=/app path=/app/" in protocol.transport.buffer
 
 

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -632,7 +632,9 @@ async def test_root_path(http_protocol_cls: "Type[HttpToolsProtocol | H11Protoco
         assert scope["type"] == "http"
         root_path = scope.get("root_path", "")
         path = scope["path"]
-        response = Response(f"root_path={root_path} path={path}", media_type="text/plain")
+        response = Response(
+            f"root_path={root_path} path={path}", media_type="text/plain"
+        )
         await response(scope, receive, send)
 
     protocol = get_connected_protocol(app, http_protocol_cls, root_path="/app")

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -630,15 +630,17 @@ async def test_http10_request(
 async def test_root_path(http_protocol_cls: "Type[HttpToolsProtocol | H11Protocol]"):
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         assert scope["type"] == "http"
-        path = scope.get("root_path", "") + scope["path"]
-        response = Response("Path: " + path, media_type="text/plain")
+        root_path = scope.get("root_path", "")
+        path = scope["path"]
+        response = Response(f"root_path={root_path} path={path}", media_type="text/plain")
         await response(scope, receive, send)
 
     protocol = get_connected_protocol(app, http_protocol_cls, root_path="/app")
     protocol.data_received(SIMPLE_GET_REQUEST)
     await protocol.loop.run_one()
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
-    assert b"Path: /app/" in protocol.transport.buffer
+    # assert b"Path: /app/" in protocol.transport.buffer
+    assert b"root_path=/app path=/app/" in protocol.transport.buffer
 
 
 @pytest.mark.anyio
@@ -647,8 +649,8 @@ async def test_raw_path(http_protocol_cls: "Type[HttpToolsProtocol | H11Protocol
         assert scope["type"] == "http"
         path = scope["path"]
         raw_path = scope.get("raw_path", None)
-        assert "/one/two" == path
-        assert b"/one%2Ftwo" == raw_path
+        assert "/app/one/two" == path
+        assert b"/app/one%2Ftwo" == raw_path
 
         response = Response("Done", media_type="text/plain")
         await response(scope, receive, send)

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -28,10 +28,14 @@ def build_environ(
     """
     Builds a scope and request message into a WSGI environ object.
     """
+    script_name = scope.get("root_path", "").encode("utf8").decode("latin1")
+    path_info = scope["path"].encode("utf8").decode("latin1")
+    if path_info.startswith(script_name):
+        path_info = path_info[len(script_name) :]
     environ = {
         "REQUEST_METHOD": scope["method"],
-        "SCRIPT_NAME": "",
-        "PATH_INFO": scope["path"].encode("utf8").decode("latin1"),
+        "SCRIPT_NAME": script_name,
+        "PATH_INFO": path_info,
         "QUERY_STRING": scope["query_string"].decode("ascii"),
         "SERVER_PROTOCOL": "HTTP/%s" % scope["http_version"],
         "wsgi.version": (1, 0),

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -198,6 +198,9 @@ class H11Protocol(asyncio.Protocol):
             elif isinstance(event, h11.Request):
                 self.headers = [(key.lower(), value) for key, value in event.headers]
                 raw_path, _, query_string = event.target.partition(b"?")
+                path = unquote(raw_path.decode("ascii"))
+                full_path = self.root_path + path
+                full_raw_path = self.root_path.encode("ascii") + raw_path
                 self.scope = {
                     "type": "http",
                     "asgi": {
@@ -210,8 +213,8 @@ class H11Protocol(asyncio.Protocol):
                     "scheme": self.scheme,  # type: ignore[typeddict-item]
                     "method": event.method.decode("ascii"),
                     "root_path": self.root_path,
-                    "path": unquote(raw_path.decode("ascii")),
-                    "raw_path": raw_path,
+                    "path": full_path,
+                    "raw_path": full_raw_path,
                     "query_string": query_string,
                     "headers": self.headers,
                     "state": self.app_state.copy(),

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -260,8 +260,10 @@ class HttpToolsProtocol(asyncio.Protocol):
         path = raw_path.decode("ascii")
         if "%" in path:
             path = urllib.parse.unquote(path)
-        self.scope["path"] = path
-        self.scope["raw_path"] = raw_path
+        full_path = self.root_path + path
+        full_raw_path = self.root_path.encode() + raw_path
+        self.scope["path"] = full_path
+        self.scope["raw_path"] = full_raw_path
         self.scope["query_string"] = parsed_url.query or b""
 
         # Handle 503 responses when 'limit_concurrency' is exceeded.

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -261,7 +261,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         if "%" in path:
             path = urllib.parse.unquote(path)
         full_path = self.root_path + path
-        full_raw_path = self.root_path.encode() + raw_path
+        full_raw_path = self.root_path.encode("ascii") + raw_path
         self.scope["path"] = full_path
         self.scope["raw_path"] = full_raw_path
         self.scope["query_string"] = parsed_url.query or b""

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -184,6 +184,9 @@ class WebSocketProtocol(WebSocketServerProtocol):
             (name.encode("ascii"), value.encode("ascii", errors="surrogateescape"))
             for name, value in headers.raw_items()
         ]
+        path = unquote(path_portion)
+        full_path = self.root_path + path
+        full_raw_path = self.root_path.encode("ascii") + path_portion.encode("ascii")
 
         self.scope = {
             "type": "websocket",
@@ -193,8 +196,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
             "server": self.server,
             "client": self.client,
             "root_path": self.root_path,
-            "path": unquote(path_portion),
-            "raw_path": path_portion.encode("ascii"),
+            "path": full_path,
+            "raw_path": full_raw_path,
             "query_string": query_string.encode("ascii"),
             "headers": asgi_headers,
             "subprotocols": subprotocols,

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -164,6 +164,9 @@ class WSProtocol(asyncio.Protocol):
         headers = [(b"host", event.host.encode())]
         headers += [(key.lower(), value) for key, value in event.extra_headers]
         raw_path, _, query_string = event.target.partition("?")
+        path = unquote(raw_path)
+        full_path = self.root_path + path
+        full_raw_path = self.root_path.encode("ascii") + raw_path.encode("ascii")
         self.scope: "WebSocketScope" = {
             "type": "websocket",
             "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
@@ -172,8 +175,8 @@ class WSProtocol(asyncio.Protocol):
             "server": self.server,
             "client": self.client,
             "root_path": self.root_path,
-            "path": unquote(raw_path),
-            "raw_path": raw_path.encode("ascii"),
+            "path": full_path,
+            "raw_path": full_raw_path,
             "query_string": query_string.encode("ascii"),
             "headers": headers,
             "subprotocols": event.subprotocols,


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

♻️ Update `root_path` handling (from `--root-path` CLI option) to include the root path prefix in the full ASGI `path` as per the ASGI spec, equivalent to Starlette 0.35.0

# Why

Uvicorn doesn't receive the scope from another ASGI component on top, it creates it from the raw HTTP protocol.

When it receives the CLI option `--root-path` it means that Uvicorn is behind another HTTP frontend proxy (like Traefik or Nginx) that is receiving that "root path" prefix and stripping it.

More or less like this:

* The client sends a request to: `https://example.com/api/v1/items/42`
* The HTTP proxy (e.g. Traefik, Nginx, HAProxy) is listening on the server at `example.com`, so it takes this request
	* The HTTP proxy handles HTTPS with the certificates it has installed (e.g. with some Let's Encrypt) and handles the HTTPS communication
	* The HTTP proxy takes the path `/api/v1/items/42` and removes the prefix it has configured of `/api/v1`
* The HTTP proxy sends the pure and unencrypted HTTP request (after handling the TLS/HTTPS part) to the local Uvicorn server
	* Uvicorn is listening on `http://127.0.0.1:8000`, notice that it's not HTTPS, only HTTP, and it's only on localhost, not the open web IP, it's also on port `8000`, not in the standard HTTP port `80` nor HTTPS port `443`
	* the HTTP proxy sends the request with the removed path prefix configured, so, the request URL goes to `http://127.0.0.1/items/42`
	* Uvicorn is handling an ASGI app (e.g. Starlette, FastAPI) that knows of the path `/items/42`, but doesn't know of the prefix `/api/v1`, but the app might need to create some `url_for` in templates or such, so it needs to also know the original path prefix it should use.
	* Uvicorn is running with the option `--root-path=/api/v1`, the same path prefix used by the HTTP proxy, to let it know that it is being served to the external clients at that path prefix.
	* Uvicorn creates an ASGI scope that has as the `root_path` the value in the CLI option: `/api/v1`. But the path it received by the pure HTTP protocol was only `/items/42` because the HTTP proxy sent the request to the local Uvicorn running on localhost.
	* So, to be compliant with the ASGI spec and make the `path` have the full path used by the clients, including any path prefix, it has to prepend that path prefix provided by the CLI `--root-path` to the ASGI scope key `path`.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
