### PR TITLE
Change CTRL_C_EVENT to the SIGINT signal, as PyCharm does not handle CTRL_C_EVENT signals.

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -90,7 +90,7 @@ class BaseReload:
         if sys.platform == "win32":  # pragma: py-not-win32
             self.is_restarting = True
             assert self.process.pid is not None
-            os.kill(self.process.pid, signal.CTRL_C_EVENT)
+            os.kill(self.process.pid, signal.SIGINT)
         else:  # pragma: py-win32
             self.process.terminate()
         self.process.join()


### PR DESCRIPTION
# Summary

Unfortunately, starting from uvicorn 0.21.1, when developing with PyCharm, reload cannot terminate the process properly.
Change CTRL_C_EVENT to the SIGINT signal, as PyCharm does not handle CTRL_C_EVENT signals.

`os.kill(self.process.pid, signal.CTRL_C_EVENT)`  -- >>  `os.kill(self.process.pid, signal.SIGINT)` 

I am certain that this is an issue with PyCharm. Unfortunately, they haven't responded to my feedback. I hope the author can make a compromise and merge this pull request, as it addresses a significant usability issue.