### PR TITLE
Fix nav override for newer version of Mkdocs Material

### DIFF
--- a/docs/overrides/partials/nav.html
+++ b/docs/overrides/partials/nav.html
@@ -1,3 +1,5 @@
+{% import "partials/nav-item.html" as item with context %}
+
 <!-- Determine class according to configuration -->
  {% set class = "md-nav md-nav--primary" %}
  {% if "navigation.tabs" in features %}
@@ -35,12 +37,11 @@
      </div>
    {% endif %}
 
-   <!-- Render item list -->
+   <!-- Navigation list -->
    <ul class="md-nav__list" data-md-scrollfix>
      {% for nav_item in nav %}
        {% set path = "__nav_" ~ loop.index %}
-       {% set level = 1 %}
-       {% include "partials/nav-item.html" %}
+       {{ item.render(nav_item, path, 1) }}
      {% endfor %}
    </ul>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ watchgod==0.8.2
 
 # Documentation
 mkdocs==1.5.3
-mkdocs-material==9.1.21
+mkdocs-material==9.5.5


### PR DESCRIPTION
Following #2229, I've investigated why the navigation bar was hidden in newer version of Mkdocs Material. The `partials/nav.html` have slightly changed, so we needed to update our own override.

Now it displays correctly!