### PR TITLE
Fixed default to use stdout instead of stderr

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -80,7 +80,7 @@ LOGGING_CONFIG: dict[str, Any] = {
         "default": {
             "formatter": "default",
             "class": "logging.StreamHandler",
-            "stream": "ext://sys.stderr",
+            "stream": "ext://sys.stdout",
         },
         "access": {
             "formatter": "access",


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Hey, I wanted to change that for the longest time. It makes literally no sense  to print every single line of output as stderr instead of stdout, and I belive that this change will improve every single programmer's mental health as well as the visibility inside of terminal. :> For example in pyCharm stderr is defaultly rendered as red, so it actually conflicts with the config that has errors and critical errors in red*. Thanks for your time! ❤

# Checklist

- [✔] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [❌] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [❌] I've updated the documentation accordingly.
