### PR TITLE
Use `X-Forwarded-Proto` for WebSockets scheme when the proxy provides it

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -142,3 +142,8 @@ async def test_proxy_headers_websocket_x_forwarded_proto(
         async with websockets.client.connect(url, extra_headers=headers) as websocket:
             data = await websocket.recv()
             assert data == "wss://1.2.3.4:0"
+
+        headers = {"X-Forwarded-Proto": "wss", "X-Forwarded-For": "1.2.3.4"}
+        async with websockets.client.connect(url, extra_headers=headers) as websocket:
+            data = await websocket.recv()
+            assert data == "wss://1.2.3.4:0"

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -115,7 +115,18 @@ async def test_proxy_headers_invalid_x_forwarded_for() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    "x_forwarded_proto,addr",
+    [
+        ("http", "ws://1.2.3.4:0"),
+        ("https", "wss://1.2.3.4:0"),
+        ("ws", "ws://1.2.3.4:0"),
+        ("wss", "wss://1.2.3.4:0"),
+    ],
+)
 async def test_proxy_headers_websocket_x_forwarded_proto(
+    x_forwarded_proto: str,
+    addr: str,
     ws_protocol_cls: "Type[WSProtocol | WebSocketProtocol]",
     http_protocol_cls: "Type[H11Protocol | HttpToolsProtocol]",
     unused_tcp_port: int,
@@ -138,12 +149,7 @@ async def test_proxy_headers_websocket_x_forwarded_proto(
 
     async with run_server(config):
         url = f"ws://127.0.0.1:{unused_tcp_port}"
-        headers = {"X-Forwarded-Proto": "https", "X-Forwarded-For": "1.2.3.4"}
+        headers = {"X-Forwarded-Proto": x_forwarded_proto, "X-Forwarded-For": "1.2.3.4"}
         async with websockets.client.connect(url, extra_headers=headers) as websocket:
             data = await websocket.recv()
-            assert data == "wss://1.2.3.4:0"
-
-        headers = {"X-Forwarded-Proto": "wss", "X-Forwarded-For": "1.2.3.4"}
-        async with websockets.client.connect(url, extra_headers=headers) as websocket:
-            data = await websocket.recv()
-            assert data == "wss://1.2.3.4:0"
+            assert data == addr

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -62,7 +62,6 @@ class ProxyHeadersMiddleware:
                     x_forwarded_proto = (
                         headers[b"x-forwarded-proto"].decode("latin1").strip()
                     )
-
                     if scope["type"] == "websocket":
                         scope["scheme"] = x_forwarded_proto.replace("http", "ws")
                     else:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -62,11 +62,10 @@ class ProxyHeadersMiddleware:
                     x_forwarded_proto = (
                         headers[b"x-forwarded-proto"].decode("latin1").strip()
                     )
-                    if scope["type"] == "websocket":
-                        if x_forwarded_proto == "http":
-                            scope["scheme"] = "ws"
-                        elif x_forwarded_proto == "https":
-                            scope["scheme"] = "wss"
+                    if scope["type"] == "websocket" and x_forwarded_proto == "http":
+                        scope["scheme"] = "ws"
+                    elif scope["type"] == "websocket" and x_forwarded_proto == "https":
+                        scope["scheme"] = "wss"
                     else:
                         scope["scheme"] = x_forwarded_proto
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -63,9 +63,10 @@ class ProxyHeadersMiddleware:
                         headers[b"x-forwarded-proto"].decode("latin1").strip()
                     )
                     if scope["type"] == "websocket":
-                        scope["scheme"] = (
-                            "wss" if x_forwarded_proto == "https" else "ws"
-                        )
+                        if x_forwarded_proto == "http":
+                            scope["scheme"] = "ws"
+                        elif x_forwarded_proto == "https":
+                            scope["scheme"] = "wss"
                     else:
                         scope["scheme"] = x_forwarded_proto
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -62,12 +62,10 @@ class ProxyHeadersMiddleware:
                     x_forwarded_proto = (
                         headers[b"x-forwarded-proto"].decode("latin1").strip()
                     )
-                    if scope["type"] == "websocket" and x_forwarded_proto == "http":
-                        scope["scheme"] = "ws"
-                    elif scope["type"] == "websocket" and x_forwarded_proto == "https":
-                        scope["scheme"] = "wss"
-                    else:
-                        scope["scheme"] = x_forwarded_proto
+                    scope["scheme"] = x_forwarded_proto
+
+                    if scope["type"] == "websocket":
+                        scope["scheme"] = x_forwarded_proto.replace("http", "ws")
 
                 if b"x-forwarded-for" in headers:
                     # Determine the client address from the last trusted IP in the

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -62,10 +62,11 @@ class ProxyHeadersMiddleware:
                     x_forwarded_proto = (
                         headers[b"x-forwarded-proto"].decode("latin1").strip()
                     )
-                    scope["scheme"] = x_forwarded_proto
 
                     if scope["type"] == "websocket":
                         scope["scheme"] = x_forwarded_proto.replace("http", "ws")
+                    else:
+                        scope["scheme"] = x_forwarded_proto
 
                 if b"x-forwarded-for" in headers:
                     # Determine the client address from the last trusted IP in the


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Fix for https://github.com/encode/uvicorn/pull/2043 which set the scheme to `ws` when the proxy passes `wss` in `X-Forwarded-Proto`. Traefik sets the proto to `ws`/`wss` for websockets. https://github.com/traefik/traefik/blob/c1ef7429771104e79f2e87b236b21495cb5765f0/pkg/middlewares/forwardedheaders/forwarded_header.go#L148-L153

(please note the code is not tested)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
