### PR TITLE
Add CIDR optionality to `ProxyHeadersMiddleware`

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -43,8 +43,13 @@ async def app(
         # trusted proxy list
         (["127.0.0.1", "10.0.0.1"], "Remote: https://1.2.3.4:0"),
         ("127.0.0.1, 10.0.0.1", "Remote: https://1.2.3.4:0"),
+        # trusted proxy list with CIDR
+        (["127.0.0.1", "10.0.0.1", "10.0.1.0/24"], "Remote: https://1.2.3.4:0"),
+        ("127.0.0.1, 10.0.0.1, 10.0.1.0/24", "Remote: https://1.2.3.4:0"),
         # request from untrusted proxy
         ("192.168.0.1", "Remote: http://127.0.0.1:123"),
+        # request from untrusted proxy with CIDR
+        ("192.168.0.0/24", "Remote: http://127.0.0.1:123"),
     ],
 )
 async def test_proxy_headers_trusted_hosts(trusted_hosts: list[str] | str, response_text: str) -> None:
@@ -75,6 +80,11 @@ async def test_proxy_headers_trusted_hosts(trusted_hosts: list[str] | str, respo
         ),
         # should set first untrusted as remote address
         (["192.168.0.2", "127.0.0.1"], "Remote: https://10.0.2.1:0"),
+        # works with CIDRs
+        (
+            ["127.0.0.1", "10.0.2.0/24", "192.168.0.2"],
+            "Remote: https://1.2.3.4:0",
+        ),
     ],
 )
 async def test_proxy_headers_multiple_proxies(trusted_hosts: list[str] | str, response_text: str) -> None:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -40,6 +40,9 @@ class ProxyHeadersMiddleware:
             if not self.check_trusted_host(host):
                 return host
 
+        return ""
+        
+
     def check_trusted_host(self, host: str) -> bool:
         for trusted_net in self.trusted_hosts:
             if ipaddress.ip_address(host) in trusted_net:
@@ -72,6 +75,6 @@ class ProxyHeadersMiddleware:
                     x_forwarded_for_hosts = [item.strip() for item in x_forwarded_for.split(",")]
                     host = self.get_trusted_client_host(x_forwarded_for_hosts)
                     port = 0
-                    scope["client"] = (host, port)  # type: ignore[arg-type]
+                    scope["client"] = (host, port)
 
         return await self.app(scope, receive, send)

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -32,15 +32,13 @@ class ProxyHeadersMiddleware:
 
         self.trusted_hosts = {ipaddress.ip_network(host) for host in trusted_hosts_set}
 
-    def get_trusted_client_host(self, x_forwarded_for_hosts: list[str]) -> str | None:
+    def get_trusted_client_host(self, x_forwarded_for_hosts: list[str]) -> str:
         if self.always_trust:
             return x_forwarded_for_hosts[0]
 
         for host in reversed(x_forwarded_for_hosts):
             if not self.check_trusted_host(host):
                 return host
-
-        return None
 
     def check_trusted_host(self, host: str) -> bool:
         for trusted_net in self.trusted_hosts:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -37,14 +37,14 @@ class ProxyHeadersMiddleware:
             return x_forwarded_for_hosts[0]
 
         for host in reversed(x_forwarded_for_hosts):
-            if self.check_trusted_host(host):
+            if not self.check_trusted_host(host):
                 return host
 
         return None
 
     def check_trusted_host(self, host: str) -> bool:
-        for trusted_host in self.trusted_hosts:
-            if host in trusted_host:
+        for trusted_net in self.trusted_hosts:
+            if ipaddress.ip_address(host) in trusted_net:
                 return True
         return False
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -41,7 +41,6 @@ class ProxyHeadersMiddleware:
                 return host
 
         return ""
-        
 
     def check_trusted_host(self, host: str) -> bool:
         for trusted_net in self.trusted_hosts:


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
Added the ability to pass CIDRs to `ProxyHeadersMiddleware` using the stdlib `ipaddress` library.  This should fix this comment - https://github.com/encode/uvicorn/issues/1068#issuecomment-1004813267
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
