### PR TITLE
Bump httpx to 0.27.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ trustme==1.1.0
 cryptography==42.0.4
 coverage==7.4.1
 coverage-conditional-plugin==0.9.0
-httpx==0.26.0
+httpx==0.27.0
 watchgod==0.8.2
 
 # Documentation

--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -17,8 +17,8 @@ async def test_message_logger(caplog):
         caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
         caplog.set_level(TRACE_LOG_LEVEL)
 
-        app = MessageLoggerMiddleware(app)
-        async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+        transport = httpx.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
             response = await client.get("/")
         assert response.status_code == 200
         messages = [record.msg % record.args for record in caplog.records]
@@ -37,8 +37,8 @@ async def test_message_logger_exc(caplog):
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
         caplog.set_level(TRACE_LOG_LEVEL)
-        app = MessageLoggerMiddleware(app)
-        async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+        transport = httpx.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
             with pytest.raises(RuntimeError):
                 await client.get("/")
         messages = [record.msg % record.args for record in caplog.records]

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -49,7 +49,8 @@ async def app(
 )
 async def test_proxy_headers_trusted_hosts(trusted_hosts: list[str] | str, response_text: str) -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
-    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
+    transport = httpx.ASGITransport(app=app_with_middleware)  # type: ignore
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         headers = {"X-Forwarded-Proto": "https", "X-Forwarded-For": "1.2.3.4"}
         response = await client.get("/", headers=headers)
 
@@ -79,7 +80,8 @@ async def test_proxy_headers_trusted_hosts(trusted_hosts: list[str] | str, respo
 )
 async def test_proxy_headers_multiple_proxies(trusted_hosts: list[str] | str, response_text: str) -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts=trusted_hosts)
-    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
+    transport = httpx.ASGITransport(app=app_with_middleware)  # type: ignore
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         headers = {
             "X-Forwarded-Proto": "https",
             "X-Forwarded-For": "1.2.3.4, 10.0.2.1, 192.168.0.2",
@@ -93,7 +95,8 @@ async def test_proxy_headers_multiple_proxies(trusted_hosts: list[str] | str, re
 @pytest.mark.anyio
 async def test_proxy_headers_invalid_x_forwarded_for() -> None:
     app_with_middleware = ProxyHeadersMiddleware(app, trusted_hosts="*")
-    async with httpx.AsyncClient(app=app_with_middleware, base_url="http://testserver") as client:
+    transport = httpx.ASGITransport(app=app_with_middleware)  # type: ignore
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         headers = httpx.Headers(
             {
                 "X-Forwarded-Proto": "https",

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -59,8 +59,8 @@ def wsgi_middleware(request: pytest.FixtureRequest) -> Callable:
 
 @pytest.mark.anyio
 async def test_wsgi_get(wsgi_middleware: Callable) -> None:
-    app = wsgi_middleware(hello_world)
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+    transport = httpx.ASGITransport(wsgi_middleware(hello_world))
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.get("/")
     assert response.status_code == 200
     assert response.text == "Hello World!\n"
@@ -68,8 +68,8 @@ async def test_wsgi_get(wsgi_middleware: Callable) -> None:
 
 @pytest.mark.anyio
 async def test_wsgi_post(wsgi_middleware: Callable) -> None:
-    app = wsgi_middleware(echo_body)
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+    transport = httpx.ASGITransport(wsgi_middleware(echo_body))
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.post("/", json={"example": 123})
     assert response.status_code == 200
     assert response.text == '{"example": 123}'
@@ -81,8 +81,8 @@ async def test_wsgi_put_more_body(wsgi_middleware: Callable) -> None:
         for _ in range(1024):
             yield b"123456789abcdef\n" * 64
 
-    app = wsgi_middleware(echo_body)
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+    transport = httpx.ASGITransport(wsgi_middleware(echo_body))
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.put("/", content=generate_body())
     assert response.status_code == 200
     assert response.text == "123456789abcdef\n" * 64 * 1024
@@ -92,21 +92,14 @@ async def test_wsgi_put_more_body(wsgi_middleware: Callable) -> None:
 async def test_wsgi_exception(wsgi_middleware: Callable) -> None:
     # Note that we're testing the WSGI app directly here.
     # The HTTP protocol implementations would catch this error and return 500.
-    app = wsgi_middleware(raise_exception)
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
+    transport = httpx.ASGITransport(wsgi_middleware(raise_exception))
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
         with pytest.raises(RuntimeError):
             await client.get("/")
 
 
 @pytest.mark.anyio
 async def test_wsgi_exc_info(wsgi_middleware: Callable) -> None:
-    # Note that we're testing the WSGI app directly here.
-    # The HTTP protocol implementations would catch this error and return 500.
-    app = wsgi_middleware(return_exc_info)
-    async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
-        with pytest.raises(RuntimeError):
-            response = await client.get("/")
-
     app = wsgi_middleware(return_exc_info)
     transport = httpx.ASGITransport(
         app=app,

--- a/tools/cli_usage.py
+++ b/tools/cli_usage.py
@@ -16,9 +16,7 @@ def _get_usage_lines() -> typing.List[str]:
 
 
 def _find_next_codefence_lineno(lines: typing.List[str], after: int) -> int:
-    return next(
-        lineno for lineno, line in enumerate(lines[after:], after) if line == "```"
-    )
+    return next(lineno for lineno, line in enumerate(lines[after:], after) if line == "```")
 
 
 def _get_insert_location(lines: typing.List[str]) -> typing.Tuple[int, int]:


### PR DESCRIPTION
# Summary

httpx version 0.27.0 deprecated the `app=` shortcut, which makes uvicorn's testsuite now fail in openSUSE. This PR fixes the tests for httpx 0.27.0 by relying on `ASGITransport(app=app)` instead.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
