### PR TITLE
Deprecate the `uvicorn.workers` module

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -182,6 +182,15 @@ Uvicorn provides a lightweight way to run multiple worker processes, for example
 
 ### Gunicorn
 
+!!! warning
+    The `uvicorn.workers` module is deprecated and will be removed in a future release.
+
+    You should use the [`uvicorn-worker`](https://github.com/Kludex/uvicorn-worker) package instead.
+
+    ```bash
+    python -m pip install uvicorn-worker
+    ```
+
 Gunicorn is probably the simplest way to run and manage Uvicorn in a production setting. Uvicorn includes a gunicorn worker class that means you can get set up with very little configuration.
 
 The following will start Gunicorn with four worker processes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -262,6 +262,15 @@ if __name__ == "__main__":
 
 ### Running with Gunicorn
 
+!!! warning
+    The `uvicorn.workers` module is deprecated and will be removed in a future release.
+
+    You should use the [`uvicorn-worker`](https://github.com/Kludex/uvicorn-worker) package instead.
+
+    ```bash
+    python -m pip install uvicorn-worker
+    ```
+
 [Gunicorn][gunicorn] is a mature, fully featured server and process manager.
 
 Uvicorn includes a Gunicorn worker class allowing you to run ASGI applications,

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import signal
 import sys
+import warnings
 from typing import Any
 
 from gunicorn.arbiter import Arbiter
@@ -11,6 +12,12 @@ from gunicorn.workers.base import Worker
 
 from uvicorn.config import Config
 from uvicorn.main import Server
+
+warnings.warn(
+    "The `uvicorn.workers` module is deprecated. Please use `uvicorn-worker` package instead.\n"
+    "For more details, see https://github.com/Kludex/uvicorn-worker.",
+    DeprecationWarning,
+)
 
 
 class UvicornWorker(Worker):


### PR DESCRIPTION
The idea is to deprecate this module in favor of https://github.com/Kludex/uvicorn-worker, and remove it in some time.

The new package is tested.

- Closes https://github.com/encode/uvicorn/issues/1834
- Closes https://github.com/encode/uvicorn/issues/611