### PR TITLE
fix: stop server on "lifespan.shutdown.failed"

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -262,3 +262,32 @@ def test_lifespan_state():
     loop = asyncio.new_event_loop()
     loop.run_until_complete(test())
     loop.close()
+
+
+@pytest.mark.parametrize("mode", ("auto", "on"))
+@pytest.mark.parametrize("raise_exception", (True, False))
+def test_lifespan_receive_shutdown_failed_before_shutdown(mode, raise_exception, caplog):
+    async def app(scope, receive, send):
+        message = await receive()
+        assert message["type"] == "lifespan.startup"
+        await send({"type": "lifespan.startup.complete"})
+        await send({"type": "lifespan.shutdown.failed", "message": "the lifespan event failed"})
+
+        if raise_exception:
+            # App should be able to re-raise an exception caught in lifespan context.
+            raise RuntimeError()
+
+    async def test():
+        config = Config(app=app, lifespan=mode)
+        lifespan = LifespanOn(config)
+        await lifespan.startup()
+        assert lifespan.shutdown_failed
+        assert lifespan.should_exit
+
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(test())
+    error_messages = [
+        record.message for record in caplog.records if record.name == "uvicorn.error" and record.levelname == "ERROR"
+    ]
+    assert "the lifespan event failed" in error_messages.pop(0)
+    loop.close()

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -71,7 +71,6 @@ class LifespanOn:
 
         if self.shutdown_failed or (self.error_occured and self.config.lifespan == "on"):
             self.logger.error("Application shutdown failed. Exiting.")
-            self.should_exit = True
         else:
             self.logger.info("Application shutdown complete.")
 
@@ -130,6 +129,7 @@ class LifespanOn:
             assert not self.shutdown_event.is_set(), STATE_TRANSITION_ERROR
             self.shutdown_event.set()
             self.shutdown_failed = True
+            self.should_exit = True
             if message.get("message"):
                 self.logger.error(message["message"])
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -252,7 +252,7 @@ class Server:
             return True
         if self.config.limit_max_requests is not None:
             return self.server_state.total_requests >= self.config.limit_max_requests
-        return False
+        return self.lifespan.should_exit
 
     async def shutdown(self, sockets: list[socket.socket] | None = None) -> None:
         logger.info("Shutting down")


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Stop the server if a "lifespan.shutdown.failure" message is received from the application after "lifespan.startup.complete" has been sent by the application, but before the server has sent "lifespan.shutdown".

Applications typically use a context manager around the asgi lifespan protocol to manage resources that should share the same lifecycle as the web server. Where a managed resource encounters an error before the server has initiated shutdown, app frameworks such as starlette and litestar will send a `lifespan.shutdown.failed` message.

E.g, in [starlette](https://github.com/encode/starlette/blob/eb76cae6fdb6c1b0bfcace17d0dec946fe767f84/starlette/routing.py#L723-L750):

```py
    async def lifespan(self, scope: Scope, receive: Receive, send: Send) -> None:
        started = False
        app: typing.Any = scope.get("app")
        await receive()
        try:
            async with self.lifespan_context(app) as maybe_state:
                ...
        except BaseException:
            exc_text = traceback.format_exc()
            if started:
                await send({"type": "lifespan.shutdown.failed", "message": exc_text})
            else:
                await send({"type": "lifespan.startup.failed", "message": exc_text})
            raise
        else:
            await send({"type": "lifespan.shutdown.complete"})
```

This PR gives the application a way to tell the server that something critical has failed internally, and that it should shut down.

Closes #2308

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
