### PR TITLE
Remove forced `raise_signal` calls

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,36 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import signal
 import sys
-from typing import Generator
 
 import pytest
 
 from uvicorn.config import Config
 from uvicorn.server import Server
-
-
-# asyncio does NOT allow raising in signal handlers, so to detect
-# raised signals raised a mutable `witness` receives the signal
-@contextlib.contextmanager
-def capture_signal_sync(sig: signal.Signals) -> Generator[list[int], None, None]:
-    """Replace `sig` handling with a normal exception via `signal"""
-    witness: list[int] = []
-    original_handler = signal.signal(sig, lambda signum, frame: witness.append(signum))
-    yield witness
-    signal.signal(sig, original_handler)
-
-
-@contextlib.contextmanager
-def capture_signal_async(sig: signal.Signals) -> Generator[list[int], None, None]:  # pragma: py-win32
-    """Replace `sig` handling with a normal exception via `asyncio"""
-    witness: list[int] = []
-    original_handler = signal.getsignal(sig)
-    asyncio.get_running_loop().add_signal_handler(sig, witness.append, sig)
-    yield witness
-    signal.signal(sig, original_handler)
 
 
 async def dummy_app(scope, receive, send):  # pragma: py-win32

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -58,8 +58,6 @@ class Server:
         self.force_exit = False
         self.last_notified = 0.0
 
-        self._captured_signals: list[int] = []
-
     def run(self, sockets: list[socket.socket] | None = None) -> None:
         self.config.setup_event_loop()
         return asyncio.run(self.serve(sockets=sockets))
@@ -323,7 +321,6 @@ class Server:
                 signal.signal(sig, handler)
 
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
-        self._captured_signals.append(sig)
         if self.should_exit and sig == signal.SIGINT:
             self.force_exit = True
         else:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -321,11 +321,6 @@ class Server:
         finally:
             for sig, handler in original_handlers.items():
                 signal.signal(sig, handler)
-        # If we did gracefully shut down due to a signal, try to
-        # trigger the expected behaviour now; multiple signals would be
-        # done LIFO, see https://stackoverflow.com/questions/48434964
-        for captured_signal in reversed(self._captured_signals):
-            signal.raise_signal(captured_signal)
 
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
         self._captured_signals.append(sig)


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
This change removes the `raise_signal` call which breaks default signal handling for subprocesses.

Closes https://github.com/encode/uvicorn/issues/2289 (and possibly https://github.com/encode/uvicorn/issues/2294)

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
