### PR TITLE
Suppress side-effects of signal propagation

### DIFF
--- a/uvicorn/_subprocess.py
+++ b/uvicorn/_subprocess.py
@@ -75,5 +75,10 @@ def subprocess_started(
     # Logging needs to be setup again for each child.
     config.configure_logging()
 
-    # Now we can call into `Server.run(sockets=sockets)`
-    target(sockets=sockets)
+    try:
+        # Now we can call into `Server.run(sockets=sockets)`
+        target(sockets=sockets)
+    except KeyboardInterrupt:
+        # supress the exception to avoid a traceback from subprocess.Popen
+        # the parent already expects us to end, so no vital information is lost
+        pass

--- a/uvicorn/_subprocess.py
+++ b/uvicorn/_subprocess.py
@@ -78,7 +78,7 @@ def subprocess_started(
     try:
         # Now we can call into `Server.run(sockets=sockets)`
         target(sockets=sockets)
-    except KeyboardInterrupt:
+    except KeyboardInterrupt:  # pragma: py-not-win32
         # supress the exception to avoid a traceback from subprocess.Popen
         # the parent already expects us to end, so no vital information is lost
         pass

--- a/uvicorn/_subprocess.py
+++ b/uvicorn/_subprocess.py
@@ -78,7 +78,7 @@ def subprocess_started(
     try:
         # Now we can call into `Server.run(sockets=sockets)`
         target(sockets=sockets)
-    except KeyboardInterrupt:  # pragma: py-not-win32
+    except KeyboardInterrupt:  # pragma: no cover
         # supress the exception to avoid a traceback from subprocess.Popen
         # the parent already expects us to end, so no vital information is lost
         pass

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -566,16 +566,18 @@ def run(
         logger.warning("You must pass the application as an import string to enable 'reload' or " "'workers'.")
         sys.exit(1)
 
-    if config.should_reload:
-        sock = config.bind_socket()
-        ChangeReload(config, target=server.run, sockets=[sock]).run()
-    elif config.workers > 1:
-        sock = config.bind_socket()
-        Multiprocess(config, target=server.run, sockets=[sock]).run()
-    else:
-        server.run()
-    if config.uds and os.path.exists(config.uds):
-        os.remove(config.uds)  # pragma: py-win32
+    try:
+        if config.should_reload:
+            sock = config.bind_socket()
+            ChangeReload(config, target=server.run, sockets=[sock]).run()
+        elif config.workers > 1:
+            sock = config.bind_socket()
+            Multiprocess(config, target=server.run, sockets=[sock]).run()
+        else:
+            server.run()
+    finally:
+        if config.uds and os.path.exists(config.uds):
+            os.remove(config.uds)  # pragma: py-win32
 
     if not server.started and not config.should_reload and config.workers == 1:
         sys.exit(STARTUP_FAILURE)


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR suppresses noise and dirt from signal propagation introduced in #1600.

- Suppress tracebacks from worker/reload subprocesses on termination. These are triggered deep inside [``multiprocessing.process``](https://github.com/python/cpython/blob/eebea7e515462b503632ada74923ec3246599c9c/Lib/multiprocessing/process.py#L326-L330) on any exception. Since the shutdown exception is expected, subprocesses spawned for workers/reload simply discard it.
   - Fixes #2294.
- Always run cleanup of unix domain sockets when the `uvicorn.run` exits. This would previously be skipped on forced shutdown.

**Note**: I was not able to reproduce #2281 / #2289 so I do not know if they are fixed by this. However, this fixes the various reports on those discussions/issues about tracebacks.

--------

~~I do not have access to a Windows machine for testing so had to emulate it. It would be nice if someone can confirm that this works on Windows.~~ A minimal repro is the program
```
# test.py
async def dummy_app(scope, receive, send): pass
```
run via
```
python -m uvicorn test:dummy_app --reload
```

@johanboekhoven kindly [tested this on Windows](https://github.com/encode/uvicorn/issues/2294#issuecomment-2090197491).

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
    - This change has no effect on behaviour, merely output.
- [x] I've updated the documentation accordingly.
    - This change has no effect on documented behaviour.
