### PR TITLE
Add `reason` support on WebSocketDisconnectEvent

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -646,10 +646,7 @@ async def test_client_close(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTP
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
-    assert disconnect_message is not None
-    assert disconnect_message["type"] == "websocket.disconnect"
-    assert disconnect_message["code"] == 1001
-    assert disconnect_message["reason"] == "custom reason"
+    assert disconnect_message == {"type": "websocket.disconnect", "code": 1001, "reason": "custom reason"}
 
 
 async def test_client_connection_lost(

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -204,6 +204,7 @@ class WebSocketResponseBodyEvent(TypedDict):
 class WebSocketDisconnectEvent(TypedDict):
     type: Literal["websocket.disconnect"]
     code: int
+    reason: NotRequired[str | None]
 
 
 class WebSocketCloseEvent(TypedDict):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -382,7 +382,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             self.closed_event.set()
             if self.ws_server.closing:
                 return {"type": "websocket.disconnect", "code": 1012}
-            return {"type": "websocket.disconnect", "code": exc.code}
+            return {"type": "websocket.disconnect", "code": exc.code, "reason": exc.reason}
 
         if isinstance(data, str):
             return {"type": "websocket.receive", "text": data}

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -212,7 +212,7 @@ class WSProtocol(asyncio.Protocol):
     def handle_close(self, event: events.CloseConnection) -> None:
         if self.conn.state == ConnectionState.REMOTE_CLOSING:
             self.transport.write(self.conn.send(event.response()))
-        self.queue.put_nowait({"type": "websocket.disconnect", "code": event.code})
+        self.queue.put_nowait({"type": "websocket.disconnect", "code": event.code, "reason": event.reason})
         self.transport.close()
 
     def handle_ping(self, event: events.Ping) -> None:
@@ -336,7 +336,7 @@ class WSProtocol(asyncio.Protocol):
                     self.close_sent = True
                     code = message.get("code", 1000)
                     reason = message.get("reason", "") or ""
-                    self.queue.put_nowait({"type": "websocket.disconnect", "code": code})
+                    self.queue.put_nowait({"type": "websocket.disconnect", "code": code, "reason": reason})
                     output = self.conn.send(wsproto.events.CloseConnection(code=code, reason=reason))
                     if not self.transport.is_closing():
                         self.transport.write(output)


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In the ASGI specification repo, we recently talked about the [lack of support for the `reason` field in the `WebSocketDisconnectEvent`](https://github.com/django/asgiref/issues/459). This will be likely [added to the spec soon](https://github.com/django/asgiref/pull/462).

This PR adds support for this new addition. It doesn't need to be merged before the spec is officially modified, but we're already prepared here 😄

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] ~I've updated the documentation accordingly.~ *Don't think it's necessary for this change*
