### PR TITLE
Allow horizontal tabs `\t` in response header values

### DIFF
--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -26,7 +26,7 @@ from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_wi
 from uvicorn.server import ServerState
 
 HEADER_RE = re.compile(b'[\x00-\x1f\x7f()<>@,;:[]={} \t\\"]')
-HEADER_VALUE_RE = re.compile(b"[\x00-\x1f\x7f]")
+HEADER_VALUE_RE = re.compile(b"[\x00-\x08\x0a-\x1f\x7f]")
 
 
 def _get_status_line(status_code: int) -> bytes:


### PR DESCRIPTION
# Summary

This PR allows for `\t` to be returned in response header values by uvicorn when `httptools` are in use.
As explained in #2344, both the letter of the current spec (RFC 9210), and the `h11` implementation, allow tab characters to be present in HTTP header values.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
