### PR TITLE
fix: upgrade is not websocket and dependencies are installed, should not warning

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1036,7 +1036,7 @@ async def test_lifespan_state(http_protocol_cls: HTTPProtocol):
 
 
 async def test_header_upgrade_is_not_websocket_depend_installed(
-        caplog: pytest.LogCaptureFixture, http_protocol_cls: HTTPProtocol
+    caplog: pytest.LogCaptureFixture, http_protocol_cls: HTTPProtocol
 ):
     caplog.set_level(logging.WARNING, logger="uvicorn.error")
     app = Response("Hello, world", media_type="text/plain")

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -157,7 +157,7 @@ class H11Protocol(asyncio.Protocol):
             msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
             self.logger.warning(msg)
 
-    def _should_upgrade(self,) -> bool:
+    def _should_upgrade(self) -> bool:
         upgrade = self._get_upgrade()
         if upgrade == b"websocket" and self._should_upgrade_to_ws():
             return True

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -147,17 +147,14 @@ class HttpToolsProtocol(asyncio.Protocol):
         return True
 
     def _unsupported_upgrade_warning(self) -> None:
-        msg = "Unsupported upgrade request."
-        self.logger.warning(msg)
+        self.logger.warning("Unsupported upgrade request.")
         if not self._should_upgrade_to_ws():
             msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
             self.logger.warning(msg)
 
     def _should_upgrade(self) -> bool:
         upgrade = self._get_upgrade()
-        if upgrade == b"websocket" and self._should_upgrade_to_ws():
-            return True
-        return False
+        return upgrade == b"websocket" and self._should_upgrade_to_ws()
 
     def data_received(self, data: bytes) -> None:
         self._unset_keepalive_if_required()

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -142,6 +142,8 @@ class HttpToolsProtocol(asyncio.Protocol):
         return None
 
     def _should_upgrade_to_ws(self, upgrade: bytes | None) -> bool:
+        if upgrade != b"websocket":
+            return False
         if upgrade == b"websocket" and self.ws_protocol_class is not None:
             return True
         if self.config.ws == "auto":


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
When I upgraded uvicorn to standard, I found that I encountered a lot of `Unsupported upgrade request.` prompts in the logs, so I debugged locally and found that h11 and httptools handle upgrades with different logic. I think I should keep the same logic.
If the upgrade field is not equal to websocket in h11, the `self._should_upgrade_to_ws()` method will not run, while httptools is different.
<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
