### PR TITLE
feat: Improve process termination logic in multiprocess manager

### DIFF
--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -92,7 +92,7 @@ class Process:
 
     def join(self, timeout: float | None = None) -> None:
         logger.info(f"Waiting for child process [{self.process.pid}]")
-        self.process.join(join_timeout)
+        self.process.join(timeout)
         # Timeout, kill the process
         while self.process.exitcode is None:
             self.process.kill()

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -90,9 +90,13 @@ class Process:
         # In Unix, the method will send SIGKILL to the process.
         self.process.kill()
 
-    def join(self) -> None:
+    def join(self, join_timeout: float | None = None) -> None:
         logger.info(f"Waiting for child process [{self.process.pid}]")
-        self.process.join()
+        self.process.join(join_timeout)
+        # Timeout, kill the process
+        while self.process.exitcode is None:
+            self.process.kill()
+            self.process.join(1)
 
     @property
     def pid(self) -> int | None:
@@ -131,7 +135,7 @@ class Multiprocess:
 
     def join_all(self) -> None:
         for process in self.processes:
-            process.join()
+            process.join(self.config.timeout_graceful_shutdown)
 
     def restart_all(self) -> None:
         for idx, process in enumerate(tuple(self.processes)):

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -90,7 +90,7 @@ class Process:
         # In Unix, the method will send SIGKILL to the process.
         self.process.kill()
 
-    def join(self, join_timeout: float | None = None) -> None:
+    def join(self, timeout: float | None = None) -> None:
         logger.info(f"Waiting for child process [{self.process.pid}]")
         self.process.join(join_timeout)
         # Timeout, kill the process


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

About https://github.com/encode/uvicorn/discussions/2369

In our cluster, we accidentally discovered the zombie process. We found the reason. Uvicorn's new process manager will JOIN child processes one by one after sending all exit signals. When the previous child process does not exit for a long time, the subsequent child processes cannot be JOIN.

I noticed that Uvicorn has an inherent shutdown timeout, which would be nice if we could use it with a multiprocessor.

The reason why we don't use terminate&join sequentially is to kill all processes faster, as mentioned in this PR https://github.com/encode/uvicorn/pull/2010

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
