### PR TITLE
Iterate subprocesses in-place

### DIFF
--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -134,7 +134,7 @@ class Multiprocess:
             process.join()
 
     def restart_all(self) -> None:
-        for idx, process in enumerate(tuple(self.processes)):
+        for idx, process in enumerate(self.processes):
             process.terminate()
             process.join()
             new_process = Process(self.config, self.target, self.sockets)
@@ -163,7 +163,7 @@ class Multiprocess:
         if self.should_exit.is_set():
             return  # parent process is exiting, no need to keep subprocess alive
 
-        for idx, process in enumerate(tuple(self.processes)):
+        for idx, process in enumerate(self.processes):
             if process.is_alive():
                 continue
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -174,10 +174,9 @@ class Multiprocess:
                 return
 
             logger.info(f"Child process [{process.pid}] died")
-            del self.processes[idx]
             process = Process(self.config, self.target, self.sockets)
             process.start()
-            self.processes.append(process)
+            self.processes[idx] = process
 
     def handle_signals(self) -> None:
         for sig in tuple(self.signal_queue):


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR fixes a subtle [iterate-remove bug](https://stackoverflow.com/questions/6260089/strange-result-when-removing-item-from-a-list-while-iterating-over-it-in-python) when checking subprocesses. Previously, subprocesses were deleted by index, which would shift the remaining processes and their index to go out of sync. This caused the wrong process to be deleted if more than one died in a cycle.  See #2372.

Instead of being deleted-appended, process are now replaced inplace to ensure positions and thus iteration is stable. This also makes copying the process list superfluous, so I removed this where appropriate.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
