### PR TITLE
Remove signal testing order dependency 

### DIFF
--- a/tests/supervisors/test_signal.py
+++ b/tests/supervisors/test_signal.py
@@ -5,7 +5,7 @@ from asyncio import Event
 import httpx
 import pytest
 
-from tests.utils import run_server
+from tests.utils import run_server, assert_signal
 from uvicorn import Server
 from uvicorn.config import Config
 
@@ -31,8 +31,8 @@ async def test_sigint_finish_req(unused_tcp_port: int):
 
     config = Config(app=wait_app, reload=False, port=unused_tcp_port, timeout_graceful_shutdown=1)
     server: Server
-    async with run_server(config) as server:
-        async with httpx.AsyncClient() as client:
+    with assert_signal(signal.SIGINT):
+        async with run_server(config) as server, httpx.AsyncClient() as client:
             req = asyncio.create_task(client.get(f"http://127.0.0.1:{unused_tcp_port}"))
             await asyncio.sleep(0.1)  # ensure next tick
             server.handle_exit(sig=signal.SIGINT, frame=None)  # exit
@@ -64,8 +64,8 @@ async def test_sigint_abort_req(unused_tcp_port: int, caplog):
 
     config = Config(app=forever_app, reload=False, port=unused_tcp_port, timeout_graceful_shutdown=1)
     server: Server
-    async with run_server(config) as server:
-        async with httpx.AsyncClient() as client:
+    with assert_signal(signal.SIGINT):
+        async with run_server(config) as server, httpx.AsyncClient() as client:
             req = asyncio.create_task(client.get(f"http://127.0.0.1:{unused_tcp_port}"))
             await asyncio.sleep(0.1)  # next tick
             # trigger exit, this request should time out in ~1 sec
@@ -94,10 +94,10 @@ async def test_sigint_deny_request_after_triggered(unused_tcp_port: int, caplog)
 
     config = Config(app=app, reload=False, port=unused_tcp_port, timeout_graceful_shutdown=1)
     server: Server
-    async with run_server(config) as server:
-        # exit and ensure we do not accept more requests
-        server.handle_exit(sig=signal.SIGINT, frame=None)
-        await asyncio.sleep(0.1)  # next tick
-        async with httpx.AsyncClient() as client:
+    with assert_signal(signal.SIGINT):
+        async with run_server(config) as server, httpx.AsyncClient() as client:
+            # exit and ensure we do not accept more requests
+            server.handle_exit(sig=signal.SIGINT, frame=None)
+            await asyncio.sleep(0.1)  # next tick
             with pytest.raises(httpx.ConnectError):
                 await client.get(f"http://127.0.0.1:{unused_tcp_port}")

--- a/tests/supervisors/test_signal.py
+++ b/tests/supervisors/test_signal.py
@@ -5,7 +5,7 @@ from asyncio import Event
 import httpx
 import pytest
 
-from tests.utils import run_server, assert_signal
+from tests.utils import assert_signal, run_server
 from uvicorn import Server
 from uvicorn.config import Config
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,14 +24,15 @@ async def run_server(config: Config, sockets: list[socket] | None = None) -> Asy
 
 
 @contextmanager
-def assert_signal(sig: int):
+def assert_signal(sig: signal.Signals):
+    """Check that a signal was received and handled in a block"""
     seen: set[int] = set()
     prev_handler = signal.signal(sig, lambda num, frame: seen.add(num))
     try:
         yield
+        assert sig in seen, f"process signal {signal.Signals(sig)!r} was not received or handled"
     finally:
         signal.signal(sig, prev_handler)
-        assert sig in seen
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,7 @@ import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
+import signal
 from socket import socket
 
 from uvicorn import Config, Server
@@ -20,6 +21,17 @@ async def run_server(config: Config, sockets: list[socket] | None = None) -> Asy
     finally:
         await server.shutdown()
         task.cancel()
+
+
+@contextmanager
+def assert_signal(sig: int):
+    seen: set[int] = set()
+    prev_handler = signal.signal(sig, lambda num, frame: seen.add(num))
+    try:
+        yield
+    finally:
+        signal.signal(sig, prev_handler)
+        assert sig in seen
 
 
 @contextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
-import signal
 from socket import socket
 
 from uvicorn import Config, Server


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR adds explicit management to signal handling for `signal`-tests.
- Add an `assert_signal` utility to test that a signal was received in a block. The utility sets-and-resets a custom signal handler to work the same regardless of the previous `signal` handler state.
- Use the helper on `supervisors/test_signal.py`. These tests were discovered to be order dependent with other tests (see https://github.com/encode/uvicorn/pull/1600#issuecomment-2146915909 and https://github.com/encode/uvicorn/pull/1600#issuecomment-2149095346), specifically the other `supervisor/*` tests that set but do not reset signal handlers.

<!-- Write a small summary about what is happening here. -->

# Notes

The changes do not touch on the `--timeout-graceful-shutdown` behaviour also noted in https://github.com/encode/uvicorn/pull/1600#issuecomment-2146915909. I haven't figured out whether these are actually related, but the changes make `test_signal.py` reliable again for diagnosing the error.

The utility is not used in `test_server.py` as those tests need control of the specific signal handler type, namely also using `asyncio`'s `add_signal_handler`.

The utility is not used in the other `supervisor/*` tests as these test the actual signal handlers, not just receiving a signal.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
  - See discussion on #1600
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
  - There are no changes to documented behaviour.

