### PR TITLE
Quiet KeyboardInterrupt

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -102,7 +102,8 @@ def test_run_match_config_params() -> None:
         if key not in ("self", "timeout_notify", "callback_notify")
     }
     run_params = {
-        key: repr(value) for key, value in inspect.signature(run).parameters.items() if key not in ("app_dir",)
+        key: repr(value) for key, value in inspect.signature(run).parameters.items()
+        if key not in ("app_dir", "suppress_ki")
     }
     assert config_params == run_params
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -102,7 +102,8 @@ def test_run_match_config_params() -> None:
         if key not in ("self", "timeout_notify", "callback_notify")
     }
     run_params = {
-        key: repr(value) for key, value in inspect.signature(run).parameters.items()
+        key: repr(value)
+        for key, value in inspect.signature(run).parameters.items()
         if key not in ("app_dir", "suppress_ki")
     }
     assert config_params == run_params

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -507,6 +507,7 @@ def run(
     app_dir: str | None = None,
     factory: bool = False,
     h11_max_incomplete_event_size: int | None = None,
+    suppress_ki: bool = False,
 ) -> None:
     if app_dir is not None:
         sys.path.insert(0, app_dir)
@@ -577,7 +578,9 @@ def run(
             server.run()
     except KeyboardInterrupt:
         # KI is received deep inside asyncio and comes with a noisy traceback
-        # raise a new KI here to shorten the traceback
+        # suppress it or raise a new KI here to shorten the traceback
+        if suppress_ki:
+            return
         raise KeyboardInterrupt("quit uvicorn") from None
     finally:
         if config.uds and os.path.exists(config.uds):

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -575,6 +575,10 @@ def run(
             Multiprocess(config, target=server.run, sockets=[sock]).run()
         else:
             server.run()
+    except KeyboardInterrupt:
+        # KI is received deep inside asyncio and comes with a noisy traceback
+        # raise a new KI here to shorten the traceback
+        raise KeyboardInterrupt("quit uvicorn") from None
     finally:
         if config.uds and os.path.exists(config.uds):
             os.remove(config.uds)  # pragma: py-win32


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR quiets the `KeyboardInterrupt` when quitting a programatic run of `uvicorn`.

- The default traceback is much shorter now. It shows that it originates in `uvicorn` and notes that it quits uvicorn to avoid confusing it with a regular error.
  <details>
  <summary>New traceback</summary>

  ```
  INFO:     Started server process [33977]
  INFO:     Waiting for application startup.
  INFO:     Application startup complete.
  INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
  ^CINFO:     Shutting down
  INFO:     Waiting for application shutdown.
  INFO:     Application shutdown complete.
  INFO:     Finished server process [33977]
  Traceback (most recent call last):
    File "/Users/maxfischer/code_projects/uvicorn/run_uvicorn.py", line 3, in <module>
      uvicorn.run("test:dummy_app")
    File "/Users/maxfischer/code_projects/uvicorn/uvicorn/main.py", line 584, in run
      raise KeyboardInterrupt("quit uvicorn") from None
  KeyboardInterrupt: quit uvicorn
  ```
  </details>
  <details>
  <summary>Old traceback</summary>

  ```
  INFO:     Started server process [33710]
  INFO:     Waiting for application startup.
  INFO:     Application startup complete.
  INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
  ^CINFO:     Shutting down
  INFO:     Waiting for application shutdown.
  INFO:     Application shutdown complete.
  INFO:     Finished server process [33710]
  Traceback (most recent call last):
    File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
      return self._loop.run_until_complete(task)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "uvloop/loop.pyx", line 1517, in uvloop.loop.Loop.run_until_complete
  asyncio.exceptions.CancelledError
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/Users/maxfischer/code_projects/uvicorn/run_uvicorn.py", line 3, in <module>
      uvicorn.run("test:dummy_app")
    File "/Users/maxfischer/code_projects/uvicorn/uvicorn/main.py", line 577, in run
      server.run()
    File "/Users/maxfischer/code_projects/uvicorn/uvicorn/server.py", line 65, in run
      return asyncio.run(self.serve(sockets=sockets))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
      return runner.run(main)
             ^^^^^^^^^^^^^^^^
    File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 123, in run
      raise KeyboardInterrupt()
  KeyboardInterrupt
  ```
  </details>
- `uvicorn.run` now has a flag `suppress_ki` that completely silences the `KeyboardInterrupt`. This allows programmatic usage to *almost* restore the pre-#1600 behaviour - the noisy exception is gone (as before), but triggering CTRL+C again still allows to shut down the program (as is usual for Python).

<!-- Write a small summary about what is happening here. -->

# Open design decisions

Should `suppress_ki` default to `True`? It's no problem for the CLI to set it explicitly to `False` and `async` code (which motivated #1600) does not go through this function at all.

Is `suppress_ki` a suitable name? `ki` is commonly used as an abbreviation of `KeyboardInterrupt` (see e.g. `trio`) but usually only needed in very technical situations.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
