### PR TITLE
Suppress interrupt indication on CLI and programmatic usage

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -575,6 +575,8 @@ def run(
             Multiprocess(config, target=server.run, sockets=[sock]).run()
         else:
             server.run()
+    except KeyboardInterrupt:
+        pass
     finally:
         if config.uds and os.path.exists(config.uds):
             os.remove(config.uds)  # pragma: py-win32


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR suppresses `KeyboardInterrupt` on CLI and programmatic usage, restoring the non-`async` behaviour from before #1600.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
