### PR TITLE
Allow passing a custom loop setup function instead of None

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,11 @@ Options:
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
-  --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
+  --loop [custom|auto|asyncio|uvloop]
+                                  Event loop implementation.  [default: auto]
+  --loop-setup TEXT               Import path to event loop setup function.,
+                                  i.e. a (use_subprocess: bool) -> None
+                                  callable.
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
   --ws [auto|none|websockets|wsproto]

--- a/docs/index.md
+++ b/docs/index.md
@@ -127,7 +127,11 @@ Options:
   --workers INTEGER               Number of worker processes. Defaults to the
                                   $WEB_CONCURRENCY environment variable if
                                   available, or 1. Not valid with --reload.
-  --loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]
+  --loop [custom|auto|asyncio|uvloop]
+                                  Event loop implementation.  [default: auto]
+  --loop-setup TEXT               Import path to event loop setup function.,
+                                  i.e. a (use_subprocess: bool) -> None
+                                  callable.
   --http [auto|h11|httptools]     HTTP protocol implementation.  [default:
                                   auto]
   --ws [auto|none|websockets|wsproto]

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -123,6 +123,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     show_default=True,
 )
 @click.option(
+    "--loop-setup",
+    type=str,
+    default=None,
+    help="Import path to event loop setup function., i.e. a (use_subprocess: bool) -> None callable.",
+    show_default=True,
+)
+@click.option(
     "--http",
     type=HTTP_CHOICES,
     default="auto",
@@ -365,6 +372,7 @@ def main(
     uds: str,
     fd: int,
     loop: LoopSetupType,
+    loop_setup: str | None,
     http: HTTPProtocolType,
     ws: WSProtocolType,
     ws_max_size: int,
@@ -414,6 +422,7 @@ def main(
         uds=uds,
         fd=fd,
         loop=loop,
+        loop_setup=loop_setup,
         http=http,
         ws=ws,
         ws_max_size=ws_max_size,
@@ -466,6 +475,7 @@ def run(
     uds: str | None = None,
     fd: int | None = None,
     loop: LoopSetupType = "auto",
+    loop_setup: str | None = None,
     http: type[asyncio.Protocol] | HTTPProtocolType = "auto",
     ws: type[asyncio.Protocol] | WSProtocolType = "auto",
     ws_max_size: int = 16777216,
@@ -518,6 +528,7 @@ def run(
         uds=uds,
         fd=fd,
         loop=loop,
+        loop_setup=loop_setup,
         http=http,
         ws=ws,
         ws_max_size=ws_max_size,


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
Support passing a custom IOLoop setup function in order to support running `uvicorn` in custom ioloop implementation other that the default and `uvloop`.

For example this feature will allow using [this monitored IOLoop](https://github.com/gnir-work/monitored-ioloop) inside `uvicorn` applications :)

Link to discussions thread - https://github.com/encode/uvicorn/discussions/2256

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
