### PR TITLE
Fix 0.30.4 issue with connection close header

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1011,6 +1011,7 @@ async def test_return_close_header(http_protocol_cls: HTTPProtocol):
 
 async def test_close_connection_with_multiple_requests(http_protocol_cls: HTTPProtocol):
     app = Response("Hello, world", media_type="text/plain")
+
     protocol = get_connected_protocol(app, http_protocol_cls)
     protocol.data_received(REQUEST_AFTER_CONNECTION_CLOSE)
     await protocol.loop.run_one()

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -259,10 +259,10 @@ class H11Protocol(asyncio.Protocol):
                     self.transport.resume_reading()
                     self.conn.start_next_cycle()
                     continue
-                if self.conn.their_state == h11.MUST_CLOSE:
-                    break
                 self.cycle.more_body = False
                 self.cycle.message_event.set()
+                if self.conn.their_state == h11.MUST_CLOSE:
+                    break
 
     def handle_websocket_upgrade(self, event: h11.Request) -> None:
         if self.logger.level <= TRACE_LOG_LEVEL:  # pragma: full coverage


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
When `connection: close` header is passed to uvicorn server, `RequestResponseCycle`'s `receive` method goes into waiting state. Resulting in request timeout or explicit connection close action from the client.
This PR will fix the issue.
Detailed RCA: https://github.com/encode/uvicorn/pull/2375#issuecomment-2263997261
<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
