### PR TITLE
Added logging for startup failures.

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -65,7 +65,7 @@ class Server:
         try:
             self.config.setup_event_loop()
             return asyncio.run(self.serve(sockets=sockets))
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             tb = traceback.format_exc()
             logger.error("run error, %s:\n\t%s", str(e), tb)
             raise e

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -10,6 +10,7 @@ import socket
 import sys
 import threading
 import time
+import traceback
 from email.utils import formatdate
 from types import FrameType
 from typing import TYPE_CHECKING, Generator, Sequence, Union
@@ -61,8 +62,13 @@ class Server:
         self._captured_signals: list[int] = []
 
     def run(self, sockets: list[socket.socket] | None = None) -> None:
-        self.config.setup_event_loop()
-        return asyncio.run(self.serve(sockets=sockets))
+        try:
+            self.config.setup_event_loop()
+            return asyncio.run(self.serve(sockets=sockets))
+        except Exception as e:
+            tb = traceback.format_exc()
+            logger.error("run error, %s:\n\t%s", str(e), tb)
+            raise e
 
     async def serve(self, sockets: list[socket.socket] | None = None) -> None:
         with self.capture_signals():


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Added logging for startup failures.

We deploy our Uvicorn app in Kubernetes, and we send our logs to the Aliyun log service. However, we've noticed that when the startup fails (e.g: due to a forgotten module import), the error logs are not visible in the Aliyun log service. As a result:
  1. We are forced to log into the Kubernetes node to determine what happened.
  2. Furthermore, when the startup fails, the Kubernetes pod is restarted, leading to the loss of logs, which increases the difficulty of troubleshooting.

Therefore, I've added logging to capture errors when the startup fails.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

