### PR TITLE
Add delayed-shutdown 

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,6 +114,8 @@ Options:
   --timeout-graceful-shutdown INTEGER
                                   Maximum number of seconds to wait for
                                   graceful shutdown.
+  --shutdown-delay FLOAT
+                                  Time in seconds to delay shutdown when a shutdown-signal is received
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,8 +114,6 @@ Options:
   --timeout-graceful-shutdown INTEGER
                                   Maximum number of seconds to wait for
                                   graceful shutdown.
-  --shutdown-delay FLOAT
-                                  Time in seconds to delay shutdown when a shutdown-signal is received
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -223,6 +223,7 @@ class Config:
         headers: list[tuple[str, str]] | None = None,
         factory: bool = False,
         h11_max_incomplete_event_size: int | None = None,
+        shutdown_delay: float = 0,
     ):
         self.app = app
         self.host = host
@@ -268,6 +269,7 @@ class Config:
         self.encoded_headers: list[tuple[bytes, bytes]] = []
         self.factory = factory
         self.h11_max_incomplete_event_size = h11_max_incomplete_event_size
+        self.shutdown_delay = shutdown_delay
 
         self.loaded = False
         self.configure_logging()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -408,6 +408,7 @@ def main(
     app_dir: str,
     h11_max_incomplete_event_size: int | None,
     factory: bool,
+    shutdown_delay: float = 0,
 ) -> None:
     run(
         app,
@@ -457,6 +458,7 @@ def main(
         factory=factory,
         app_dir=app_dir,
         h11_max_incomplete_event_size=h11_max_incomplete_event_size,
+        shutdown_delay=shutdown_delay,
     )
 
 
@@ -509,6 +511,7 @@ def run(
     app_dir: str | None = None,
     factory: bool = False,
     h11_max_incomplete_event_size: int | None = None,
+    shutdown_delay: float = 0,
 ) -> None:
     if app_dir is not None:
         sys.path.insert(0, app_dir)
@@ -560,6 +563,7 @@ def run(
         use_colors=use_colors,
         factory=factory,
         h11_max_incomplete_event_size=h11_max_incomplete_event_size,
+        shutdown_delay=shutdown_delay,
     )
     server = Server(config=config)
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -259,8 +259,12 @@ class Server:
         return False
 
     async def shutdown(self, sockets: list[socket.socket] | None = None) -> None:
-        logger.info("Shutting down")
+        if self.config.shutdown_delay:
+            logger.info(f"Shutting down in {self.config.shutdown_delay} seconds")
+            self.config.app.uvicorn_shutdown_triggered = True
+            await asyncio.sleep(self.config.shutdown_delay)
 
+        logger.info("Shutting down")
         # Stop accepting new connections.
         for server in self.servers:
             server.close()

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -48,6 +48,10 @@ class ServerState:
         self.default_headers: list[tuple[bytes, bytes]] = []
 
 
+class ShutdownTrigger:
+    is_shutdown_triggered: bool = False
+
+
 class Server:
     def __init__(self, config: Config) -> None:
         self.config = config
@@ -261,7 +265,7 @@ class Server:
     async def shutdown(self, sockets: list[socket.socket] | None = None) -> None:
         if self.config.shutdown_delay:
             logger.info(f"Shutting down in {self.config.shutdown_delay} seconds")
-            self.config.app.uvicorn_shutdown_triggered = True
+            ShutdownTrigger.is_shutdown_triggered = True
             await asyncio.sleep(self.config.shutdown_delay)
 
         logger.info("Shutting down")


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
I have seen several issues/question on e.g StackOverflow regarding "gracefull shutdown" in FastAPI/uvicorn, and I had the same issue. While we have the `timeout_graceful_shutdown` there is a a problem in e.g Kubernetes. When we are scaling number of pods/instances down, we are sending a `SIGTERM` to the pod, but the load-balancer keep sending requests until the `health/ready` does not respond status `200`. Say the load-balancer pings `health/ready` every 5 seconds until it gets a non-200-status, then the app could still get requests for 5 seconds after the `SIGTERM` has been received meaning that all requests in that 5 sec interval would fail.

By adding a delayed shutdown we simply delay the shutdown of the app by a given number of seconds, while setting a flag in the serving app (`uvicorn_shutdown_triggered`). The app can then use this property to check, if a health-point should return 200 or something else to notify the load-balancer that the app is currently under shutdown,  while still accepting requests. After the `delayed_shutdown` time has passed the app shuts down as it normally would.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
