### PR TITLE
feat(server): log warning when max request limit is exceeded

### DIFF
--- a/tools/cli_usage.py
+++ b/tools/cli_usage.py
@@ -2,6 +2,7 @@
 Look for a marker comment in docs pages, and place the output of
 `$ uvicorn --help` there. Pass `--check` to ensure the content is in sync.
 """
+
 import argparse
 import subprocess
 import sys

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -251,7 +251,11 @@ class Server:
         if self.should_exit:
             return True
         if self.config.limit_max_requests is not None:
-            return self.server_state.total_requests >= self.config.limit_max_requests
+            if self.server_state.total_requests >= self.config.limit_max_requests:
+                message = "Exceeded max request limit ending process."
+                logger.warning(message)
+                return True
+            return False
         return False
 
     async def shutdown(self, sockets: list[socket.socket] | None = None) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
ref: https://github.com/encode/uvicorn/discussions/2412

We can't exactly limit the number of requests https://github.com/encode/uvicorn/pull/2420, so at least we can have a friendly reminder log after meeting the limit.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
