### PR TITLE
Clean-shutdown the server even in early shutdown case

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -82,10 +82,13 @@ class Server:
         logger.info(message, process_id, extra={"color_message": color_message})
 
         await self.startup(sockets=sockets)
-        if self.should_exit:
-            return
-        await self.main_loop()
-        await self.shutdown(sockets=sockets)
+
+        try:
+            if self.should_exit:
+                return
+            await self.main_loop()
+        finally:
+            await self.shutdown(sockets=sockets)
 
         message = "Finished server process [%d]"
         color_message = "Finished server process [" + click.style("%d", fg="cyan") + "]"


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

When running the following code (pytest):
```python
import asyncio
from contextlib import asynccontextmanager
from random import random
from typing import AsyncIterator
from fastapi import FastAPI
from fastapi.responses import JSONResponse
import uvicorn


@asynccontextmanager
async def run_server(app: FastAPI) -> AsyncIterator[None]:
    config = uvicorn.Config(app=app, port=8089)
    server = uvicorn.Server(config)
    task = asyncio.create_task(server.serve())
    yield
    server.should_exit = True
    await task


def rng_app() -> FastAPI:
    app = FastAPI()

    @app.get("/random_number")
    async def get_random_number(max: int) -> JSONResponse:
        return JSONResponse({"number": int(random() * max)})

    return app


async def test_this() -> None:
    async with run_server(rng_app()):
        pass
```

I'm getting the following error:
```
Task was destroyed but it is pending!
task: <Task pending name='Task-3' coro=<LifespanOn.main() running at /workspaces/emcie/server/.venv/lib/python3.12/site-packages/uvicorn/lifespan/on.py:86> wait_for=<Future pending cb=[Task.task_wakeup()]>>
ERROR:    Traceback (most recent call last):
  File "/home/vscode/.pyenv/versions/3.12.4/lib/python3.12/asyncio/queues.py", line 158, in get
    await getter
GeneratorExit

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspaces/emcie/server/.venv/lib/python3.12/site-packages/starlette/routing.py", line 743, in lifespan
    await receive()
  File "/workspaces/emcie/server/.venv/lib/python3.12/site-packages/uvicorn/lifespan/on.py", line 137, in receive
    return await self.receive_queue.get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.pyenv/versions/3.12.4/lib/python3.12/asyncio/queues.py", line 160, in get
    getter.cancel()  # Just in case getter is not done yet.
    ^^^^^^^^^^^^^^^
  File "/home/vscode/.pyenv/versions/3.12.4/lib/python3.12/asyncio/base_events.py", line 795, in call_soon
    self._check_closed()
  File "/home/vscode/.pyenv/versions/3.12.4/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

This PR fixes the issue by making sure that a graceful shutdown (including that of the lifespan class) is always awaited before returning from the `serve()` function.

Please note that I didn't add a test as this meant incorporating Starlette/FastAPI in the tests as a (heavy) dependency.
# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
