### PR TITLE
Add anyio to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ coverage==7.5.4
 coverage-conditional-plugin==0.9.0
 httpx==0.27.0
 watchgod==0.8.2
+anyio==3.7.1
 
 # Documentation
 mkdocs==1.6.0


### PR DESCRIPTION
# Summary

The `anyio` package is directly needed to run tests so it should be explicitly listed in the `requirements.txt` file.
See also #2436.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
