### PR TITLE
Update test_websocket.py::test_invalid_upgrade for websockets==0.13*

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -114,6 +114,7 @@ async def test_invalid_upgrade(ws_protocol_cls: WSProtocol, http_protocol_cls: H
                     "missing or empty sec-websocket-key header",  # wsproto
                     "failed to open a websocket connection: missing " "sec-websocket-key header",
                     "failed to open a websocket connection: missing or empty " "sec-websocket-key header",
+                    "failed to open a websocket connection: missing sec-websocket-key header; 'sec-websocket-key'",
                 ]
             )
 


### PR DESCRIPTION
# Summary

Update the expected messages in
`tests/protocols/test_websocket.py::test_invalid_upgrade[websockets-h11]` to cover the new variant emitted by `websockets==0.13*`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
