### PR TITLE
Upgrade websockets to 0.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ filterwarnings = [
     'ignore: \"watchgod\" is deprecated\, you should switch to watchfiles \(`pip install watchfiles`\)\.:DeprecationWarning',
     "ignore:Uvicorn's native WSGI implementation is deprecated.*:DeprecationWarning",
     "ignore: 'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning",
+    "ignore: remove second argument of ws_handler:DeprecationWarning:websockets"
 ]
 
 [tool.coverage.run]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ h11 @ git+https://github.com/python-hyper/h11.git@master
 # Explicit optionals
 a2wsgi==1.10.6
 wsproto==1.2.0
-websockets==12.0
+websockets==13.1
 
 # Packaging
 build==1.2.1

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -357,9 +357,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             msg = "Unexpected ASGI message '%s', after sending 'websocket.close' " "or response already completed."
             raise RuntimeError(msg % message_type)
 
-    async def asgi_receive(
-        self,
-    ) -> WebSocketDisconnectEvent | WebSocketConnectEvent | WebSocketReceiveEvent:
+    async def asgi_receive(self) -> WebSocketDisconnectEvent | WebSocketConnectEvent | WebSocketReceiveEvent:
         if not self.connect_sent:
             self.connect_sent = True
             return {"type": "websocket.connect"}
@@ -380,8 +378,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             self.closed_event.set()
             if self.ws_server.closing:
                 return {"type": "websocket.disconnect", "code": 1012}
-            assert self.close_code is not None and self.close_reason is not None
-            return {"type": "websocket.disconnect", "code": self.close_code, "reason": self.close_reason}
+            return {"type": "websocket.disconnect", "code": self.close_code or 1005, "reason": self.close_reason}
 
         if isinstance(data, str):
             return {"type": "websocket.receive", "text": data}


### PR DESCRIPTION
- Closes https://github.com/encode/uvicorn/pull/2470

This pull request includes several changes to the `uvicorn` project, focusing on handling deprecation warnings and refining the WebSocket protocol implementation. The key changes involve the addition of a new filter warning, adjustments to method signatures, and improvements to exception handling in WebSocket communication.

### Handling Deprecation Warnings:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R99): Added a new deprecation warning filter for the `websockets` library. (`[pyproject.tomlR99](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R99)`)

### WebSocket Protocol Implementation:
* `uvicorn/protocols/websockets/websockets_impl.py`: 
  * Simplified the `ws_handler` method signature by removing the multi-line format. (`[uvicorn/protocols/websockets/websockets_impl.pyL227-R227](diffhunk://#diff-74255e578d2ca222f3b49857a51f2a81a9228f598393e53ba4658da913931729L227-R227)`)
  * Streamlined the `asgi_receive` method signature for better readability. (`[uvicorn/protocols/websockets/websockets_impl.pyL362-R360](diffhunk://#diff-74255e578d2ca222f3b49857a51f2a81a9228f598393e53ba4658da913931729L362-R360)`)
  * Improved exception handling in the `asgi_receive` method to use `self.close_code` and `self.close_reason` instead of the exception attributes. (`[uvicorn/protocols/websockets/websockets_impl.pyL381-R381](diffhunk://#diff-74255e578d2ca222f3b49857a51f2a81a9228f598393e53ba4658da913931729L381-R381)`)