### PR TITLE
Update link to Hypercorn project

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -593,6 +593,6 @@ It has built-in Document-oriented Database, Caching System, Authentication and P
 [asgi]: https://asgi.readthedocs.io/en/latest/
 [asgi-http]: https://asgi.readthedocs.io/en/latest/specs/www.html
 [daphne]: https://github.com/django/daphne
-[hypercorn]: https://gitlab.com/pgjones/hypercorn
+[hypercorn]: https://github.com/pgjones/hypercorn
 [uvloop_docs]: https://uvloop.readthedocs.io/
 [httptools_vs_h11]: https://github.com/python-hyper/h11/issues/9


### PR DESCRIPTION
Hypercorn project seems to be using Github now

https://github.com/pgjones/hypercorn

Link to Gitlab is 404:
https://gitlab.com/pgjones/hypercorn

I've updated the link

<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
