### PR TITLE
Add support for `[*]` in trusted hosts

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -65,7 +65,7 @@ _TRUSTED_IPv6_ADDRESSES = [
     "::11.22.33.44",  # This is a dual address
 ]
 _TRUSTED_IPv6_NETWORKS = "2001:db8:abcd:0012::0/64"
-_TRUSTED_LITERALS = "some-literal , unix:///foo/bar  ,  /foo/bar"
+_TRUSTED_LITERALS = "some-literal , unix:///foo/bar  ,  /foo/bar, garba*gewith*"
 
 
 @pytest.mark.parametrize(

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -56,6 +56,7 @@ def make_httpx_client(
 # of the _TrustedHosts.__init__ method.
 _TRUSTED_NOTHING: list[str] = []
 _TRUSTED_EVERYTHING = "*"
+_TRUSTED_EVERYTHING_LIST = ["*"]
 _TRUSTED_IPv4_ADDRESSES = "127.0.0.1, 10.0.0.1"
 _TRUSTED_IPv4_NETWORKS = ["127.0.0.0/8", "10.0.0.0/8"]
 _TRUSTED_IPv6_ADDRESSES = [
@@ -122,6 +123,7 @@ _TRUSTED_LITERALS = "some-literal , unix:///foo/bar  ,  /foo/bar, garba*gewith*"
         (_TRUSTED_EVERYTHING, "192.168.0.0", True),
         (_TRUSTED_EVERYTHING, "192.168.0.1", True),
         (_TRUSTED_EVERYTHING, "1.1.1.1", True),
+        (_TRUSTED_EVERYTHING_LIST, "1.1.1.1", True),
         # Test IPv6 Addresses
         (_TRUSTED_EVERYTHING, "2001:db8::", True),
         (_TRUSTED_EVERYTHING, "2001:db8:abcd:0012::0", True),
@@ -136,6 +138,7 @@ _TRUSTED_LITERALS = "some-literal , unix:///foo/bar  ,  /foo/bar, garba*gewith*"
         (_TRUSTED_EVERYTHING, "::b16:212c", True),  # aka ::11.22.33.44
         (_TRUSTED_EVERYTHING, "a:b:c:d::", True),
         (_TRUSTED_EVERYTHING, "::a:b:c:d", True),
+        (_TRUSTED_EVERYTHING_LIST, "::a:b:c:d", True),
         # Test Literals
         (_TRUSTED_EVERYTHING, "some-literal", True),
         (_TRUSTED_EVERYTHING, "unix:///foo/bar", True),
@@ -145,6 +148,7 @@ _TRUSTED_LITERALS = "some-literal , unix:///foo/bar  ,  /foo/bar, garba*gewith*"
         (_TRUSTED_EVERYTHING, "unix:///another/path", True),
         (_TRUSTED_EVERYTHING, "/another/path", True),
         (_TRUSTED_EVERYTHING, "", True),
+        (_TRUSTED_EVERYTHING_LIST, "", True),
         ## Trust IPv4 Addresses
         ## -----------------------------
         # Test IPv4 Addresses

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -68,7 +68,6 @@ class _TrustedHosts:
     """Container for trusted hosts and networks"""
 
     def __init__(self, trusted_hosts: list[str] | str) -> None:
-        # gunicorn sends trusted hosts as a parsed list of strings while uvicorn forwards as is provided by input
         self.always_trust: bool = trusted_hosts in ("*", ["*"])
 
         self.trusted_literals: set[str] = set()

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -68,7 +68,8 @@ class _TrustedHosts:
     """Container for trusted hosts and networks"""
 
     def __init__(self, trusted_hosts: list[str] | str) -> None:
-        self.always_trust: bool = trusted_hosts == "*"
+        # gunicorn sends trusted hosts as a parsed list of strings while uvicorn forwards as is provided by input
+        self.always_trust: bool = trusted_hosts in ("*", ["*"])
 
         self.trusted_literals: set[str] = set()
         self.trusted_hosts: set[ipaddress.IPv4Address | ipaddress.IPv6Address] = set()


### PR DESCRIPTION
# Summary

Fixed trusted host parsing for always trust case.
This PR will fix allowing all networks upon passing `--forwarded-allow-ips` as `*` from gunicorn with uvicorn as a worker class.

The fix ensures that gunicorn integration and uvicorn as a standalone application will work fine for storing and validating trusted networks.

Complete RCA is present on issue: #2477 

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
