### PR TITLE
Add `PathLike[str]` type hint for `ssl_keyfile`

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -213,7 +213,7 @@ class Config:
         timeout_notify: int = 30,
         timeout_graceful_shutdown: int | None = None,
         callback_notify: Callable[..., Awaitable[None]] | None = None,
-        ssl_keyfile: str | None = None,
+        ssl_keyfile: str | os.PathLike[str] | None = None,
         ssl_certfile: str | os.PathLike[str] | None = None,
         ssl_keyfile_password: str | None = None,
         ssl_version: int = SSL_PROTOCOL_VERSION,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -497,7 +497,7 @@ def run(
     limit_max_requests: int | None = None,
     timeout_keep_alive: int = 5,
     timeout_graceful_shutdown: int | None = None,
-    ssl_keyfile: str | None = None,
+    ssl_keyfile: str | os.PathLike[str] | None = None,
     ssl_certfile: str | os.PathLike[str] | None = None,
     ssl_keyfile_password: str | None = None,
     ssl_version: int = SSL_PROTOCOL_VERSION,


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Fix typing for `ssl_keyfile` field to allow `PathLike` types like `ssl_certfile`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
