### PR TITLE
Enhance multiprocess manager's log data

### DIFF
--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -182,7 +182,7 @@ class Multiprocess:
             if exitcode is not None and exitcode < 0:
                 try:
                     signal_name = signal.Signals(-exitcode).name
-                except ValueError:
+                except ValueError:  # pragma: no cover
                     pass
             logger.info(f"Child process [{process.pid}] died", extra={"exitcode": exitcode, "signal_name": signal_name})
             process = Process(self.config, self.target, self.sockets)


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This PR proposes to extend the multiprocess manager's "Child process died" log with additional information, specifically the exit code and the name of the signal that terminated the process, similarly as `gunicorn` is reporting. This change will provide more context for troubleshooting issues related to unexpected process termination, particularly in scenarios such as processes being terminated due to "out of memory" errors.

The additional information will be added as `extra` values in the log.


# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
