### PR TITLE
Fixes typo "extras" for "extra" in ColourizedFormatter docstring.

### DIFF
--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -16,7 +16,7 @@ class ColourizedFormatter(logging.Formatter):
     A custom log formatter class that:
 
     * Outputs the LOG_LEVEL with an appropriate color.
-    * If a log call includes an `extras={"color_message": ...}` it will be used
+    * If a log call includes an `extra={"color_message": ...}` it will be used
       for formatting the output, instead of the plain text message.
     """
 


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Fixes a typo in the docstring of `ColourizedFormatter`.

`extra={"color_message": message}` is the correct usage.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
