### PR TITLE
Add option to set worker healthcheck timeout

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -135,6 +135,10 @@ Options:
                                   buffer of an incomplete event.
   --factory                       Treat APP as an application factory, i.e. a
                                   () -> <ASGI app> callable.
+  --worker-healthcheck-timeout FLOAT
+                                  Timeout for healthcheck between supervisor
+                                  and worker in seconds (used only if workers
+                                  > 1).
   --help                          Show this message and exit.
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -205,6 +205,10 @@ Options:
                                   buffer of an incomplete event.
   --factory                       Treat APP as an application factory, i.e. a
                                   () -> <ASGI app> callable.
+  --worker-healthcheck-timeout FLOAT
+                                  Timeout for healthcheck between supervisor
+                                  and worker in seconds (used only if workers
+                                  > 1).
   --help                          Show this message and exit.
 ```
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -74,6 +74,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 * `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Please note that this can be used only with the default `websockets` protocol. **Default:** *20.0*
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.
 * `--h11-max-incomplete-event-size <int>` - Set the maximum number of bytes to buffer of an incomplete event. Only available for `h11` HTTP protocol implementation. **Default:** *'16384'* (16 KB).
+* `--worker_healthcheck_timeout <float>` - Timeout for healthcheck between supervisor and worker in seconds (used only if workers > 1). **Default:** *'5.0'* (5 s).
 
 ## Application Interface
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -223,6 +223,7 @@ class Config:
         headers: list[tuple[str, str]] | None = None,
         factory: bool = False,
         h11_max_incomplete_event_size: int | None = None,
+        worker_healthcheck_timeout: float = 5.0,
     ):
         self.app = app
         self.host = host
@@ -268,6 +269,7 @@ class Config:
         self.encoded_headers: list[tuple[bytes, bytes]] = []
         self.factory = factory
         self.h11_max_incomplete_event_size = h11_max_incomplete_event_size
+        self.worker_healthcheck_timeout = worker_healthcheck_timeout
 
         self.loaded = False
         self.configure_logging()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -360,6 +360,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     help="Treat APP as an application factory, i.e. a () -> <ASGI app> callable.",
     show_default=True,
 )
+@click.option(
+    "--worker-healthcheck-timeout",
+    "worker_healthcheck_timeout",
+    type=float,
+    default=5.0,
+    help="Timeout for healthcheck between supervisor and worker in seconds (used only if workers > 1).",
+)
 def main(
     app: str,
     host: str,
@@ -408,6 +415,7 @@ def main(
     app_dir: str,
     h11_max_incomplete_event_size: int | None,
     factory: bool,
+    worker_healthcheck_timeout: float,
 ) -> None:
     run(
         app,
@@ -457,6 +465,7 @@ def main(
         factory=factory,
         app_dir=app_dir,
         h11_max_incomplete_event_size=h11_max_incomplete_event_size,
+        worker_healthcheck_timeout=worker_healthcheck_timeout,
     )
 
 
@@ -509,6 +518,7 @@ def run(
     app_dir: str | None = None,
     factory: bool = False,
     h11_max_incomplete_event_size: int | None = None,
+    worker_healthcheck_timeout: float = 5.0,
 ) -> None:
     if app_dir is not None:
         sys.path.insert(0, app_dir)
@@ -560,6 +570,7 @@ def run(
         use_colors=use_colors,
         factory=factory,
         h11_max_incomplete_event_size=h11_max_incomplete_event_size,
+        worker_healthcheck_timeout=worker_healthcheck_timeout,
     )
     server = Server(config=config)
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -164,8 +164,10 @@ class Multiprocess:
             return  # parent process is exiting, no need to keep subprocess alive
 
         for idx, process in enumerate(self.processes):
-            if process.is_alive():
+            if process.is_alive(self.config.worker_healthcheck_timeout):
                 continue
+
+            logger.info(f"Child process [{process.pid}] is unresponsive")
 
             process.kill()  # process is hung, kill it
             process.join()
@@ -173,7 +175,6 @@ class Multiprocess:
             if self.should_exit.is_set():
                 return  # pragma: full coverage
 
-            logger.info(f"Child process [{process.pid}] died")
             process = Process(self.config, self.target, self.sockets)
             process.start()
             self.processes[idx] = process


### PR DESCRIPTION
# Summary

Adding new command line and config option `worker_healthcheck_timeout` which sets the timeout for worker liveness from the supervisor when multiple workers are in use. Default timeout is unchanged as well as frequency of health checks.

## Rationale
Applications with CPU intensive synchronous startup may starve the worker process for CPU cycles and make the `pong` thread generate response too late, which in turn makes the supervisor kill and relaunch the worker.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

## Rationale for no explicit test
I was not able to create simple unit test that would reliably trigger the health check timeout. I can 100% reliably trigger it in my application and I've also verified that longer health check timeout resolves the problem.
