### PR TITLE
Make logger names configurable

### DIFF
--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -1,3 +1,5 @@
+import logging
+
 import httpx
 import pytest
 
@@ -17,7 +19,7 @@ async def test_message_logger(caplog):
         caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
         caplog.set_level(TRACE_LOG_LEVEL)
 
-        transport = httpx.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
+        transport = httpx.ASGITransport(MessageLoggerMiddleware(app, logging.getLogger("uvicorn.asgi")))  # type: ignore
         async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
             response = await client.get("/")
         assert response.status_code == 200
@@ -37,7 +39,7 @@ async def test_message_logger_exc(caplog):
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
         caplog.set_level(TRACE_LOG_LEVEL)
-        transport = httpx.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
+        transport = httpx.ASGITransport(MessageLoggerMiddleware(app, logging.getLogger("uvicorn.asgi")))  # type: ignore
         async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
             with pytest.raises(RuntimeError):
                 await client.get("/")

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.32.0"
+__version__ = "0.32.0+logger_names_patched"
 __all__ = ["main", "run", "Config", "Server"]

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from asyncio import Queue
 from typing import Any, Union
 
@@ -34,7 +33,7 @@ class LifespanOn:
             config.load()
 
         self.config = config
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = config.get_logger("general")
         self.startup_event = asyncio.Event()
         self.shutdown_event = asyncio.Event()
         self.receive_queue: Queue[LifespanReceiveMessage] = asyncio.Queue()

--- a/uvicorn/loops/asyncio.py
+++ b/uvicorn/loops/asyncio.py
@@ -1,8 +1,5 @@
 import asyncio
-import logging
 import sys
-
-logger = logging.getLogger("uvicorn.error")
 
 
 def asyncio_setup(use_subprocess: bool = False) -> None:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 import platform
 import ssl
@@ -40,8 +39,6 @@ LOOP_CHOICES = click.Choice([key for key in LOOP_SETUPS.keys() if key != "none"]
 INTERFACE_CHOICES = click.Choice(INTERFACES)
 
 STARTUP_FAILURE = 3
-
-logger = logging.getLogger("uvicorn.error")
 
 
 def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> None:
@@ -486,6 +483,7 @@ def run(
     env_file: str | os.PathLike[str] | None = None,
     log_config: dict[str, Any] | str | RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
     log_level: str | int | None = None,
+    logger_mappings: dict | None = None,
     access_log: bool = True,
     proxy_headers: bool = True,
     server_header: bool = True,
@@ -539,6 +537,7 @@ def run(
         log_config=log_config,
         log_level=log_level,
         access_log=access_log,
+        logger_mappings=logger_mappings,
         proxy_headers=proxy_headers,
         server_header=server_header,
         date_header=date_header,
@@ -564,8 +563,9 @@ def run(
     server = Server(config=config)
 
     if (config.reload or config.workers > 1) and not isinstance(app, str):
-        logger = logging.getLogger("uvicorn.error")
-        logger.warning("You must pass the application as an import string to enable 'reload' or " "'workers'.")
+        config.get_logger("general").warning(
+            "You must pass the application as an import string to enable 'reload' or " "'workers'."
+        )
         sys.exit(1)
 
     try:

--- a/uvicorn/middleware/message_logger.py
+++ b/uvicorn/middleware/message_logger.py
@@ -34,10 +34,10 @@ def message_with_placeholders(message: Any) -> Any:
 
 
 class MessageLoggerMiddleware:
-    def __init__(self, app: "ASGI3Application"):
+    def __init__(self, app: "ASGI3Application", logger: logging.Logger):
         self.task_counter = 0
         self.app = app
-        self.logger = logging.getLogger("uvicorn.asgi")
+        self.logger = logger
 
         def trace(message: Any, *args: Any, **kwargs: Any) -> None:
             self.logger.log(TRACE_LOG_LEVEL, message, *args, **kwargs)

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -49,8 +49,8 @@ class H11Protocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
-        self.access_logger = logging.getLogger("uvicorn.access")
+        self.logger = config.get_logger("general")
+        self.access_logger = config.get_logger("access")
         self.access_log = self.access_logger.hasHandlers()
         self.conn = h11.Connection(
             h11.SERVER,

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -54,8 +54,8 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
-        self.access_logger = logging.getLogger("uvicorn.access")
+        self.logger = config.get_logger("general")
+        self.access_logger = config.get_logger("access")
         self.access_log = self.access_logger.hasHandlers()
         self.parser = httptools.HttpRequestParser(self)
         self.ws_protocol_class = config.ws_protocol_class

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -108,7 +108,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             ping_interval=self.config.ws_ping_interval,
             ping_timeout=self.config.ws_ping_timeout,
             extensions=extensions,
-            logger=logging.getLogger("uvicorn.error"),
+            logger=self.config.get_logger("general"),
         )
         self.server_header = None
         self.extra_headers = [

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import typing
 from typing import Literal, cast
 from urllib.parse import unquote
@@ -49,7 +48,7 @@ class WSProtocol(asyncio.Protocol):
         self.config = config
         self.app = cast(ASGI3Application, config.loaded_app)
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = config.get_logger("general")
         self.root_path = config.root_path
         self.app_state = app_state
 

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 import signal
 import sys
@@ -19,8 +18,6 @@ HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
-
-logger = logging.getLogger("uvicorn.error")
 
 
 class BaseReload:
@@ -51,7 +48,7 @@ class BaseReload:
         self.startup()
         for changes in self:
             if changes:
-                logger.warning(
+                self.config.get_logger("general").warning(
                     "%s detected changes in %s. Reloading...",
                     self.reloader_name,
                     ", ".join(map(_display_path, changes)),
@@ -76,7 +73,7 @@ class BaseReload:
             click.style(str(self.pid), fg="cyan", bold=True),
             click.style(str(self.reloader_name), fg="cyan", bold=True),
         )
-        logger.info(message, extra={"color_message": color_message})
+        self.config.get_logger("general").info(message, extra={"color_message": color_message})
 
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.signal_handler)
@@ -108,7 +105,7 @@ class BaseReload:
 
         message = f"Stopping reloader process [{str(self.pid)}]"
         color_message = "Stopping reloader process [{}]".format(click.style(str(self.pid), fg="cyan", bold=True))
-        logger.info(message, extra={"color_message": color_message})
+        self.config.get_logger("general").info(message, extra={"color_message": color_message})
 
     def should_restart(self) -> list[Path] | None:
         raise NotImplementedError("Reload strategies should override should_restart()")

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from socket import socket
 from typing import Callable, Iterator
 
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
-
-logger = logging.getLogger("uvicorn.error")
 
 
 class StatReload(BaseReload):
@@ -23,7 +20,9 @@ class StatReload(BaseReload):
         self.mtimes: dict[Path, float] = {}
 
         if config.reload_excludes or config.reload_includes:
-            logger.warning("--reload-include and --reload-exclude have no effect unless " "watchfiles is installed.")
+            self.config.get_logger("general").warning(
+                "--reload-include and --reload-exclude have no effect unless " "watchfiles is installed."
+            )
 
     def should_restart(self) -> list[Path] | None:
         self.pause()

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import warnings
 from pathlib import Path
 from socket import socket
@@ -16,11 +15,10 @@ if TYPE_CHECKING:
 
     DirEntry = os.DirEntry[str]
 
-logger = logging.getLogger("uvicorn.error")
-
 
 class CustomWatcher(DefaultWatcher):
     def __init__(self, root_path: Path, config: Config):
+        self.config = config
         default_includes = ["*.py"]
         self.includes = [default for default in default_includes if default not in config.reload_excludes]
         self.includes.extend(config.reload_includes)
@@ -85,7 +83,7 @@ class CustomWatcher(DefaultWatcher):
                         is_watched = True
 
                 if is_watched:
-                    logger.debug(
+                    self.config.get_logger("general").debug(
                         "WatchGodReload detected a new excluded dir '%s' in '%s'; " "Adding to exclude list.",
                         entry_path.relative_to(self.resolved_root),
                         str(self.resolved_root),
@@ -105,7 +103,7 @@ class CustomWatcher(DefaultWatcher):
 
         for include_pattern in self.includes:
             if entry_path.match(include_pattern):
-                logger.info(
+                self.config.get_logger("general").info(
                     "WatchGodReload detected a new reload dir '%s' in '%s'; " "Adding to watch list.",
                     str(entry_path.relative_to(self.resolved_root)),
                     str(self.resolved_root),

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import signal
 import sys
 import warnings
@@ -31,16 +30,6 @@ class UvicornWorker(Worker):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        logger = logging.getLogger("uvicorn.error")
-        logger.handlers = self.log.error_log.handlers
-        logger.setLevel(self.log.error_log.level)
-        logger.propagate = False
-
-        logger = logging.getLogger("uvicorn.access")
-        logger.handlers = self.log.access_log.handlers
-        logger.setLevel(self.log.access_log.level)
-        logger.propagate = False
-
         config_kwargs: dict = {
             "app": None,
             "log_config": None,
@@ -69,6 +58,16 @@ class UvicornWorker(Worker):
         config_kwargs.update(self.CONFIG_KWARGS)
 
         self.config = Config(**config_kwargs)
+
+        logger = self.config.get_logger("general")
+        logger.handlers = self.log.error_log.handlers
+        logger.setLevel(self.log.error_log.level)
+        logger.propagate = False
+
+        logger = self.config.get_logger("access")
+        logger.handlers = self.log.access_log.handlers
+        logger.setLevel(self.log.access_log.level)
+        logger.propagate = False
 
     def init_process(self) -> None:
         self.config.setup_event_loop()


### PR DESCRIPTION
I'm using uvicorn to start, programmaticly, multiple servers.
But logs were always uvicorn.error or uvicorn.access.
I need to make a difference regarding the source server emitting the log.

I added an optional parameter in Config constructor to allow overriding the loggers names.
And i patched the code to use the logger coming from Config instead of using global objects.

So, as an example, adding this parameter
logger_mappings = { "general": "mylogger.general", "access": "mylogger.access", "asgi": "mylogger.asgi", } 
to the Config constructor shall configure the logging in the correct loggers.

I did hack a bit the Config object to maintain maximum compatibility with existing code.

PS: If you find my code is ugly, i agree and i'm willing to improve it.
PS2: Forgive my english