### PR TITLE
fix: make sure always execute the shutdown logic

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -83,8 +83,9 @@ class Server:
         logger.info(message, process_id, extra={"color_message": color_message})
 
         await self.startup(sockets=sockets)
-        if self.should_exit:
-            return
+        # FIX: make sure always execute the shutdown logic, even if server received a signal during startup
+        # if self.should_exit:
+        #     return
         await self.main_loop()
         await self.shutdown(sockets=sockets)
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -84,8 +84,6 @@ class Server:
 
         await self.startup(sockets=sockets)
         # FIX: make sure always execute the shutdown logic, even if server received a signal during startup
-        # if self.should_exit:
-        #     return
         await self.main_loop()
         await self.shutdown(sockets=sockets)
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -264,8 +264,9 @@ class Server:
         logger.info("Shutting down")
 
         # Stop accepting new connections.
-        for server in self.servers:
-            server.close()
+        if hasattr(self, "servers") and self.servers:
+            for server in self.servers:
+                server.close()
         for sock in sockets or []:
             sock.close()  # pragma: full coverage
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -308,8 +308,9 @@ class Server:
             while self.server_state.tasks and not self.force_exit:
                 await asyncio.sleep(0.1)
 
-        for server in self.servers:
-            await server.wait_closed()
+        if hasattr(self, "servers") and self.servers:
+            for server in self.servers:
+                await server.wait_closed()
 
     @contextlib.contextmanager
     def capture_signals(self) -> Generator[None, None, None]:


### PR DESCRIPTION
make sure always execute the shutdown logic, even if server received a signal before entering `main_loop`

before: can not shutdown server when i try to shutdown a server during startup

![image](https://github.com/user-attachments/assets/086ce5c2-9664-4fc8-8bd0-28d0cfe7b329)

after:
![image](https://github.com/user-attachments/assets/ab584fb5-e224-4424-a273-564d3a9797b3)



<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
