### PR TITLE
Drop ASGI spec version to 2.3 on HTTP

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -860,8 +860,8 @@ def asgi2app(scope: Scope):
 @pytest.mark.parametrize(
     "asgi2or3_app, expected_scopes",
     [
-        (asgi3app, {"version": "3.0", "spec_version": "2.4"}),
-        (asgi2app, {"version": "2.0", "spec_version": "2.4"}),
+        (asgi3app, {"version": "3.0", "spec_version": "2.3"}),
+        (asgi2app, {"version": "2.0", "spec_version": "2.3"}),
     ],
 )
 async def test_scopes(

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -200,10 +200,7 @@ class H11Protocol(asyncio.Protocol):
                 full_raw_path = self.root_path.encode("ascii") + raw_path
                 self.scope = {
                     "type": "http",
-                    "asgi": {
-                        "version": self.config.asgi_version,
-                        "spec_version": "2.4",
-                    },
+                    "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
                     "http_version": event.http_version.decode("ascii"),
                     "server": self.server,
                     "client": self.client,

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -214,7 +214,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.headers = []
         self.scope = {  # type: ignore[typeddict-item]
             "type": "http",
-            "asgi": {"version": self.config.asgi_version, "spec_version": "2.4"},
+            "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
             "http_version": "1.1",
             "server": self.server,
             "client": self.client,


### PR DESCRIPTION
When we accepted https://github.com/encode/uvicorn/pull/2276, we didn't undo the version of the spec.