### PR TITLE
Update server log messages to include specific addresses

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,3 +91,9 @@ async def test_request_than_limit_max_requests_warn_log(
             responses = await asyncio.gather(*tasks)
             assert len(responses) == 2
     assert "Maximum request limit of 1 exceeded. Terminating process." in caplog.text
+
+
+async def test_log_messages_for_all_addresses(unused_tcp_port: int, caplog: pytest.LogCaptureFixture):
+    config = Config(app=app, host="0.0.0.0", port=unused_tcp_port)
+    async with run_server(config):
+        assert f"Running on http://127.0.0.1:{unused_tcp_port}" in caplog.text

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -51,7 +51,7 @@ def get_interface_ip(family: socket.AddressFamily) -> str:
         except OSError:
             return "::1" if family == socket.AF_INET6 else "127.0.0.1"
 
-        return s.getsockname()[0]  # type: ignore
+        return s.getsockname()[0]
 
 
 class ServerState:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -35,6 +35,7 @@ if sys.platform == "win32":  # pragma: py-not-win32
 
 logger = logging.getLogger("uvicorn.error")
 
+
 def get_interface_ip(family: socket.AddressFamily) -> str:
     """Get the IP address of an external interface. Used when binding to
     0.0.0.0 or ::1 to show a more useful URL.


### PR DESCRIPTION
Update server log messages to display specific addresses.

* Add `get_interface_ip` function to retrieve the IP address of an external interface.
* Update `_log_started_message` method to include following messages when host is `0.0.0.0` 
 ```
Running on http://127.0.0.1:8080
Running on http://192.168.1.10:8080
```
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/encode/uvicorn/pull/2521?shareId=a9abcbe0-9d7e-41c5-a659-018cd98be49e).

---

Failed due to 100% test coverage.