### PR TITLE
Add alls-green job

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 30
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -38,3 +38,14 @@ jobs:
       - name: "Enforce coverage"
         run: "scripts/coverage"
         shell: bash
+
+  # https://github.com/marketplace/actions/alls-green#why
+  check:
+    if: always()
+    needs: [tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Every year I need to go to the settings and remove a python version, and then add another python version...

With this job, I don't need to go every year and change that.

Now we only need a single one, instead of all python versions, and OSs.
<img width="764" alt="Screenshot 2024-12-15 at 12 41 56" src="https://github.com/user-attachments/assets/c81550ec-bbf0-4abe-9d8d-574c24efa09e" />
