### PR TITLE
Add cache to setup-python

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: pip
       - name: "Install dependencies"
         run: "scripts/install"
         shell: bash


### PR DESCRIPTION
The Windows pipeline takes 2 minutes installing the packages.