### PR TITLE
fix asgi spec violation causing crash in lilya

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -465,8 +465,11 @@ class RequestResponseCycle:
 
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
+            # we need to make sure that the headers are a list, the spec requires only an iterator
+            scope_headers = list(self.scope["headers"])
+            self.scope["headers"] = scope_headers
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if CLOSE_HEADER in scope_headers and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -468,8 +468,11 @@ class RequestResponseCycle:
 
             status_code = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
+            # we need to make sure that the headers are a list, the spec requires only an iterator
+            scope_headers = list(self.scope["headers"])
+            self.scope["headers"] = scope_headers
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if CLOSE_HEADER in scope_headers and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

Detail:

The asgi spec only specifies that the headers are an iterable. Uvicorn assumes that the headers in scope are a list. This causes a crash at least in lilya and can cause hard to debug bugs because of exhausted iterators