### PR TITLE
Idea: Pass a copy of the scope to the ASGI app to prevent headers changing to something incompatible

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -400,8 +400,14 @@ class RequestResponseCycle:
     # ASGI exception wrapper
     async def run_asgi(self, app: ASGI3Application) -> None:
         try:
+            # asgi apps can manipulate the scope, make sure we don't get a manipulated scope
+            # this can lead to problems when e.g. the headers are exchanged by an iterator
             result = await app(  # type: ignore[func-returns-value]
-                self.scope, self.receive, self.send
+                # asgi apps can manipulate the scope, make sure we don't get a manipulated scope
+                # this can lead to problems when e.g. the headers are exchanged by an iterator
+                self.scope.copy(),
+                self.receive,
+                self.send,
             )
         except BaseException as exc:
             msg = "Exception in ASGI application\n"

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -407,7 +407,7 @@ class RequestResponseCycle:
     async def run_asgi(self, app: ASGI3Application) -> None:
         try:
             result = await app(  # type: ignore[func-returns-value]
-                self.scope, self.receive, self.send
+                self.scope.copy(), self.receive, self.send
             )
         except BaseException as exc:
             msg = "Exception in ASGI application\n"


### PR DESCRIPTION

<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

Changes:

The asgi spec allows changing the scope. We rely on headers as list so we copy the scope to the asgi app. Otherwise we can have suddenly headers which are an (exhausted) iterator.

Discussion: #2572 .

I am not sure if this is a good solution. In lilya we copy the scope because of this issue. So please give me guidance in case it
doesn't matches your expectations.
I can only say: I investigated a  sudden crash in lilya and could trace it back to my changes and the expectation that the headers are something like a list in uvicorn. No offense meant, it is just an idea how to fix the root issue.