### PR TITLE
relax reload_dirs to allow files, and stop adding cwd when reload_dirs is set

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -315,7 +315,10 @@ def test_should_watch_one_dir_cwd(mocker: MockerFixture, reload_directory_struct
         )
         WatchFilesReload(config, target=run, sockets=[])
         mock_watch.assert_called_once()
-        assert mock_watch.call_args[0] == (Path.cwd(),)
+        assert set(mock_watch.call_args[0]) == {
+            app_first_dir,
+            app_dir,
+        }
 
 
 @pytest.mark.skipif(WatchFilesReload is None, reason="watchfiles not available")
@@ -333,7 +336,6 @@ def test_should_watch_separate_dirs_outside_cwd(mocker: MockerFixture, reload_di
     assert set(mock_watch.call_args[0]) == {
         app_dir,
         app_first_dir,
-        Path.cwd(),
     }
 
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -150,7 +150,7 @@ def resolve_reload_patterns(patterns_list: list[str], directories_list: list[str
     directories = list(set(directories))
     directories = list(map(Path, directories))
     directories = list(map(lambda x: x.resolve(), directories))
-    directories = list({reload_path for reload_path in directories if is_dir(reload_path)})
+    directories = list(set(directories))
 
     children = []
     for j in range(len(directories)):

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -150,7 +150,7 @@ def resolve_reload_patterns(patterns_list: list[str], directories_list: list[str
     directories = list(set(directories))
     directories = list(map(Path, directories))
     directories = list(map(lambda x: x.resolve(), directories))
-    directories = list(set(directories))
+    directories = list(set(filter(Path.exists, directories)))
 
     children = []
     for j in range(len(directories)):

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -63,10 +63,7 @@ class WatchFilesReload(BaseReload):
         self.reloader_name = "WatchFiles"
         self.reload_dirs = []
         for directory in config.reload_dirs:
-            if Path.cwd() not in directory.parents:
-                self.reload_dirs.append(directory)
-        if Path.cwd() not in self.reload_dirs:
-            self.reload_dirs.append(Path.cwd())
+            self.reload_dirs.append(directory)
 
         self.watch_filter = FileFilter(config)
         self.watcher = watch(


### PR DESCRIPTION
# Summary

Based on the discussion on https://github.com/encode/uvicorn/discussions/1833 the behavior currently done by a uvicorn is intuitive and most likely will lead to bugs by downstream users. It's also the case that watchfiles can watch individual files, as such it's a manufactured constraint by uvicorn is very arbitrary. Some other ASGIs just has `reload_paths`, that handles files just fine. I didn't change the variable name to not break backwards compatibility, but the former change can be seen as breaking, even if the existing behavior can be considered as a bug. 

# Checklist

- [X] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.

I'm not familiar with the larger project, so I will be holding off on documentation and tests until it's verified that the project has interest in the change getting merged.