### PR TITLE
Avoid test dependency on typing_extensions

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -9,7 +9,6 @@ import pytest
 import websockets
 import websockets.client
 import websockets.exceptions
-from typing_extensions import TypedDict
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
 from websockets.typing import Subprotocol
 
@@ -777,7 +776,7 @@ async def test_server_reject_connection(
     assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
 
 
-class EmptyDict(TypedDict): ...
+class EmptyDict(typing.TypedDict): ...
 
 
 async def test_server_reject_connection_with_response(


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

TypedDict was added to the standard library typing module in Python 3.8. Since this project already requires at least Python 3.9, we can rely on this being available.

Previous discussed in https://github.com/encode/uvicorn/discussions/2589.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
