### PR TITLE
Reload on SIGHUP signal when BaseReload class is used (one worker)

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -45,8 +45,8 @@ class BaseReload:
         A signal handler that is registered with the parent process.
         """
         if sig == signal.SIGHUP:
--            logger.info("Received SIGHUP. Reloading...")
--            self.restart()
+            logger.info("Received SIGHUP. Reloading...")
+            self.restart()
         else:
             # shutdown
             if sys.platform == "win32" and self.is_restarting:


### PR DESCRIPTION
PR to reload BaseReload class worker when the SIGHUP signal is received. Currently, the SIGHUP signal causes shutdown. The goal is to make the behaviour consistent with the Multiprocess class.

I use Uvicorn on DEV with one worker and PROD with many workers using systemd with the below config line. Thus, reloading uvicorn with the same command on both DEV and PROD is convenient.
`ExecReload=/bin/kill -s HUP $MAINPID`
