### PR TITLE
Don't include `cwd()` when non-empty `--reload-dirs` is passed

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -306,24 +306,21 @@ class TestBaseReload:
 
 
 @pytest.mark.skipif(WatchFilesReload is None, reason="watchfiles not available")
-def test_should_watch_one_dir_cwd(mocker: MockerFixture, reload_directory_structure: Path):
+def test_should_watch_cwd(mocker: MockerFixture, reload_directory_structure: Path):
     mock_watch = mocker.patch("uvicorn.supervisors.watchfilesreload.watch")
-    app_dir = reload_directory_structure / "app"
-    app_first_dir = reload_directory_structure / "app_first"
 
-    with as_cwd(reload_directory_structure):
-        config = Config(
-            app="tests.test_config:asgi_app",
-            reload=True,
-            reload_dirs=[str(app_dir), str(app_first_dir)],
-        )
-        WatchFilesReload(config, target=run, sockets=[])
-        mock_watch.assert_called_once()
-        assert mock_watch.call_args[0] == (Path.cwd(),)
+    config = Config(
+        app="tests.test_config:asgi_app",
+        reload=True,
+        reload_dirs=[],
+    )
+    WatchFilesReload(config, target=run, sockets=[])
+    mock_watch.assert_called_once()
+    assert mock_watch.call_args[0] == (Path.cwd(),)
 
 
 @pytest.mark.skipif(WatchFilesReload is None, reason="watchfiles not available")
-def test_should_watch_separate_dirs_outside_cwd(mocker: MockerFixture, reload_directory_structure: Path):
+def test_should_watch_multiple_dirs(mocker: MockerFixture, reload_directory_structure: Path):
     mock_watch = mocker.patch("uvicorn.supervisors.watchfilesreload.watch")
     app_dir = reload_directory_structure / "app"
     app_first_dir = reload_directory_structure / "app_first"
@@ -337,7 +334,6 @@ def test_should_watch_separate_dirs_outside_cwd(mocker: MockerFixture, reload_di
     assert set(mock_watch.call_args[0]) == {
         app_dir,
         app_first_dir,
-        Path.cwd(),
     }
 
 

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -309,11 +309,7 @@ class TestBaseReload:
 def test_should_watch_cwd(mocker: MockerFixture, reload_directory_structure: Path):
     mock_watch = mocker.patch("uvicorn.supervisors.watchfilesreload.watch")
 
-    config = Config(
-        app="tests.test_config:asgi_app",
-        reload=True,
-        reload_dirs=[],
-    )
+    config = Config(app="tests.test_config:asgi_app", reload=True, reload_dirs=[])
     WatchFilesReload(config, target=run, sockets=[])
     mock_watch.assert_called_once()
     assert mock_watch.call_args[0] == (Path.cwd(),)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -313,7 +313,7 @@ class Config:
                         + "directories, watching current working directory.",
                         reload_dirs,
                     )
-                self.reload_dirs = [Path(os.getcwd())]
+                self.reload_dirs = [Path.cwd()]
 
             logger.info(
                 "Will watch for changes in these directories: %s",

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -62,10 +62,10 @@ class WatchFilesReload(BaseReload):
         super().__init__(config, target, sockets)
         self.reloader_name = "WatchFiles"
         self.reload_dirs = []
-        for directory in config.reload_dirs:
-            if Path.cwd() not in directory.parents:
+        if config.reload_dirs:
+            for directory in config.reload_dirs:
                 self.reload_dirs.append(directory)
-        if Path.cwd() not in self.reload_dirs:
+        else:
             self.reload_dirs.append(Path.cwd())
 
         self.watch_filter = FileFilter(config)

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -62,11 +62,8 @@ class WatchFilesReload(BaseReload):
         super().__init__(config, target, sockets)
         self.reloader_name = "WatchFiles"
         self.reload_dirs = []
-        if config.reload_dirs:
-            for directory in config.reload_dirs:
-                self.reload_dirs.append(directory)
-        else:
-            self.reload_dirs.append(Path.cwd())
+        for directory in config.reload_dirs:
+            self.reload_dirs.append(directory)
 
         self.watch_filter = FileFilter(config)
         self.watcher = watch(


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

This PR fixes the behavior of `--reload-dir` to match the documentation. The documentation states:

```
  --reload-dir PATH               Set reload directories explicitly, instead
                                  of using the current working directory.
```

also:

> `--reload-dir <path>` - Specify which directories to watch for python file changes. May be used multiple times. If unused, then by default the whole current directory will be watched. If you are running programmatically use `reload_dirs=[]` and pass a list of strings.

However, the current implementation always adds `Path.cwd()` to list of watched directories. This is undesirable and contradicts the documentation. `Path.cwd()` should only be added as a default when no `--reload-dir` is specified.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] <!-- I've updated the documentation accordingly. --> No documentation update is required.