### PR TITLE
Flush the stdout buffer on Windows to trigger reload

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -90,7 +90,10 @@ class BaseReload:
             self.is_restarting = True
             assert self.process.pid is not None
             os.kill(self.process.pid, signal.CTRL_C_EVENT)
-            print("")  # This helps trigger windows to respond to the Ctrl+C event
+
+            # This is a workaround to ensure the Ctrl+C event is processed
+            sys.stdout.write(" ") # This has to be a non-empty string
+            sys.stdout.flush()
         else:  # pragma: py-win32
             self.process.terminate()
         self.process.join()

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -90,7 +90,7 @@ class BaseReload:
             self.is_restarting = True
             assert self.process.pid is not None
             os.kill(self.process.pid, signal.CTRL_C_EVENT)
-            print("") # This helps trigger windows to respond to the Ctrl+C event
+            print("")  # This helps trigger windows to respond to the Ctrl+C event
         else:  # pragma: py-win32
             self.process.terminate()
         self.process.join()

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -92,7 +92,7 @@ class BaseReload:
             os.kill(self.process.pid, signal.CTRL_C_EVENT)
 
             # This is a workaround to ensure the Ctrl+C event is processed
-            sys.stdout.write(" ") # This has to be a non-empty string
+            sys.stdout.write(" ")  # This has to be a non-empty string
             sys.stdout.flush()
         else:  # pragma: py-win32
             self.process.terminate()

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -90,6 +90,7 @@ class BaseReload:
             self.is_restarting = True
             assert self.process.pid is not None
             os.kill(self.process.pid, signal.CTRL_C_EVENT)
+            print("") # This helps trigger windows to respond to the Ctrl+C event
         else:  # pragma: py-win32
             self.process.terminate()
         self.process.join()


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
I'm raising this in response to #2000 as it's a fix I've been using locally. Through my experimentation, I have found that printing something after the Ctrl+C event is sent, allows the terminal running uvicorn to process the event, causing it to reload immediately.

I explain this in #2000 and there is already a reply saying it has resolved the issue for somebody else.

Tested on Windows 11 with:
- PyCharm (built-in terminal)
- VS Code (built-in terminal)
- Windows Terminal app

All of these now reliably reload for me. However I still have issues in CI running headlessly. I've started #2609 to discuss a fix for this too.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

Don't believe the last two points are necessary here but feel free to correct me.