### PR TITLE
bug(reload exclude dir): Resolve directory path before comparing to `path.parents()`

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -129,7 +129,7 @@ class TestBaseReload:
             config = Config(
                 app="tests.test_config:asgi_app",
                 reload=True,
-                reload_excludes=[str(sub_dir)],
+                reload_excludes=[str(sub_dir.relative_to(self.reload_path))],  # make it relative to current working dir
             )
             reloader = self._setup_reloader(config)
 
@@ -284,7 +284,7 @@ class TestBaseReload:
             config = Config(
                 app="tests.test_config:asgi_app",
                 reload=True,
-                reload_excludes=[str(sub_dir)],
+                reload_excludes=[str(sub_dir.relative_to(self.reload_path))],  # make it relative to current working dir
             )
             reloader = self._setup_reloader(config)
 

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -23,6 +23,7 @@ class FileFilter:
         for e in config.reload_excludes:
             p = Path(e)
             try:
+                p = p.resolve()
                 is_dir = p.is_dir()
             except OSError:  # pragma: no cover
                 # gets raised on Windows for values like "*.py"


### PR DESCRIPTION
# Summary

This is just the `bug` fix from #2602 

* bug: Checking if a excluded path is within a path's `.parents()` only works if the excluded path is an absolute path.
	* The watched paths (`config.reload_dirs`) [are absolute](https://github.com/encode/uvicorn/blob/4fdfec4adf1ba6da5e65c8422321e203b6050052/uvicorn/config.py#L152), so the path parents are also absolute.
	* Therefore, all excluded dirs in `FileFilter` should also be absolute paths.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [NA] I've updated the documentation accordingly.
