### PR TITLE
Bump h11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 -e .[standard]
 
-# TODO: Remove this after h11 makes a release. By this writing, h11 was on 0.14.0.
 # Core dependencies
-h11 @ git+https://github.com/python-hyper/h11.git@master
+h11==0.16.0
 
 # Explicit optionals
 a2wsgi==1.10.8


### PR DESCRIPTION
# Summary
[h11](https://github.com/python-hyper/h11) has now released version 0.16.0 which amongst other things fixes a vulnerability, I've updated the requirements in uvicorn to use this release instead of targeting the main branch so we can use the latest tagged release and avoid this vulnerability

```
                            Vulnerable Dependencies                             
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ Package     ┃ Version        ┃ Vulnerability ID            ┃ Fix Versions    ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ h11         │ 0.14.0         │ GHSA-vqfr-h8mv-ghfj         │ 0.16.0          │
└─────────────┴────────────────┴─────────────────────────────┴─────────────────┘
```

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
