### PR TITLE
chore: improve type hints

### DIFF
--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -4,7 +4,8 @@ import contextlib
 import logging
 import socket
 import sys
-import typing
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
@@ -15,7 +16,7 @@ from tests.utils import run_server
 from uvicorn import Config
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     import sys
 
     from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
@@ -32,7 +33,7 @@ pytestmark = pytest.mark.anyio
 
 
 @contextlib.contextmanager
-def caplog_for_logger(caplog: pytest.LogCaptureFixture, logger_name: str) -> typing.Iterator[pytest.LogCaptureFixture]:
+def caplog_for_logger(caplog: pytest.LogCaptureFixture, logger_name: str) -> Iterator[pytest.LogCaptureFixture]:
     logger = logging.getLogger(logger_name)
     logger.propagate, old_propagate = False, logger.propagate
     logger.addHandler(caplog.handler)

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import typing
 from copy import deepcopy
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import httpx
 import pytest
@@ -35,7 +35,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     skip_if_no_wsproto = pytest.mark.skipif(True, reason="wsproto is not installed.")
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     import sys
 
     from uvicorn.protocols.http.h11_impl import H11Protocol
@@ -776,7 +776,7 @@ async def test_server_reject_connection(
     assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
 
 
-class EmptyDict(typing.TypedDict): ...
+class EmptyDict(TypedDict): ...
 
 
 async def test_server_reject_connection_with_response(
@@ -1142,12 +1142,12 @@ async def test_multiple_server_header(
 
 
 async def test_lifespan_state(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
-    expected_states: list[dict[str, typing.Any]] = [
+    expected_states: list[dict[str, Any]] = [
         {"a": 123, "b": [1]},
         {"a": 123, "b": [1, 2]},
     ]
 
-    actual_states: list[dict[str, typing.Any]] = []
+    actual_states: list[dict[str, Any]] = []
 
     async def lifespan_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         message = await receive()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,9 +7,9 @@ import logging
 import os
 import socket
 import sys
-import typing
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Literal
+from typing import IO, Any, Callable, Literal
 from unittest.mock import MagicMock
 
 import pytest
@@ -291,7 +291,7 @@ def test_ssl_config_combined(tls_certificate_key_and_chain_path: str) -> None:
     assert config.is_ssl is True
 
 
-def asgi2_app(scope: Scope) -> typing.Callable:
+def asgi2_app(scope: Scope) -> Callable:
     async def asgi(receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:  # pragma: nocover
         pass
 
@@ -374,7 +374,7 @@ def test_log_config_yaml(
 @pytest.mark.parametrize("config_file", ["log_config.ini", configparser.ConfigParser(), io.StringIO()])
 def test_log_config_file(
     mocked_logging_config_module: MagicMock,
-    config_file: str | configparser.RawConfigParser | typing.IO[Any],
+    config_file: str | configparser.RawConfigParser | IO[Any],
 ) -> None:
     """
     Test that one can load a configparser config from disk.
@@ -386,14 +386,14 @@ def test_log_config_file(
 
 
 @pytest.fixture(params=[0, 1])
-def web_concurrency(request: pytest.FixtureRequest) -> typing.Iterator[int]:
+def web_concurrency(request: pytest.FixtureRequest) -> Iterator[int]:
     yield request.param
     if os.getenv("WEB_CONCURRENCY"):
         del os.environ["WEB_CONCURRENCY"]
 
 
 @pytest.fixture(params=["127.0.0.1", "127.0.0.2"])
-def forwarded_allow_ips(request: pytest.FixtureRequest) -> typing.Iterator[str]:
+def forwarded_allow_ips(request: pytest.FixtureRequest) -> Iterator[str]:
     yield request.param
     if os.getenv("FORWARDED_ALLOW_IPS"):
         del os.environ["FORWARDED_ALLOW_IPS"]

--- a/uvicorn/protocols/websockets/auto.py
+++ b/uvicorn/protocols/websockets/auto.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import typing
+from typing import Callable
 
-AutoWebSocketsProtocol: typing.Callable[..., asyncio.Protocol] | None
+AutoWebSocketsProtocol: Callable[..., asyncio.Protocol] | None
 try:
     import websockets  # noqa
 except ImportError:  # pragma: no cover

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import typing
-from typing import Literal, cast
+from typing import Any, Literal, cast
 from urllib.parse import unquote
 
 import wsproto
@@ -41,7 +40,7 @@ class WSProtocol(asyncio.Protocol):
         self,
         config: Config,
         server_state: ServerState,
-        app_state: dict[str, typing.Any],
+        app_state: dict[str, Any],
         _loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         if not config.loaded:
@@ -256,7 +255,7 @@ class WSProtocol(asyncio.Protocol):
 
         if not self.handshake_complete:
             if message_type == "websocket.accept":
-                message = typing.cast(WebSocketAcceptEvent, message)
+                message = cast(WebSocketAcceptEvent, message)
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
                     get_client_addr(self.scope),
@@ -293,7 +292,7 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.close()
 
             elif message_type == "websocket.http.response.start":
-                message = typing.cast(WebSocketResponseStartEvent, message)
+                message = cast(WebSocketResponseStartEvent, message)
                 # ensure status code is in the valid range
                 if not (100 <= message["status"] < 600):
                     msg = "Invalid HTTP status code '%d' in response."
@@ -325,7 +324,7 @@ class WSProtocol(asyncio.Protocol):
         elif not self.close_sent and not self.response_started:
             try:
                 if message_type == "websocket.send":
-                    message = typing.cast(WebSocketSendEvent, message)
+                    message = cast(WebSocketSendEvent, message)
                     bytes_data = message.get("bytes")
                     text_data = message.get("text")
                     data = text_data if bytes_data is None else bytes_data
@@ -334,7 +333,7 @@ class WSProtocol(asyncio.Protocol):
                         self.transport.write(output)
 
                 elif message_type == "websocket.close":
-                    message = typing.cast(WebSocketCloseEvent, message)
+                    message = cast(WebSocketCloseEvent, message)
                     self.close_sent = True
                     code = message.get("code", 1000)
                     reason = message.get("reason", "") or ""
@@ -351,7 +350,7 @@ class WSProtocol(asyncio.Protocol):
                 raise ClientDisconnected from exc
         elif self.response_started:
             if message_type == "websocket.http.response.body":
-                message = typing.cast("WebSocketResponseBodyEvent", message)
+                message = cast("WebSocketResponseBodyEvent", message)
                 body_finished = not message.get("more_body", False)
                 reject_data = events.RejectData(data=message["body"], body_finished=body_finished)
                 output = self.conn.send(reject_data)


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
Only improve type hints, does not change any code logic.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

# Description
Changes are made by the following script:
```py
# refactor.py
"""
Change typing import style for python files
    'import typing' -> 'from typing import Any,cast,...'
    'typing.Any' -> 'Any'
    'typing.cast' -> 'cast'
    'typing.ContextManager' -> 'contextlib.AbstractContextManager'
"""

import re
from pathlib import Path

for d in (Path().resolve().name, "tests"):
    for p in Path(d).rglob("*.py"):
        s = p.read_text()
        t = "import typing"
        if t not in s:
            continue
        pattern = re.compile(r"(\W?)typing\.(\w+)(\W)")
        ws = set([i[1] for i in pattern.findall(s)])
        imports = "from typing import "
        for cm in ("ContextManager", "AsyncContextManager"):
            if cm not in ws:
                continue
            # typing.ContextManager -> contextlib.AbstractContextManager
            # typing.AsyncContextManager -> contextlib.AbstractAsyncContextManager
            ws.remove(cm)
            imports = f"from contextlib import Abstract{cm}\n" + imports
            s = re.sub(rf"(\W?)typing\.({cm})(\W)", r"\1Abstract\2\3", s)
        s = pattern.sub(r"\1\2\3", s)
        imports += ", ".join(sorted(ws))
        s = s.replace(t, imports)
        p.write_text(s)
        print(p, "updated.")
```
- Command line:
```bash
python refactor.py
./scripts/lint
./scripts/check
```
