### PR TITLE
Fix test_loop_auto for Python 3.14

### DIFF
--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -38,10 +38,8 @@ def test_loop_auto():
     policy = asyncio.get_event_loop_policy()
 
     # https://github.com/python/cpython/issues/131148
-    if sys.version_info >= (3, 14):
-        BaseDefaultEventLoopPolicy = asyncio.events._BaseDefaultEventLoopPolicy
-    else:
-        BaseDefaultEventLoopPolicy = asyncio.events.BaseDefaultEventLoopPolicy
+    prefix = "_" if sys.version_info >= (3, 14) else ""
+    BaseDefaultEventLoopPolicy = getattr(asyncio.events, f"{prefix}BaseDefaultEventLoopPolicy")
 
     assert isinstance(policy, BaseDefaultEventLoopPolicy)
     assert type(policy).__module__.startswith(expected_loop)

--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import sys
 
 import pytest
 
@@ -35,7 +36,14 @@ async def app(scope, receive, send):
 def test_loop_auto():
     auto_loop_setup()
     policy = asyncio.get_event_loop_policy()
-    assert isinstance(policy, asyncio.events.BaseDefaultEventLoopPolicy)
+
+    # https://github.com/python/cpython/issues/131148
+    if sys.version_info >= (3, 14):
+        BaseDefaultEventLoopPolicy = asyncio.events._BaseDefaultEventLoopPolicy
+    else:
+        BaseDefaultEventLoopPolicy = asyncio.events.BaseDefaultEventLoopPolicy
+
+    assert isinstance(policy, BaseDefaultEventLoopPolicy)
     assert type(policy).__module__.startswith(expected_loop)
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

In Python 3.14, `asyncio.events.BaseDefaultEventLoopPolicy`, which was always a private/undocumented API, was renamed with a leading underscore. See https://github.com/python/cpython/issues/131148.

This PR adapts `test_loop_auto`, which contains a type check against this undocumented type, to support either name depending on the interpreter version, fixing failures like the following on Python 3.14:

```
________________________________ test_loop_auto ________________________________

    def test_loop_auto():
        auto_loop_setup()
        policy = asyncio.get_event_loop_policy()
>       assert isinstance(policy, asyncio.events.BaseDefaultEventLoopPolicy)
E       AttributeError: module 'asyncio.events' has no attribute 'BaseDefaultEventLoopPolicy'

tests/test_auto_detection.py:38: AttributeError
```

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. **(The change was to a test, so no new test was required.)**
- [x] I've updated the documentation accordingly. **(No documentation changes were needed.)**
