### PR TITLE
Allow to provide importable string in `--http`, `--ws` and `--loop`

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -480,7 +480,7 @@ class Config:
             try:
                 return import_from_string(self.loop)
             except ImportFromStringError as exc:
-                logger.exception("Error loading custom loop setup function. %s" % exc)
+                logger.error("Error loading custom loop setup function. %s" % exc)
                 sys.exit(1)
         if loop_factory is None:
             return None

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -38,24 +38,24 @@ LOG_LEVELS: dict[str, int] = {
     "debug": logging.DEBUG,
     "trace": TRACE_LOG_LEVEL,
 }
-HTTP_PROTOCOLS: dict[HTTPProtocolType, str] = {
+HTTP_PROTOCOLS: dict[str, str] = {
     "auto": "uvicorn.protocols.http.auto:AutoHTTPProtocol",
     "h11": "uvicorn.protocols.http.h11_impl:H11Protocol",
     "httptools": "uvicorn.protocols.http.httptools_impl:HttpToolsProtocol",
 }
-WS_PROTOCOLS: dict[WSProtocolType, str | None] = {
+WS_PROTOCOLS: dict[str, str | None] = {
     "auto": "uvicorn.protocols.websockets.auto:AutoWebSocketsProtocol",
     "none": None,
     "websockets": "uvicorn.protocols.websockets.websockets_impl:WebSocketProtocol",
     "websockets-sansio": "uvicorn.protocols.websockets.websockets_sansio_impl:WebSocketsSansIOProtocol",
     "wsproto": "uvicorn.protocols.websockets.wsproto_impl:WSProtocol",
 }
-LIFESPAN: dict[LifespanType, str] = {
+LIFESPAN: dict[str, str] = {
     "auto": "uvicorn.lifespan.on:LifespanOn",
     "on": "uvicorn.lifespan.on:LifespanOn",
     "off": "uvicorn.lifespan.off:LifespanOff",
 }
-LOOP_FACTORIES: dict[LoopFactoryType | str, str | None] = {
+LOOP_FACTORIES: dict[str, str | None] = {
     "none": None,
     "auto": "uvicorn.loops.auto:auto_loop_factory",
     "asyncio": "uvicorn.loops.asyncio:asyncio_loop_factory",
@@ -183,8 +183,8 @@ class Config:
         uds: str | None = None,
         fd: int | None = None,
         loop: LoopFactoryType | str = "auto",
-        http: type[asyncio.Protocol] | HTTPProtocolType = "auto",
-        ws: type[asyncio.Protocol] | WSProtocolType = "auto",
+        http: type[asyncio.Protocol] | HTTPProtocolType | str = "auto",
+        ws: type[asyncio.Protocol] | WSProtocolType | str = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
         ws_max_queue: int = 32,
         ws_ping_interval: float | None = 20.0,
@@ -419,13 +419,13 @@ class Config:
         )
 
         if isinstance(self.http, str):
-            http_protocol_class = import_from_string(HTTP_PROTOCOLS[self.http])
+            http_protocol_class = import_from_string(HTTP_PROTOCOLS.get(self.http, self.http))
             self.http_protocol_class: type[asyncio.Protocol] = http_protocol_class
         else:
             self.http_protocol_class = self.http
 
         if isinstance(self.ws, str):
-            ws_protocol_class = import_from_string(WS_PROTOCOLS[self.ws])
+            ws_protocol_class = import_from_string(WS_PROTOCOLS.get(self.ws, self.ws))
             self.ws_protocol_class: type[asyncio.Protocol] | None = ws_protocol_class
         else:
             self.ws_protocol_class = self.ws
@@ -480,7 +480,7 @@ class Config:
             try:
                 return import_from_string(self.loop)
             except ImportFromStringError as exc:
-                logger.error("Error loading custom loop setup function. %s" % exc)
+                logger.exception("Error loading custom loop setup function. %s" % exc)
                 sys.exit(1)
         if loop_factory is None:
             return None

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -8,21 +8,18 @@ import ssl
 import sys
 import warnings
 from configparser import RawConfigParser
-from typing import IO, Any, Callable
+from typing import IO, Any, Callable, get_args
 
 import click
 
 import uvicorn
 from uvicorn._types import ASGIApplication
 from uvicorn.config import (
-    HTTP_PROTOCOLS,
     INTERFACES,
     LIFESPAN,
     LOG_LEVELS,
     LOGGING_CONFIG,
-    LOOP_FACTORIES,
     SSL_PROTOCOL_VERSION,
-    WS_PROTOCOLS,
     Config,
     HTTPProtocolType,
     InterfaceType,
@@ -34,11 +31,13 @@ from uvicorn.server import Server
 from uvicorn.supervisors import ChangeReload, Multiprocess
 
 LEVEL_CHOICES = click.Choice(list(LOG_LEVELS.keys()))
-HTTP_CHOICES = click.Choice(list(HTTP_PROTOCOLS.keys()))
-WS_CHOICES = click.Choice(list(WS_PROTOCOLS.keys()))
 LIFESPAN_CHOICES = click.Choice(list(LIFESPAN.keys()))
-LOOP_CHOICES = click.Choice([key for key in LOOP_FACTORIES.keys() if key != "none"])
 INTERFACE_CHOICES = click.Choice(INTERFACES)
+
+
+def _metavar_from_type(_type: Any) -> str:
+    return f"[{'|'.join(key for key in get_args(_type) if key != 'none')}]"
+
 
 STARTUP_FAILURE = 3
 
@@ -118,21 +117,24 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
 )
 @click.option(
     "--loop",
-    type=LOOP_CHOICES,
+    type=str,
+    metavar=_metavar_from_type(LoopFactoryType),
     default="auto",
     help="Event loop factory implementation.",
     show_default=True,
 )
 @click.option(
     "--http",
-    type=HTTP_CHOICES,
+    type=str,
+    metavar=_metavar_from_type(HTTPProtocolType),
     default="auto",
     help="HTTP protocol implementation.",
     show_default=True,
 )
 @click.option(
     "--ws",
-    type=WS_CHOICES,
+    type=str,
+    metavar=_metavar_from_type(WSProtocolType),
     default="auto",
     help="WebSocket protocol implementation.",
     show_default=True,
@@ -368,8 +370,8 @@ def main(
     uds: str,
     fd: int,
     loop: LoopFactoryType | str,
-    http: HTTPProtocolType,
-    ws: WSProtocolType,
+    http: HTTPProtocolType | str,
+    ws: WSProtocolType | str,
     ws_max_size: int,
     ws_max_queue: int,
     ws_ping_interval: float,
@@ -469,8 +471,8 @@ def run(
     uds: str | None = None,
     fd: int | None = None,
     loop: LoopFactoryType | str = "auto",
-    http: type[asyncio.Protocol] | HTTPProtocolType = "auto",
-    ws: type[asyncio.Protocol] | WSProtocolType = "auto",
+    http: type[asyncio.Protocol] | HTTPProtocolType | str = "auto",
+    ws: type[asyncio.Protocol] | WSProtocolType | str = "auto",
     ws_max_size: int = 16777216,
     ws_max_queue: int = 32,
     ws_ping_interval: float | None = 20.0,


### PR DESCRIPTION
Now it's possible to pass strings for those options:

```bash
uvicorn --loop rloop:new_event_loop main:app
```