### PR TITLE
In tests, use iscoroutinefunction from inspect rather than asyncio

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -454,10 +454,10 @@ class Config:
             if inspect.isclass(self.loaded_app):
                 use_asgi_3 = hasattr(self.loaded_app, "__await__")
             elif inspect.isfunction(self.loaded_app):
-                use_asgi_3 = asyncio.iscoroutinefunction(self.loaded_app)
+                use_asgi_3 = inspect.iscoroutinefunction(self.loaded_app)
             else:
                 call = getattr(self.loaded_app, "__call__", None)
-                use_asgi_3 = asyncio.iscoroutinefunction(call)
+                use_asgi_3 = inspect.iscoroutinefunction(call)
             self.interface = "asgi3" if use_asgi_3 else "asgi2"
 
         if self.interface == "wsgi":


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

In the tests, this replaces `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`. The `asyncio` version is deprecated and slated for removal in Python 3.16. The `inspect` version was introduced in Python 3.5.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change. **No new tests were needed; the change is in test code.**
- [x] I've updated the documentation accordingly.  **No updates were required.**
