### PR TITLE
Fixed socket sharing bug on Windows

### DIFF
--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import multiprocessing
 import socket
 from unittest.mock import patch
 
@@ -22,7 +23,7 @@ def test_get_subprocess() -> None:
     config = Config(app=app, fd=fd)
     config.load()
 
-    process = get_subprocess(config, server_run, [fdsock])
+    process, _ = get_subprocess(config, server_run, [fdsock])
     assert isinstance(process, SpawnProcess)
 
     fdsock.close()
@@ -33,10 +34,11 @@ def test_subprocess_started() -> None:
     fd = fdsock.fileno()
     config = Config(app=app, fd=fd)
     config.load()
+    event = multiprocessing.Event()
 
     with patch("tests.test_subprocess.server_run") as mock_run:
         with patch.object(config, "configure_logging") as mock_config_logging:
-            subprocess_started(config, server_run, [fdsock], None)
+            subprocess_started(config, server_run, [fdsock], event, None)
             mock_run.assert_called_once()
             mock_config_logging.assert_called_once()
 

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -81,8 +81,13 @@ class BaseReload:
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.signal_handler)
 
-        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+        process, event = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+
+        self.process = process
         self.process.start()
+
+        if event is not None:  # pragma: py-not-win32
+            event.wait()
 
     def restart(self) -> None:
         if sys.platform == "win32":  # pragma: py-not-win32
@@ -97,8 +102,13 @@ class BaseReload:
             self.process.terminate()
         self.process.join()
 
-        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+        process, event = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+
+        self.process = process
         self.process.start()
+
+        if event is not None:  # pragma: py-not-win32
+            event.wait()
 
     def shutdown(self) -> None:
         if sys.platform == "win32":

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -32,8 +32,11 @@ class Process:
     ) -> None:
         self.real_target = target
 
+        process, start_event = get_subprocess(config, self.target, sockets)
+
         self.parent_conn, self.child_conn = Pipe()
-        self.process = get_subprocess(config, self.target, sockets)
+        self.process = process
+        self.start_event = start_event
 
     def ping(self, timeout: float = 5) -> bool:
         self.parent_conn.send(b"ping")
@@ -71,6 +74,9 @@ class Process:
 
     def start(self) -> None:
         self.process.start()
+
+        if self.start_event is not None:  # pragma: py-not-win32
+            self.start_event.wait()
 
     def terminate(self) -> None:
         if self.process.exitcode is None:  # Process is still running


### PR DESCRIPTION
# Summary

I ran into an issue when running uvicorn with multiple workers on Windows. This issue is almost identical to the ones discussed in #539 and #802. When running the example `main.py` with `uvicorn main:app --workers 2`, I get the following exception:

	Traceback (most recent call last):
	  File "C:\Users\Jason\miniconda3\Lib\multiprocessing\process.py", line 313, in _bootstrap
	    self.run()
	    ~~~~~~~~^^
	  File "C:\Users\Jason\miniconda3\Lib\multiprocessing\process.py", line 108, in run
	    self._target(*self._args, **self._kwargs)
	    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "C:\Users\Jason\Downloads\uvicorn\uvicorn\_subprocess.py", line 102, in subprocess_started
	    target(sockets=sockets)
	    ~~~~~~^^^^^^^^^^^^^^^^^
	  File "C:\Users\Jason\Downloads\uvicorn\uvicorn\supervisors\multiprocess.py", line 67, in target
	    return self.real_target(sockets)
	           ~~~~~~~~~~~~~~~~^^^^^^^^^
	  File "C:\Users\Jason\Downloads\uvicorn\uvicorn\server.py", line 66, in run
	    return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
	  File "C:\Users\Jason\miniconda3\Lib\asyncio\runners.py", line 195, in run
	    return runner.run(main)
	           ~~~~~~~~~~^^^^^^
	  File "C:\Users\Jason\miniconda3\Lib\asyncio\runners.py", line 118, in run
	    return self._loop.run_until_complete(task)
	           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
	  File "C:\Users\Jason\miniconda3\Lib\asyncio\base_events.py", line 725, in run_until_complete
	    return future.result()
	           ~~~~~~~~~~~~~^^
	  File "C:\Users\Jason\Downloads\uvicorn\uvicorn\server.py", line 70, in serve
	    await self._serve(sockets)
	  File "C:\Users\Jason\Downloads\uvicorn\uvicorn\server.py", line 85, in _serve
	    await self.startup(sockets=sockets)
	  File "C:\Users\Jason\Downloads\uvicorn\uvicorn\server.py", line 121, in startup
	    server = await loop.create_server(create_protocol, sock=sock, ssl=config.ssl, backlog=config.backlog)
	             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	  File "C:\Users\Jason\miniconda3\Lib\asyncio\base_events.py", line 1655, in create_server
	    server._start_serving()
	    ~~~~~~~~~~~~~~~~~~~~~^^
	  File "C:\Users\Jason\miniconda3\Lib\asyncio\base_events.py", line 317, in _start_serving
	    sock.listen(self._backlog)
	    ~~~~~~~~~~~^^^^^^^^^^^^^^^
	OSError: [WinError 10022] An invalid argument was supplied

At first, I was confused because it seemed like this exact issue was already fixed. However, after some investigation, I discovered what appears to be a bug with `WSASocket` (the Windows API call that is used by `socket.fromshare`). If two or more processes attempt to duplicate the same socket at "the same time" (by calling `WSASocket` with the struct initialized by `WSADuplicateSocket`), one of the `WSASocket` calls will fail.

Initially, I thought this has to be a bug with how uvicorn initializes its sockets. But no. This happens even in this very simple example:

	import socket
	import multiprocessing as mp
	
	def subproc(q):
	    s = socket.fromshare(q.get())
	    s.listen(100)
	
	if __name__ == '__main__':
	    sock = socket.socket(family=socket.AF_INET)
	    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
	    sock.bind(("127.0.0.1", 7566))
	    sock.set_inheritable(True)
	
	    spawn = mp.get_context("spawn")
	
	    q0 = mp.Queue()
	    p0 = spawn.Process(target=subproc, args=(q0,))
	    p0.start()
	
	    q1 = mp.Queue()
	    p1 = spawn.Process(target=subproc, args=(q1,))
	    p1.start()
	
	    q0.put(sock.share(p0.pid))
	    q1.put(sock.share(p1.pid))
	
	    p0.join()
	    p1.join()

The implementations of both `socket.share` and `socket.fromshare` are pretty straight-forward, so I don't think this is an issue with Python. 

In any case, the solution I implemented is to simply wait for each process to duplicate its sockets before allowing the parent to continue.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
