### PR TITLE
feat(proxy_headers): add support for x-forwarded-host

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -260,6 +260,7 @@ Uvicorn currently supports the following headers:
 
 - `X-Forwarded-For` ([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For))
 - `X-Forwarded-Proto`([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto))
+- `X-Forwarded-Host`([MDN Reference]([https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host]))
 
 Uvicorn can use these headers to correctly set the client and protocol in the request.
 However as anyone can set these headers you must configure which "clients" you will trust to have set them correctly.
@@ -270,7 +271,7 @@ or Literals (e.g. `/path/to/socket.sock`). When running from CLI these are confi
 !!! Warning "Only trust clients you can actually trust!"
     Incorrectly trusting other clients can lead to malicious actors spoofing their apparent client address to your application.
 
-A proxy chain may send a header once per hop rather than as a single comma-separated value. Repeated `X-Forwarded-For` fields are combined in order (as the equivalent comma-separated list, [RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)), while for `X-Forwarded-Proto` the last field is used.
+A proxy chain may send a header once per hop rather than as a single comma-separated value. Repeated `X-Forwarded-For` fields are combined in order (as the equivalent comma-separated list, [RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)), while for `X-Forwarded-Proto` and `X-Forwarded-Host` the last field is used.
 
 For more information, check [`ProxyHeadersMiddleware`](https://github.com/Kludex/uvicorn/blob/main/uvicorn/middleware/proxy_headers.py).
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -114,7 +114,7 @@ Note that WSGI mode always disables WebSocket support, as it is not supported by
 ## HTTP
 
 * `--root-path <str>` - Set the ASGI `root_path` for applications submounted below a given URL path. **Default:** *""*.
-* `--proxy-headers / --no-proxy-headers` - Enable/Disable X-Forwarded-Proto, X-Forwarded-For to populate remote address info. Defaults to enabled, but is restricted to only trusting connecting IPs in the `forwarded-allow-ips` configuration.
+* `--proxy-headers / --no-proxy-headers` - Enable/Disable X-Forwarded-Proto, X-Forwarded-For, X-Forwarded-Host to populate remote address info. Defaults to enabled, but is restricted to only trusting connecting IPs in the `forwarded-allow-ips` configuration.
 * `--forwarded-allow-ips <comma-separated-list>` - Comma separated list of IP Addresses, IP Networks, or literals (e.g. UNIX Socket path) to trust with proxy headers. Defaults to the `$FORWARDED_ALLOW_IPS` environment variable if available, or '127.0.0.1'. The literal `'*'` means trust everything.
 * `--server-header / --no-server-header` - Enable/Disable default `Server` header. **Default:** *True*.
 * `--date-header / --no-date-header` - Enable/Disable default `Date` header. **Default:** *True*.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -115,7 +115,7 @@ Note that WSGI mode always disables WebSocket support, as it is not supported by
 ## HTTP
 
 * `--root-path <str>` - Set the ASGI `root_path` for applications submounted below a given URL path. **Default:** *""*.
-* `--proxy-headers / --no-proxy-headers` - Enable/Disable X-Forwarded-Proto, X-Forwarded-For to populate remote address info. Defaults to enabled, but is restricted to only trusting connecting IPs in the `forwarded-allow-ips` configuration.
+* `--proxy-headers / --no-proxy-headers` - Enable/Disable X-Forwarded-Proto, X-Forwarded-For, X-Forwarded-Host to populate remote address info. Defaults to enabled, but is restricted to only trusting connecting IPs in the `forwarded-allow-ips` configuration.
 * `--forwarded-allow-ips <comma-separated-list>` - Comma separated list of IP Addresses, IP Networks, or literals (e.g. UNIX Socket path) to trust with proxy headers. Defaults to the `$FORWARDED_ALLOW_IPS` environment variable if available, or '127.0.0.1'. The literal `'*'` means trust everything.
 * `--server-header / --no-server-header` - Enable/Disable default `Server` header. **Default:** *True*.
 * `--date-header / --no-date-header` - Enable/Disable default `Date` header. **Default:** *True*.

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 X_FORWARDED_FOR = "X-Forwarded-For"
 X_FORWARDED_PROTO = "X-Forwarded-Proto"
+X_FORWARDED_HOST = "X-Forwarded-Host"
 
 
 async def default_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -646,3 +647,106 @@ async def test_proxy_headers_haproxy_behind_alb() -> None:
     await middleware(scope, _noop_receive, _noop_send)
     assert captured["client"] == ("1.2.3.4", 0)
     assert captured["scheme"] == "https"
+
+
+async def app_with_host_header(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+    headers = dict(scope["headers"])  # type: ignore[typeddict-item]
+    host_header = headers.get(b"host", b"").decode("latin1")
+    server = scope.get("server")
+    if server:
+        host: str = server[0]  # type: ignore[index]
+        port: int | None = server[1]  # type: ignore[index]
+        with contextlib.suppress(ValueError):
+            if ipaddress.ip_address(host).version == 6:
+                host = f"[{host}]"
+        server_str = f"{host}:{port}" if port else host
+    else:
+        server_str = "NONE"  # pragma: no cover
+
+    response = Response(f"host={host_header} server={server_str}", media_type="text/plain")
+    await response(scope, receive, send)
+
+
+@pytest.mark.anyio
+async def test_proxy_headers_x_forwarded_host_untrusted() -> None:
+    """X-Forwarded-Host should be ignored from untrusted proxies"""
+    app = ProxyHeadersMiddleware(app_with_host_header, trusted_hosts="192.168.0.1")
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 123))  # type: ignore
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        headers = {X_FORWARDED_HOST: "malicious.com"}
+        response = await client.get("/", headers=headers)
+
+    assert response.status_code == 200
+    # Should use the original server, not the forwarded host
+    assert response.text == "host=testserver server=testserver"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("forwarded_host", "expected_host", "expected_server"),
+    [
+        # Hostname without port
+        ("example.com", "example.com", "example.com:80"),
+        # Hostname with port
+        ("example.com:8080", "example.com:8080", "example.com:8080"),
+        # IPv4 without port
+        ("192.0.2.10", "192.0.2.10", "192.0.2.10:80"),
+        # IPv4 with port
+        ("192.0.2.10:8080", "192.0.2.10:8080", "192.0.2.10:8080"),
+        # IPv6 without port
+        ("[2001:db8::1]", "[2001:db8::1]", "[2001:db8::1]:80"),
+        # IPv6 with port
+        ("[2001:db8::1]:8080", "[2001:db8::1]:8080", "[2001:db8::1]:8080"),
+        # Invalid port
+        # unrecognized or malformed value is treated conservatively and returned without a port
+        # (see _parse_host_port implementation)
+        ("example.com:not-a-port", "example.com:not-a-port", "example.com:not-a-port:80"),
+        # Empty values
+        ("", "testserver", "testserver"),
+        ("   ", "testserver", "testserver"),
+    ],
+)
+async def test_proxy_headers_x_forwarded_host(
+    forwarded_host: str,
+    expected_host: str,
+    expected_server: str,
+) -> None:
+    app = ProxyHeadersMiddleware(app_with_host_header, trusted_hosts="*")
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 123))  # type: ignore
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        headers = {X_FORWARDED_HOST: forwarded_host}
+        response = await client.get("/", headers=headers)
+
+    assert response.status_code == 200
+    assert response.text == f"host={expected_host} server={expected_server}"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("forwarded_host", "scheme", "expected_host", "expected_server"),
+    [
+        # HTTPS defaults to port 443
+        ("example.com", "https", "example.com", "example.com:443"),
+        ("example.com:9000", "https", "example.com:9000", "example.com:9000"),
+        # WSS defaults to port 443
+        ("example.com", "wss", "example.com", "example.com:443"),
+        # HTTP defaults to port 80
+        ("example.com", "http", "example.com", "example.com:80"),
+        # WS defaults to port 80
+        ("example.com", "ws", "example.com", "example.com:80"),
+    ],
+)
+async def test_proxy_headers_x_forwarded_host_with_scheme(
+    forwarded_host: str,
+    scheme: str,
+    expected_host: str,
+    expected_server: str,
+) -> None:
+    app = ProxyHeadersMiddleware(app_with_host_header, trusted_hosts="*")
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 123))  # type: ignore
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        headers = {X_FORWARDED_HOST: forwarded_host, X_FORWARDED_PROTO: scheme}
+        response = await client.get("/", headers=headers)
+
+    assert response.status_code == 200
+    assert response.text == f"host={expected_host} server={expected_server}"

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -10,15 +10,16 @@ class ProxyHeadersMiddleware:
     """Middleware for handling known proxy headers
 
     This middleware can be used when a known proxy is fronting the application,
-    and is trusted to be properly setting the `X-Forwarded-Proto` and
-    `X-Forwarded-For` headers with the connecting client information.
+    and is trusted to be properly setting the `X-Forwarded-Proto`, `X-Forwarded-For`,
+    and `X-Forwarded-Host` headers with the connecting client information.
 
-    Modifies the `client` and `scheme` information so that they reference
+    Modifies the `client`, `scheme`, and `server` information so that they reference
     the connecting client, rather that the connecting proxy.
 
     References:
     - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies>
     - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For>
+    - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host>
     """
 
     def __init__(self, app: ASGI3Application, trusted_hosts: list[str] | str = "127.0.0.1") -> None:
@@ -35,11 +36,14 @@ class ProxyHeadersMiddleware:
         if client_host in self.trusted_hosts:
             x_forwarded_proto_value: bytes | None = None
             x_forwarded_for_values: list[bytes] = []
+            x_forwarded_host_value: bytes | None = None
             for name, value in scope["headers"]:
                 if name == b"x-forwarded-proto":
                     x_forwarded_proto_value = value
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
+                elif name == b"x-forwarded-host":
+                    x_forwarded_host_value = value
 
             if x_forwarded_proto_value is not None:
                 x_forwarded_proto = x_forwarded_proto_value.decode("latin1").strip()
@@ -59,6 +63,26 @@ class ProxyHeadersMiddleware:
                     # Only set the client if we actually got something usable.
                     # See: https://github.com/Kludex/uvicorn/issues/1068
                     scope["client"] = (host, port)
+
+            if x_forwarded_host_value:
+                x_forwarded_host = x_forwarded_host_value.decode("latin1").strip()
+                if x_forwarded_host:
+                    port = 443 if scope.get("scheme") in ("https", "wss") else 80
+                    forwarded_host, forwarded_port = _parse_host_port(x_forwarded_host)
+
+                    if forwarded_host == x_forwarded_host:
+                        scope["server"] = (forwarded_host, port)
+                    else:
+                        # Only use forwarded_port is a non-zero value is returned.
+                        # see _parse_host_port implementation
+                        if forwarded_port == 0:
+                            forwarded_port = port
+                        scope["server"] = (forwarded_host, forwarded_port)
+
+                    # Update or add the Host header
+                    new_headers = [(name, value) for name, value in scope["headers"] if name != b"host"]
+                    new_headers.append((b"host", x_forwarded_host.encode("latin1")))
+                    scope["headers"] = new_headers
 
         return await self.app(scope, receive, send)
 


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Fixes https://github.com/Kludex/uvicorn/issues/965

Add support for [X-Forwarded-Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-Host) header in uvicorn.

If a non-empty value is found for `X-Forwarded-Host`:
- Updates `scope["server"]` with `(host, port)` values
- Updates value of `host` header in `scope["headers"]`

> [!NOTE]
> This is my first contribution to `uvicorn`, feedback is welcomed 🙏🏻  


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `X-Forwarded-Host` when processing trusted proxy headers.
  * Forwarded host values now update request host and server information, including IPv4, IPv6, and explicit port formats.
  * Scheme-specific default ports are applied when no port is provided.

* **Bug Fixes**
  * Untrusted, empty, or whitespace-only forwarded host values are safely ignored.

* **Documentation**
  * Updated proxy header and deployment documentation to describe `X-Forwarded-Host` handling and its “last field” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->