### PR TITLE
Add `--bind` / `-b` option for multiple socket bindings

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -48,6 +48,11 @@ uvicorn itself.
 * `--fd <int>` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.
 * `--bind <str>` / `-b <str>` - Bind to one or more addresses. May be specified multiple times to listen on multiple sockets simultaneously. Supported formats: `HOST:PORT` (e.g. `0.0.0.0:8000`), `[HOST]:PORT` for IPv6 (e.g. `[::1]:8000`), `unix:PATH` (e.g. `unix:/tmp/uvicorn.sock`), `fd://NUM` (e.g. `fd://3`). Mutually exclusive with `--host`, `--port`, `--uds`, and `--fd`.
 
+!!! note
+    The `--host`, `--port`, `--uds`, and `--fd` options each bind to a single address of a single type.
+    Use `--bind` when you need to listen on multiple addresses (e.g. dual-stack IPv4 + IPv6) or mix
+    transport types (e.g. a TCP port for internal services and a unix socket behind a reverse proxy).
+
 ## Development
 
 * `--reload` - Enable auto-reload. Uvicorn supports two versions of auto-reloading behavior enabled by this option. **Default:** *False*.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -46,6 +46,7 @@ uvicorn itself.
 * `--port <int>` - Bind to a socket with this port. If set to 0, an available port will be picked. **Default:** *8000*.
 * `--uds <path>` - Bind to a UNIX domain socket, for example `--uds /tmp/uvicorn.sock`. Useful if you want to run Uvicorn behind a reverse proxy.
 * `--fd <int>` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.
+* `--bind <str>` / `-b <str>` - Bind to one or more addresses. May be specified multiple times to listen on multiple sockets simultaneously. Supported formats: `HOST:PORT` (e.g. `0.0.0.0:8000`), `[HOST]:PORT` for IPv6 (e.g. `[::1]:8000`), `unix:PATH` (e.g. `unix:/tmp/uvicorn.sock`), `fd://NUM` (e.g. `fd://3`). Mutually exclusive with `--host`, `--port`, `--uds`, and `--fd`.
 
 ## Development
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,11 +240,8 @@ def test_cli_bind_multiple() -> None:
 def test_cli_bind_mutually_exclusive(extra_args: list[str]) -> None:
     runner = CliRunner()
 
-    result = runner.invoke(cli, ["tests.test_cli:App", "-b", "127.0.0.1:8000", *extra_args])
-
-    assert result.exit_code != 0
-    assert isinstance(result.exception, ValueError)
-    assert "'bind' is mutually exclusive with" in str(result.exception)
+    with pytest.raises(ValueError, match="'bind' is mutually exclusive with.*"):
+        runner.invoke(cli, ["tests.test_cli:App", "-b", "127.0.0.1:8000", *extra_args], catch_exceptions=False)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -219,9 +219,7 @@ def test_cli_bind_multiple() -> None:
     runner = CliRunner()
 
     with mock.patch.object(main, "run") as mock_run:
-        result = runner.invoke(
-            cli, ["tests.test_cli:App", "-b", "127.0.0.1:8000", "-b", "127.0.0.1:9000"]
-        )
+        result = runner.invoke(cli, ["tests.test_cli:App", "-b", "127.0.0.1:8000", "-b", "127.0.0.1:9000"])
 
     assert result.output == ""
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,7 +263,7 @@ def test_cli_bind_unix_cleanup() -> None:  # pragma: py-win32
         mock_run.assert_called_once()
         assert not Path(sock_path).exists()
     finally:
-        if Path(sock_path).exists():
+        if Path(sock_path).exists():  # pragma: no cover
             os.remove(sock_path)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,3 +201,60 @@ def test_set_app_via_environment_variable():
             args, _ = mock_run.call_args
             assert result.exit_code == 0
             assert args == (app_path,)
+
+
+def test_cli_bind_option() -> None:
+    runner = CliRunner()
+
+    with mock.patch.object(main, "run") as mock_run:
+        result = runner.invoke(cli, ["tests.test_cli:App", "--bind", "0.0.0.0:8000"])
+
+    assert result.output == ""
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+    assert mock_run.call_args[1]["bind"] == ["0.0.0.0:8000"]
+
+
+def test_cli_bind_multiple() -> None:
+    runner = CliRunner()
+
+    with mock.patch.object(main, "run") as mock_run:
+        result = runner.invoke(
+            cli, ["tests.test_cli:App", "-b", "127.0.0.1:8000", "-b", "127.0.0.1:9000"]
+        )
+
+    assert result.output == ""
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+    assert mock_run.call_args[1]["bind"] == ["127.0.0.1:8000", "127.0.0.1:9000"]
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["--host", "0.0.0.0"],
+        ["--port", "9000"],
+        ["--uds", "/tmp/test.sock"],
+        ["--fd", "3"],
+    ],
+    ids=["host", "port", "uds", "fd"],
+)
+def test_cli_bind_mutually_exclusive(extra_args: list[str]) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["tests.test_cli:App", "-b", "127.0.0.1:8000", *extra_args])
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
+    assert "'bind' is mutually exclusive with" in str(result.exception)
+
+
+def test_cli_bind_without_value_passes_none() -> None:
+    runner = CliRunner()
+
+    with mock.patch.object(main, "run") as mock_run:
+        result = runner.invoke(cli, ["tests.test_cli:App"])
+
+    assert result.exit_code in (0, 3)
+    mock_run.assert_called_once()
+    assert mock_run.call_args[1]["bind"] is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -593,3 +593,61 @@ def test_setup_event_loop_is_removed(caplog: pytest.LogCaptureFixture) -> None:
         AttributeError, match="The `setup_event_loop` method was replaced by `get_loop_factory` in uvicorn 0.36.0."
     ):
         config.setup_event_loop()
+
+
+@pytest.mark.parametrize(
+    "bind_str, expected_family",
+    [
+        ("127.0.0.1:0", socket.AF_INET),
+        ("0.0.0.0:0", socket.AF_INET),
+        ("[::1]:0", socket.AF_INET6),
+        ("[::]:0", socket.AF_INET6),
+        ("localhost:0", socket.AF_INET),
+    ],
+    ids=["ipv4", "ipv4-wildcard", "ipv6", "ipv6-wildcard", "hostname"],
+)
+def test_bind_sockets_address_formats(bind_str: str, expected_family: socket.AddressFamily) -> None:
+    config = Config(app=asgi_app, bind=[bind_str])
+    sockets = config.bind_sockets()
+    assert len(sockets) == 1
+    assert sockets[0].family == expected_family
+    sockets[0].close()
+
+
+def test_bind_sockets_multiple() -> None:
+    config = Config(app=asgi_app, bind=["127.0.0.1:0", "127.0.0.1:0"])
+    sockets = config.bind_sockets()
+    assert len(sockets) == 2
+    for sock in sockets:
+        assert sock.family == socket.AF_INET
+        sock.close()
+
+
+def test_bind_sockets_default_port() -> None:
+    config = Config(app=asgi_app, bind=["127.0.0.1"])
+    sockets = config.bind_sockets()
+    assert len(sockets) == 1
+    assert sockets[0].getsockname()[1] == 8000
+    sockets[0].close()
+
+
+def test_bind_sockets_fallback() -> None:
+    config = Config(app=asgi_app, bind=None)
+    sockets = config.bind_sockets()
+    assert len(sockets) == 1
+    sockets[0].close()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"host": "0.0.0.0"},
+        {"port": 9000},
+        {"uds": "/tmp/test.sock"},
+        {"fd": 3},
+    ],
+    ids=["host", "port", "uds", "fd"],
+)
+def test_bind_mutually_exclusive_with_other_params(kwargs: dict[str, Any]) -> None:
+    with pytest.raises(ValueError, match="'bind' is mutually exclusive with"):
+        Config(app=asgi_app, bind=["127.0.0.1:0"], **kwargs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,6 +117,20 @@ async def test_exit_on_create_server_with_invalid_host() -> None:
     assert exc_info.value.code == 1
 
 
+async def test_run_with_bind(unused_tcp_port: int) -> None:
+    config = Config(app=app, bind=[f"127.0.0.1:{unused_tcp_port}"], loop="asyncio", limit_max_requests=1)
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+    assert response.status_code == 204
+
+
+async def test_run_with_bind_multiple() -> None:
+    config = Config(app=app, bind=["127.0.0.1:0", "127.0.0.1:0"], loop="asyncio", limit_max_requests=1)
+    async with run_server(config):
+        pass  # Startup itself validates multiple sockets work
+
+
 def test_deprecated_server_state_from_main() -> None:
     with pytest.deprecated_call(
         match="uvicorn.main.ServerState is deprecated, use uvicorn.server.ServerState instead."

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -183,6 +183,7 @@ class Config:
         port: int = 8000,
         uds: str | None = None,
         fd: int | None = None,
+        bind: list[str] | None = None,
         loop: LoopFactoryType | str = "auto",
         http: type[asyncio.Protocol] | HTTPProtocolType | str = "auto",
         ws: type[asyncio.Protocol] | WSProtocolType | str = "auto",
@@ -233,6 +234,21 @@ class Config:
         self.port = port
         self.uds = uds
         self.fd = fd
+        self.bind = bind
+
+        if bind is not None:
+            conflicting: list[str] = []
+            if host != "127.0.0.1":
+                conflicting.append("host")
+            if port != 8000:
+                conflicting.append("port")
+            if uds is not None:
+                conflicting.append("uds")
+            if fd is not None:
+                conflicting.append("fd")
+            if conflicting:
+                raise ValueError(f"'bind' is mutually exclusive with {', '.join(map(repr, conflicting))}")
+
         self.loop = loop
         self.http = http
         self.ws = ws
@@ -344,11 +360,7 @@ class Config:
 
     @property
     def asgi_version(self) -> Literal["2.0", "3.0"]:
-        mapping: dict[str, Literal["2.0", "3.0"]] = {
-            "asgi2": "2.0",
-            "asgi3": "3.0",
-            "wsgi": "3.0",
-        }
+        mapping: dict[str, Literal["2.0", "3.0"]] = {"asgi2": "2.0", "asgi3": "3.0", "wsgi": "3.0"}
         return mapping[self.interface]
 
     @property
@@ -496,25 +508,29 @@ class Config:
             return None
         return loop_factory(use_subprocess=self.use_subprocess)
 
-    def bind_socket(self) -> socket.socket:
+    def _bind_one(
+        self,
+        *,
+        uds: str | None = None,
+        fd: int | None = None,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+    ) -> socket.socket:
         logger_args: list[str | int]
-        if self.uds:  # pragma: py-win32
-            path = self.uds
+        if uds:  # pragma: py-win32
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             try:
-                sock.bind(path)
-                uds_perms = 0o666
-                os.chmod(self.uds, uds_perms)
+                sock.bind(uds)
+                os.chmod(uds, 0o666)
             except OSError as exc:  # pragma: full coverage
                 logger.error(exc)
                 sys.exit(1)
-
             message = "Uvicorn running on unix socket %s (Press CTRL+C to quit)"
             sock_name_format = "%s"
             color_message = "Uvicorn running on " + click.style(sock_name_format, bold=True) + " (Press CTRL+C to quit)"
-            logger_args = [self.uds]
-        elif self.fd:  # pragma: py-win32
-            sock = socket.fromfd(self.fd, socket.AF_UNIX, socket.SOCK_STREAM)
+            logger_args = [uds]
+        elif fd is not None:  # pragma: py-win32
+            sock = socket.fromfd(fd, socket.AF_UNIX, socket.SOCK_STREAM)
             message = "Uvicorn running on socket %s (Press CTRL+C to quit)"
             fd_name_format = "%s"
             color_message = "Uvicorn running on " + click.style(fd_name_format, bold=True) + " (Press CTRL+C to quit)"
@@ -522,27 +538,48 @@ class Config:
         else:
             family = socket.AF_INET
             addr_format = "%s://%s:%d"
-
-            if self.host and ":" in self.host:  # pragma: full coverage
-                # It's an IPv6 address.
+            if host and ":" in host:  # pragma: full coverage
                 family = socket.AF_INET6
                 addr_format = "%s://[%s]:%d"
-
             sock = socket.socket(family=family)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
-                sock.bind((self.host, self.port))
+                sock.bind((host, port))
             except OSError as exc:  # pragma: full coverage
                 logger.error(exc)
                 sys.exit(1)
-
             message = f"Uvicorn running on {addr_format} (Press CTRL+C to quit)"
             color_message = "Uvicorn running on " + click.style(addr_format, bold=True) + " (Press CTRL+C to quit)"
             protocol_name = "https" if self.is_ssl else "http"
-            logger_args = [protocol_name, self.host, sock.getsockname()[1]]
+            logger_args = [protocol_name, host, sock.getsockname()[1]]
         logger.info(message, *logger_args, extra={"color_message": color_message})
         sock.set_inheritable(True)
         return sock
+
+    def bind_socket(self) -> socket.socket:
+        return self._bind_one(uds=self.uds, fd=self.fd, host=self.host, port=self.port)
+
+    def bind_sockets(self) -> list[socket.socket]:
+        if self.bind is None:
+            return [self.bind_socket()]
+
+        sockets: list[socket.socket] = []
+        for bind_str in self.bind:
+            if bind_str.startswith("unix:"):
+                sock = self._bind_one(uds=bind_str[5:])
+            elif bind_str.startswith("fd://"):
+                sock = self._bind_one(fd=int(bind_str[5:]))
+            else:
+                # Strip brackets for IPv6, then rsplit on last colon.
+                raw = bind_str.replace("[", "").replace("]", "")
+                try:
+                    host, port_str = raw.rsplit(":", 1)
+                    port = int(port_str)
+                except (ValueError, IndexError):
+                    host, port = raw, 8000
+                sock = self._bind_one(host=host, port=port)
+            sockets.append(sock)
+        return sockets
 
     @property
     def should_reload(self) -> bool:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -565,9 +565,9 @@ class Config:
 
         sockets: list[socket.socket] = []
         for bind_str in self.bind:
-            if bind_str.startswith("unix:"):
+            if bind_str.startswith("unix:"):  # pragma: py-win32
                 sock = self._bind_one(uds=bind_str[5:])
-            elif bind_str.startswith("fd://"):
+            elif bind_str.startswith("fd://"):  # pragma: py-win32
                 sock = self._bind_one(fd=int(bind_str[5:]))
             else:
                 # Strip brackets for IPv6, then rsplit on last colon.

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -610,11 +610,9 @@ def run(
     finally:
         if config.uds and os.path.exists(config.uds):
             os.remove(config.uds)  # pragma: py-win32
-        for bind_str in config.bind or []:
-            if bind_str.startswith("unix:"):  # pragma: py-win32
-                path = bind_str[5:]
-                if os.path.exists(path):
-                    os.remove(path)
+        for path in config.bind_unix_paths:  # pragma: py-win32
+            if os.path.exists(path):
+                os.remove(path)
 
     if not server.started and not config.should_reload and config.workers == 1:
         sys.exit(STARTUP_FAILURE)

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -611,10 +611,10 @@ def run(
         if config.uds and os.path.exists(config.uds):
             os.remove(config.uds)  # pragma: py-win32
         for bind_str in config.bind or []:
-            if bind_str.startswith("unix:"):
+            if bind_str.startswith("unix:"):  # pragma: py-win32
                 path = bind_str[5:]
                 if os.path.exists(path):
-                    os.remove(path)  # pragma: py-win32
+                    os.remove(path)
 
     if not server.started and not config.should_reload and config.workers == 1:
         sys.exit(STARTUP_FAILURE)

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -77,6 +77,9 @@ class Server:
         if not config.loaded:
             config.load()
 
+        if sockets is None and config.bind is not None:
+            sockets = config.bind_sockets()
+
         self.lifespan = config.lifespan_class(config)
 
         message = "Started server process [%d]"
@@ -101,9 +104,6 @@ class Server:
 
         config = self.config
 
-        if sockets is None and config.bind is not None:
-            sockets = config.bind_sockets()
-
         def create_protocol(
             _loop: asyncio.AbstractEventLoop | None = None,
         ) -> asyncio.Protocol:
@@ -121,9 +121,7 @@ class Server:
             # Explicitly passed a list of open sockets.
             # We use this when the server is run from a Gunicorn worker.
 
-            def _share_socket(
-                sock: socket.SocketType,
-            ) -> socket.SocketType:  # pragma py-not-win32
+            def _share_socket(sock: socket.SocketType) -> socket.SocketType:  # pragma py-not-win32
                 # Windows requires the socket be explicitly shared across
                 # multiple workers (processes).
                 from socket import fromshare  # type: ignore[attr-defined]

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -101,6 +101,9 @@ class Server:
 
         config = self.config
 
+        if sockets is None and config.bind is not None:
+            sockets = config.bind_sockets()
+
         def create_protocol(
             _loop: asyncio.AbstractEventLoop | None = None,
         ) -> asyncio.Protocol:
@@ -191,10 +194,7 @@ class Server:
 
         if config.fd is not None:  # pragma: py-win32
             sock = listeners[0]
-            logger.info(
-                "Uvicorn running on socket %s (Press CTRL+C to quit)",
-                sock.getsockname(),
-            )
+            logger.info("Uvicorn running on socket %s (Press CTRL+C to quit)", sock.getsockname())
 
         elif config.uds is not None:  # pragma: py-win32
             logger.info("Uvicorn running on unix socket %s (Press CTRL+C to quit)", config.uds)


### PR DESCRIPTION
Add a `--bind` / `-b` option for binding to multiple addresses simultaneously. Accepts `HOST:PORT`, `[HOST]:PORT` (IPv6), `unix:PATH`, and `fd://NUM` formats. Mutually exclusive with `--host`/`--port`/`--uds`/`--fd`, fully backwards compatible.

Supersedes #2486, which changed `--host` to accept multiple values - that approach altered the type signature of `host` from `str` to `list[str]`, breaking the existing API. A dedicated `--bind` option avoids that, and also covers mixed binding types (e.g. TCP + UDS) that multi-host alone can't express. This follows the pattern established by Gunicorn and Hypercorn.

Closes #2808 as well, which hardcoded UDS + host/port together rather than offering a general mechanism.