### PR TITLE
Add fragmented body benchmark for chunked body accumulation

### DIFF
--- a/tests/benchmarks/http.py
+++ b/tests/benchmarks/http.py
@@ -61,6 +61,20 @@ START_POST_REQUEST = b"\r\n".join(
 
 FINISH_POST_REQUEST = b'{"hello": "world"}'
 
+BODY_CHUNK_SIZE = 256
+FRAGMENTED_BODY_SIZE = 100_000
+FRAGMENTED_POST_HEADERS = b"\r\n".join(
+    [
+        b"POST / HTTP/1.1",
+        b"Host: example.org",
+        b"Content-Type: application/octet-stream",
+        b"Content-Length: " + str(FRAGMENTED_BODY_SIZE).encode(),
+        b"",
+        b"",
+    ]
+)
+FRAGMENTED_BODY_CHUNKS = [b"x" * BODY_CHUNK_SIZE] * (FRAGMENTED_BODY_SIZE // BODY_CHUNK_SIZE)
+
 
 class MockTransport:
     def __init__(self) -> None:

--- a/tests/benchmarks/test_http.py
+++ b/tests/benchmarks/test_http.py
@@ -7,6 +7,8 @@ import pytest
 from tests.benchmarks.http import (
     CONNECTION_CLOSE_REQUEST,
     FINISH_POST_REQUEST,
+    FRAGMENTED_BODY_CHUNKS,
+    FRAGMENTED_POST_HEADERS,
     HTTP10_GET_REQUEST,
     LARGE_POST_REQUEST,
     SIMPLE_GET_REQUEST,
@@ -88,6 +90,14 @@ async def test_bench_http10(http_protocol_cls: type[HTTPProtocol]) -> None:
 async def test_bench_connection_close(http_protocol_cls: type[HTTPProtocol]) -> None:
     protocol = get_connected_protocol(_plain_text_app, http_protocol_cls)
     protocol.data_received(CONNECTION_CLOSE_REQUEST)
+    await protocol.loop.run_one()
+
+
+async def test_bench_fragmented_body(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_plain_text_app, http_protocol_cls)
+    protocol.data_received(FRAGMENTED_POST_HEADERS)
+    for chunk in FRAGMENTED_BODY_CHUNKS:
+        protocol.data_received(chunk)
     await protocol.loop.run_one()
 
 


### PR DESCRIPTION
## Summary

- Add `test_bench_fragmented_body` benchmark that sends 100KB in 390 x 256-byte chunks
- Exercises the `body +=` accumulation path that is O(n^2) with `bytes` concatenation
- Establishes a baseline for measuring body accumulation optimizations

## Test plan

- [x] `uv run pytest tests/benchmarks/ -v` - all 20 benchmarks pass
- [x] `uv run ruff check tests/benchmarks/` - clean