### PR TITLE
Disable pytest-xdist for CodSpeed benchmark runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,4 +31,4 @@ jobs:
         uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # v4
         with:
           mode: instrumentation
-          run: uv run pytest tests/benchmarks/ --codspeed
+          run: uv run pytest tests/benchmarks/ --codspeed -n 0


### PR DESCRIPTION
## Summary

- Pass `-n 0` to disable xdist parallel workers when running benchmarks
- CodSpeed instrumentation does not work with pytest-xdist, resulting in `0 benchmarked`

## Test plan

- [x] Verify CodSpeed reports benchmarked count > 0 after merge