### PR TITLE
Pre-compute root_path bytes encoding once per connection

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -62,6 +62,7 @@ class H11Protocol(asyncio.Protocol):
         )
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
+        self.root_path_encoded = config.root_path.encode("ascii")
         self.limit_concurrency = config.limit_concurrency
         self.app_state = app_state
 
@@ -199,7 +200,7 @@ class H11Protocol(asyncio.Protocol):
                 raw_path, _, query_string = event.target.partition(b"?")
                 path = unquote(raw_path.decode("ascii"))
                 full_path = self.root_path + path
-                full_raw_path = self.root_path.encode("ascii") + raw_path
+                full_raw_path = self.root_path_encoded + raw_path
                 self.scope = {
                     "type": "http",
                     "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -70,6 +70,7 @@ class HttpToolsProtocol(asyncio.Protocol):
 
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
+        self.root_path_encoded = config.root_path.encode("ascii")
         self.limit_concurrency = config.limit_concurrency
         self.app_state = app_state
 
@@ -258,7 +259,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         if "%" in path:
             path = urllib.parse.unquote(path)
         full_path = self.root_path + path
-        full_raw_path = self.root_path.encode("ascii") + raw_path
+        full_raw_path = self.root_path_encoded + raw_path
         self.scope["path"] = full_path
         self.scope["raw_path"] = full_raw_path
         self.scope["query_string"] = parsed_url.query or b""


### PR DESCRIPTION
## Summary

- Cache `root_path.encode("ascii")` as `root_path_encoded` in `__init__` for both h11 and httptools protocols
- Avoids re-encoding the same immutable string on every request

## Test plan

- [x] Full test suite passes (986 passed, 14 skipped)