### PR TITLE
Version 0.42.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,10 +4,6 @@ toc_depth: 2
 
 ## 0.42.0 (March 16, 2026)
 
-### Added
-
-* Add CodSpeed benchmark suite for HTTP and WebSocket protocols (#2844, #2846, #2849, #2851)
-
 ### Changed
 
 * Use `bytearray` for request body accumulation to avoid O(n^2) allocation on fragmented bodies (#2845)
@@ -17,7 +13,6 @@ toc_depth: 2
 * Escape brackets and backslash in httptools `HEADER_RE` regex (#2824)
 * Fix multiple issues in websockets sans-io implementation (#2825)
 * Clarify Windows asyncio event loop selection in docs (#2843)
-* Disable `pytest-xdist` for CodSpeed benchmark runs (#2847)
 
 ## 0.41.0 (February 16, 2026)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,23 @@
 toc_depth: 2
 ---
 
+## 0.42.0 (March 16, 2026)
+
+### Added
+
+* Add CodSpeed benchmark suite for HTTP and WebSocket protocols (#2844, #2846, #2849, #2851)
+
+### Changed
+
+* Use `bytearray` for request body accumulation to avoid O(n^2) allocation on fragmented bodies (#2845)
+
+### Fixed
+
+* Escape brackets and backslash in httptools `HEADER_RE` regex (#2824)
+* Fix multiple issues in websockets sans-io implementation (#2825)
+* Clarify Windows asyncio event loop selection in docs (#2843)
+* Disable `pytest-xdist` for CodSpeed benchmark runs (#2847)
+
 ## 0.41.0 (February 16, 2026)
 
 ### Added

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,7 +12,6 @@ toc_depth: 2
 
 * Escape brackets and backslash in httptools `HEADER_RE` regex (#2824)
 * Fix multiple issues in websockets sans-io implementation (#2825)
-* Clarify Windows asyncio event loop selection in docs (#2843)
 
 ## 0.41.0 (February 16, 2026)
 

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.41.0"
+__version__ = "0.42.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## Summary

Release 0.42.0.

### Changed
- Use `bytearray` for request body accumulation to avoid O(n^2) allocation on fragmented bodies (#2845)

### Fixed
- Escape brackets and backslash in httptools `HEADER_RE` regex (#2824)
- Fix multiple issues in websockets sans-io implementation (#2825)