### PR TITLE
don't call `typing.cast` in runtime

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -5,7 +5,7 @@ import contextvars
 import http
 import logging
 from collections.abc import Callable
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import unquote
 
 import h11
@@ -465,7 +465,8 @@ class RequestResponseCycle:
             if message_type != "http.response.start":
                 msg = "Expected ASGI message 'http.response.start', but got '%s'."
                 raise RuntimeError(msg % message_type)
-            message = cast("HTTPResponseStartEvent", message)
+            if TYPE_CHECKING:
+                message = cast("HTTPResponseStartEvent", message)
 
             self.response_started = True
             self.waiting_for_100_continue = False
@@ -497,7 +498,8 @@ class RequestResponseCycle:
             if message_type != "http.response.body":
                 msg = "Expected ASGI message 'http.response.body', but got '%s'."
                 raise RuntimeError(msg % message_type)
-            message = cast("HTTPResponseBodyEvent", message)
+            if TYPE_CHECKING:
+                message = cast("HTTPResponseBodyEvent", message)
 
             body = message.get("body", b"")
             more_body = message.get("more_body", False)

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -9,7 +9,7 @@ import urllib
 from asyncio.events import TimerHandle
 from collections import deque
 from collections.abc import Callable
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import httptools
 
@@ -468,7 +468,8 @@ class RequestResponseCycle:
             if message_type != "http.response.start":
                 msg = "Expected ASGI message 'http.response.start', but got '%s'."
                 raise RuntimeError(msg % message_type)
-            message = cast("HTTPResponseStartEvent", message)
+            if TYPE_CHECKING:
+                message = cast("HTTPResponseStartEvent", message)
 
             self.response_started = True
             self.waiting_for_100_continue = False
@@ -523,7 +524,9 @@ class RequestResponseCycle:
                 msg = "Expected ASGI message 'http.response.body', but got '%s'."
                 raise RuntimeError(msg % message_type)
 
-            body = cast(bytes, message.get("body", b""))
+            body = message.get("body", b"")
+            if TYPE_CHECKING:
+                body = cast(bytes, body)
             more_body = message.get("more_body", False)
 
             # Write response body

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -4,7 +4,7 @@ import asyncio
 import http
 import logging
 from collections.abc import Sequence
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import unquote
 
 import websockets
@@ -266,14 +266,18 @@ class WebSocketProtocol(WebSocketServerProtocol):
 
         if not self.handshake_started_event.is_set():
             if message_type == "websocket.accept":
-                message = cast("WebSocketAcceptEvent", message)
+                if TYPE_CHECKING:
+                    message = cast("WebSocketAcceptEvent", message)
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
                     get_client_addr(self.scope),
                     get_path_with_query_string(self.scope),
                 )
                 self.initial_response = None
-                self.accepted_subprotocol = cast(Subprotocol | None, message.get("subprotocol"))
+                if TYPE_CHECKING:
+                    self.accepted_subprotocol = cast(Subprotocol | None, message.get("subprotocol"))
+                else:
+                    self.accepted_subprotocol = message.get("subprotocol")
                 if "headers" in message:
                     self.extra_headers.extend(
                         # ASGI spec requires bytes
@@ -284,7 +288,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 self.handshake_started_event.set()
 
             elif message_type == "websocket.close":
-                message = cast("WebSocketCloseEvent", message)
+                if TYPE_CHECKING:
+                    message = cast("WebSocketCloseEvent", message)
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     get_client_addr(self.scope),
@@ -295,7 +300,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 self.closed_event.set()
 
             elif message_type == "websocket.http.response.start":
-                message = cast("WebSocketResponseStartEvent", message)
+                if TYPE_CHECKING:
+                    message = cast("WebSocketResponseStartEvent", message)
                 self.logger.info(
                     '%s - "WebSocket %s" %d',
                     get_client_addr(self.scope),
@@ -322,14 +328,16 @@ class WebSocketProtocol(WebSocketServerProtocol):
 
             try:
                 if message_type == "websocket.send":
-                    message = cast("WebSocketSendEvent", message)
+                    if TYPE_CHECKING:
+                        message = cast("WebSocketSendEvent", message)
                     bytes_data = message.get("bytes")
                     text_data = message.get("text")
                     data = text_data if bytes_data is None else bytes_data
                     await self.send(data)  # type: ignore[arg-type]
 
                 elif message_type == "websocket.close":
-                    message = cast("WebSocketCloseEvent", message)
+                    if TYPE_CHECKING:
+                        message = cast("WebSocketCloseEvent", message)
                     code = message.get("code", 1000)
                     reason = message.get("reason", "") or ""
                     await self.close(code, reason)
@@ -343,7 +351,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
 
         elif self.initial_response is not None:
             if message_type == "websocket.http.response.body":
-                message = cast("WebSocketResponseBodyEvent", message)
+                if TYPE_CHECKING:
+                    message = cast("WebSocketResponseBodyEvent", message)
                 body = self.initial_response[2] + message["body"]
                 self.initial_response = self.initial_response[:2] + (body,)
                 if not message.get("more_body", False):

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from asyncio.transports import BaseTransport, Transport
 from http import HTTPStatus
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import unquote
 
 from websockets.exceptions import InvalidState
@@ -102,7 +102,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     def connection_made(self, transport: BaseTransport) -> None:
         """Called when a connection is made."""
-        transport = cast(Transport, transport)
+        if TYPE_CHECKING:
+            transport = cast(Transport, transport)
         self.connections.add(self)
         self.transport = transport
         self.server = get_local_addr(transport)
@@ -299,7 +300,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
         if not self.handshake_complete and self.initial_response is None:
             if message_type == "websocket.accept":
-                message = cast(WebSocketAcceptEvent, message)
+                if TYPE_CHECKING:
+                    message = cast(WebSocketAcceptEvent, message)
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
                     get_client_addr(self.scope),
@@ -321,7 +323,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                     self.transport.write(b"".join(output))
 
             elif message_type == "websocket.close":
-                message = cast(WebSocketCloseEvent, message)
+                if TYPE_CHECKING:
+                    message = cast(WebSocketCloseEvent, message)
                 self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
@@ -336,7 +339,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 self.transport.write(b"".join(output))
                 self.transport.close()
             elif message_type == "websocket.http.response.start" and self.initial_response is None:
-                message = cast(WebSocketResponseStartEvent, message)
+                if TYPE_CHECKING:
+                    message = cast(WebSocketResponseStartEvent, message)
                 if not (100 <= message["status"] < 600):
                     raise RuntimeError("Invalid HTTP status code '%d' in response." % message["status"])
                 self.logger.info(
@@ -361,7 +365,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         elif not self.close_sent and self.initial_response is None:
             try:
                 if message_type == "websocket.send":
-                    message = cast(WebSocketSendEvent, message)
+                    if TYPE_CHECKING:
+                        message = cast(WebSocketSendEvent, message)
                     bytes_data = message.get("bytes")
                     text_data = message.get("text")
                     if bytes_data is not None:
@@ -373,7 +378,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
                 elif message_type == "websocket.close":
                     if not self.transport.is_closing():
-                        message = cast(WebSocketCloseEvent, message)
+                        if TYPE_CHECKING:
+                            message = cast(WebSocketCloseEvent, message)
                         code = message.get("code", 1000)
                         reason = message.get("reason", "") or ""
                         self.queue.put_nowait({"type": "websocket.disconnect", "code": code, "reason": reason})
@@ -389,7 +395,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 raise ClientDisconnected()
         elif self.initial_response is not None:
             if message_type == "websocket.http.response.body":
-                message = cast(WebSocketResponseBodyEvent, message)
+                if TYPE_CHECKING:
+                    message = cast(WebSocketResponseBodyEvent, message)
                 body = self.initial_response[2] + message["body"]
                 self.initial_response = self.initial_response[:2] + (body,)
                 if not message.get("more_body", False):

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from urllib.parse import unquote
 
 import wsproto
@@ -253,7 +253,8 @@ class WSProtocol(asyncio.Protocol):
 
         if not self.handshake_complete:
             if message_type == "websocket.accept":
-                message = cast(WebSocketAcceptEvent, message)
+                if TYPE_CHECKING:
+                    message = cast(WebSocketAcceptEvent, message)
                 self.logger.info(
                     '%s - "WebSocket %s" [accepted]',
                     get_client_addr(self.scope),
@@ -290,7 +291,8 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.close()
 
             elif message_type == "websocket.http.response.start":
-                message = cast(WebSocketResponseStartEvent, message)
+                if TYPE_CHECKING:
+                    message = cast(WebSocketResponseStartEvent, message)
                 # ensure status code is in the valid range
                 if not (100 <= message["status"] < 600):
                     msg = "Invalid HTTP status code '%d' in response."
@@ -322,7 +324,8 @@ class WSProtocol(asyncio.Protocol):
         elif not self.close_sent and not self.response_started:
             try:
                 if message_type == "websocket.send":
-                    message = cast(WebSocketSendEvent, message)
+                    if TYPE_CHECKING:
+                        message = cast(WebSocketSendEvent, message)
                     bytes_data = message.get("bytes")
                     text_data = message.get("text")
                     data = text_data if bytes_data is None else bytes_data
@@ -331,7 +334,8 @@ class WSProtocol(asyncio.Protocol):
                         self.transport.write(output)
 
                 elif message_type == "websocket.close":
-                    message = cast(WebSocketCloseEvent, message)
+                    if TYPE_CHECKING:
+                        message = cast(WebSocketCloseEvent, message)
                     self.close_sent = True
                     code = message.get("code", 1000)
                     reason = message.get("reason", "") or ""
@@ -348,7 +352,8 @@ class WSProtocol(asyncio.Protocol):
                 raise ClientDisconnected from exc
         elif self.response_started:
             if message_type == "websocket.http.response.body":
-                message = cast("WebSocketResponseBodyEvent", message)
+                if TYPE_CHECKING:
+                    message = cast("WebSocketResponseBodyEvent", message)
                 body_finished = not message.get("more_body", False)
                 reject_data = events.RejectData(data=message["body"], body_finished=body_finished)
                 output = self.conn.send(reject_data)


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

`typing.cast` is a python function and it does nothing more than adds a few extra nanoseconds in runtime

the solution is ugly, but it saves a bit resources

I hope CPython will optimize this somehow in the future.

this workaround once significantly improved performance: https://github.com/pylint-dev/astroid/pull/2500

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
