### PR TITLE
Fix request body hang after rejected HTTP Upgrade in httptools

### DIFF
--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -181,6 +181,9 @@ class HttpToolsProtocol(asyncio.Protocol):
                 self.handle_websocket_upgrade()
             else:
                 self._unsupported_upgrade_warning()
+                if self.cycle is not None:
+                    self.cycle.more_body = False
+                    self.cycle.message_event.set()
 
     def handle_websocket_upgrade(self) -> None:
         if self.logger.level <= TRACE_LOG_LEVEL:


### PR DESCRIPTION
## Summary

When httptools receives an HTTP/1.1 request with an unsupported `Upgrade`
header (e.g., `Upgrade: h2c`), it raises `HttpParserUpgrade`. If the upgrade
is rejected by `_should_upgrade()`, the warning is logged but the request
cycle is left in a broken state — `on_message_complete` never fires because
the parser is stuck in "upgrade" mode, so `more_body` remains True and the
ASGI app hangs forever waiting for body data that will never arrive.

The h11 implementation doesn't have this problem because it checks
`_should_upgrade()` within its normal event processing loop without
raising exceptions.

This fix manually signals message completion after a rejected upgrade,
allowing the ASGI app to process the request normally. Per RFC 7230, a server
MAY ignore an Upgrade header it doesn't support and process the request as-is.

**Belief that guided this fix**: don't assume an HTTP/1.1 request with an
Upgrade header will always result in a protocol switch — Uvicorn may reject
the upgrade, leaving the request body unparsed if the parser is not explicitly
resumed (#2722).

## Test plan
- [x] `tests/protocols/test_http.py` passes
- [ ] Manual test with `Upgrade: h2c` header to verify the app receives the request