### PR TITLE
Fix lifespan error handling: improve logging and auto-mode detection

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -154,6 +154,8 @@ def test_lifespan_with_failed_startup(mode, raise_exception, caplog):
         record.message for record in caplog.records if record.name == "uvicorn.error" and record.levelname == "ERROR"
     ]
     assert "the lifespan event failed" in error_messages.pop(0)
+    if raise_exception:
+        assert "Exception in 'lifespan' protocol" in error_messages.pop(0)
     assert "Application startup failed. Exiting." in error_messages.pop(0)
 
 
@@ -237,6 +239,8 @@ def test_lifespan_with_failed_shutdown(mode, raise_exception, caplog):
         record.message for record in caplog.records if record.name == "uvicorn.error" and record.levelname == "ERROR"
     ]
     assert "the lifespan event failed" in error_messages.pop(0)
+    if raise_exception:
+        assert "Exception in 'lifespan' protocol" in error_messages.pop(0)
     assert "Application shutdown failed. Exiting." in error_messages.pop(0)
     loop.close()
 

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -63,6 +63,7 @@ class LifespanOn:
 
     async def shutdown(self) -> None:
         if self.error_occurred:
+            self.logger.info("Skipping application shutdown (startup error already occurred).")
             return
         self.logger.info("Waiting for application shutdown.")
         shutdown_event: LifespanShutdownEvent = {"type": "lifespan.shutdown"}
@@ -88,8 +89,9 @@ class LifespanOn:
             self.asgi = None
             self.error_occurred = True
             if self.startup_failed or self.shutdown_failed:
+                self.logger.error("Exception in 'lifespan' protocol\n", exc_info=exc)
                 return
-            if self.config.lifespan == "auto":
+            if self.config.lifespan == "auto" and not self.startup_event.is_set():
                 msg = "ASGI 'lifespan' protocol appears unsupported."
                 self.logger.info(msg)
             else:


### PR DESCRIPTION
## Summary

Three related fixes in `lifespan/on.py`:

1. **Log when shutdown is skipped due to startup error.** When `error_occurred`
   is True from startup, `shutdown()` returns immediately without any log
   output. This leaves operators with no indication that cleanup was skipped.
   Now logs an informational message.

2. **Fix auto-mode error attribution after successful startup.** When
   `lifespan="auto"` and the ASGI app raises an exception during shutdown
   (after startup succeeded), the code incorrectly logs "ASGI lifespan
   protocol appears unsupported." If startup completed, we know lifespan IS
   supported — the exception is a real error. This fix checks whether the
   startup event was set before deciding whether to treat the exception as
   "unsupported protocol" vs. a real error.

3. **Log exceptions that occur after shutdown.failed.** If the ASGI app sends
   `lifespan.shutdown.failed` and then raises an exception, the exception
   handler returned early without logging. The exception is now logged before
   the early return, since it may contain useful diagnostic context.

**Beliefs that guided these fixes:**
- Don't assume `lifespan.shutdown.failed` triggers automatic server
  shutdown — the failure may go unnoticed if not properly logged (#2308).
- Don't rely on standard test assertions to catch exceptions within ASGI
  applications — errors can be silently swallowed.

## Test plan
- [x] `tests/test_lifespan.py` passes (16 tests)
- [x] `tests/test_main.py` passes (10 tests)