### PR TITLE
Add transport.is_closing() guard on websocket.send in sansio implementation

### DIFF
--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -369,7 +369,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                     elif text_data is not None:
                         self.conn.send_text(text_data.encode())
                     output = self.conn.data_to_send()
-                    self.transport.write(b"".join(output))
+                    if not self.transport.is_closing():
+                        self.transport.write(b"".join(output))
 
                 elif message_type == "websocket.close":
                     if not self.transport.is_closing():


### PR DESCRIPTION
## Summary

In `websockets_sansio_impl.py`, the `websocket.send` handler writes to the
transport without checking `transport.is_closing()`, while the `websocket.close`
handler in the same method (10 lines later) does perform this check. The
`wsproto_impl.py` implementation consistently checks at both points.

This inconsistency means a `websocket.send` message arriving while the
transport is closing could result in writing to a half-closed transport.

This fix adds the same `is_closing()` guard that's already used for
`websocket.close` in this file and for both message types in wsproto.

**Belief that guided this fix**: don't assume consistent behavior between
the wsproto and websockets implementations — they handle protocol states
differently. Cross-referencing all three implementations side by side
revealed this inconsistency.

## Test plan
- [x] `tests/protocols/test_websocket.py` passes