### PR TITLE
Add trace logging for WebSocket client disconnects in run_asgi

### DIFF
--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -272,7 +272,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         try:
             result = await self.app(self.scope, self.receive, self.send)
         except ClientDisconnected:
-            pass  # pragma: full coverage
+            if self.logger.level <= TRACE_LOG_LEVEL:
+                prefix = "%s:%d - " % self.client if self.client else ""
+                self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket client disconnected during ASGI app", prefix)
         except BaseException:
             self.logger.exception("Exception in ASGI application\n")
             self.send_500_response()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -272,7 +272,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         try:
             result = await self.app(self.scope, self.receive, self.send)
         except ClientDisconnected:
-            if self.logger.level <= TRACE_LOG_LEVEL:
+            if self.logger.level <= TRACE_LOG_LEVEL:  # pragma: full coverage
                 prefix = "%s:%d - " % self.client if self.client else ""
                 self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket client disconnected during ASGI app", prefix)
         except BaseException:

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -234,7 +234,9 @@ class WSProtocol(asyncio.Protocol):
         try:
             result = await self.app(self.scope, self.receive, self.send)  # type: ignore[func-returns-value]
         except ClientDisconnected:
-            pass  # pragma: full coverage
+            if self.logger.level <= TRACE_LOG_LEVEL:
+                prefix = "%s:%d - " % self.client if self.client else ""
+                self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket client disconnected during ASGI app", prefix)
         except BaseException:
             self.logger.exception("Exception in ASGI application\n")
             self.send_500_response()

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -234,7 +234,7 @@ class WSProtocol(asyncio.Protocol):
         try:
             result = await self.app(self.scope, self.receive, self.send)  # type: ignore[func-returns-value]
         except ClientDisconnected:
-            if self.logger.level <= TRACE_LOG_LEVEL:
+            if self.logger.level <= TRACE_LOG_LEVEL:  # pragma: full coverage
                 prefix = "%s:%d - " % self.client if self.client else ""
                 self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket client disconnected during ASGI app", prefix)
         except BaseException:


### PR DESCRIPTION
## Summary

Both `wsproto_impl.py` and `websockets_sansio_impl.py` silently suppress
`ClientDisconnected` exceptions in `run_asgi()` with a bare `pass`. While
client disconnects are expected and shouldn't be logged at normal levels,
having zero visibility into these events — even at trace level — makes it
hard to diagnose WebSocket connection lifecycle issues in production.

This adds TRACE-level logging using the same pattern already established
in the HTTP protocol implementations for connection events. The
`if self.logger.level <= TRACE_LOG_LEVEL` guard ensures zero overhead
when trace logging is disabled.

**Belief that guided this fix**: the server must explicitly signal when
the transport is no longer available, and operators need visibility into
disconnect events to diagnose connection issues. The existing pattern of
silently swallowing `ClientDisconnected` made these events invisible to
debugging.

## Test plan
- [x] `tests/protocols/test_websocket.py` passes