### PR TITLE
Preserve actual close code during shutdown in websockets implementation

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -376,7 +376,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
         except ConnectionClosed:
             self.closed_event.set()
             if self.ws_server.closing:
-                return {"type": "websocket.disconnect", "code": 1012}
+                code = self.close_code if self.close_code not in (None, 1005, 1006) else 1012
+                return {"type": "websocket.disconnect", "code": code}
             return {"type": "websocket.disconnect", "code": self.close_code or 1005, "reason": self.close_reason}
 
         if isinstance(data, str):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -376,7 +376,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
         except ConnectionClosed:
             self.closed_event.set()
             if self.ws_server.closing:
-                code = self.close_code if self.close_code not in (None, 1005, 1006) else 1012
+                close_code = self.close_code
+                code: int = close_code if isinstance(close_code, int) and close_code not in (1005, 1006) else 1012
                 return {"type": "websocket.disconnect", "code": code}
             return {"type": "websocket.disconnect", "code": self.close_code or 1005, "reason": self.close_reason}
 


### PR DESCRIPTION
## Summary

In `websockets_impl.py`, when a `ConnectionClosed` exception is caught during
`asgi_receive()` and the server is shutting down (`ws_server.closing` is True),
the disconnect event always reports code 1012 ("Service Restart"), regardless
of the actual close code from the connection.

This means if a client sends a normal close (1000) that races with the
server's shutdown close (1012), the app always sees 1012 — losing the
information that the client actually closed cleanly.

This fix uses the actual `close_code` when available, falling back to 1012
only when no close code was received from the connection. In practice:
- Server-initiated shutdown → `fail_connection(1012)` → code = 1012 ✓
- Client closed normally during shutdown → code = 1000 (preserved) ✓
- Transport lost with no close frame → code = 1012 (fallback) ✓

**Belief that guided this fix**: don't use a single flag
(`ws_server.closing`) to overwrite all connection state during shutdown,
because it causes `send()` and `receive()` to lose information about what
actually happened on the wire.

## Test plan
- [x] `tests/protocols/test_websocket.py` passes