### PR TITLE
Explicitly set content-length and connection headers in sansio 500 response

### DIFF
--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -287,7 +287,10 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
     def send_500_response(self) -> None:
         if self.initial_response or self.handshake_complete:
             return
-        response = self.conn.reject(500, "Internal Server Error")
+        msg = "Internal Server Error"
+        response = self.conn.reject(500, msg)
+        response.headers["content-length"] = str(len(msg))
+        response.headers["connection"] = "close"
         self.conn.send_response(response)
         output = self.conn.data_to_send()
         self.transport.write(b"".join(output))


### PR DESCRIPTION
## Summary

- The `send_500_response` method in `WebSocketsSansIOProtocol` was relying on the `websockets` library's `reject()` to implicitly set `content-length` and `connection: close` headers. While the library does currently add these headers, the other two WebSocket implementations (`wsproto_impl.py` and `websockets_impl.py`) both set them explicitly.
- This change makes the sansio implementation explicit about these headers, consistent with the other implementations and the project convention of always providing a `content-length` header when returning raw body data in WebSocket handshake error responses (rather than relying on implicit behavior or chunked transfer encoding).
- No behavioral change — the same headers were already being sent via the library; they are now explicitly enforced in application code.

## Test plan

- [x] Ran `pytest tests/protocols/test_websocket.py` — no new test failures introduced (all 8 pre-existing failures remain unchanged)
- [x] Verified that `websockets` library's `reject()` output still contains the explicitly set headers (no duplication issues)