### PR TITLE
Add docstrings to Config and Server classes

### DIFF
--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -111,6 +111,21 @@ def create_ssl_context(
     ca_certs: str | os.PathLike[str] | None,
     ciphers: str | None,
 ) -> ssl.SSLContext:
+    """Create and configure an ``ssl.SSLContext`` for serving over TLS.
+
+    Args:
+        certfile: Path to the SSL certificate file.
+        keyfile: Path to the SSL private key file.
+        password: Password for decrypting the SSL private key.
+        ssl_version: SSL protocol version constant (e.g. ``ssl.PROTOCOL_TLS_SERVER``).
+        cert_reqs: Whether client certificates are required
+            (e.g. ``ssl.CERT_NONE``).
+        ca_certs: Path to a CA certificates file for verifying client certificates.
+        ciphers: OpenSSL cipher string to restrict allowed ciphers.
+
+    Returns:
+        A configured ``ssl.SSLContext`` instance.
+    """
     ctx = ssl.SSLContext(ssl_version)
     get_password = (lambda: password) if password else None
     ctx.load_cert_chain(certfile, keyfile, get_password)
@@ -123,6 +138,11 @@ def create_ssl_context(
 
 
 def is_dir(path: Path) -> bool:
+    """Check whether *path* is an existing directory.
+
+    Relative paths are resolved before checking.  Returns ``False`` if an
+    ``OSError`` is raised (e.g. for permission errors).
+    """
     try:
         if not path.is_absolute():
             path = path.resolve()
@@ -132,6 +152,21 @@ def is_dir(path: Path) -> bool:
 
 
 def resolve_reload_patterns(patterns_list: list[str], directories_list: list[str]) -> tuple[list[str], list[Path]]:
+    """Resolve reload glob patterns into a deduplicated set of patterns and directories.
+
+    Glob patterns are expanded against the current working directory. If a
+    pattern matches an existing directory, it is added to the directory list.
+    Child directories that are already covered by a parent directory are removed.
+
+    Args:
+        patterns_list: Glob patterns to include for file watching.
+        directories_list: Explicit directory paths to watch.
+
+    Returns:
+        A tuple of ``(patterns, directories)`` where *patterns* is a
+        deduplicated list of glob strings and *directories* is a list of
+        resolved ``Path`` objects with redundant children removed.
+    """
     directories: list[Path] = list(set(map(Path, directories_list.copy())))
     patterns: list[str] = patterns_list.copy()
 
@@ -168,6 +203,11 @@ def resolve_reload_patterns(patterns_list: list[str], directories_list: list[str
 
 
 def _normalize_dirs(dirs: list[str] | str | None) -> list[str]:
+    """Normalize a directory argument into a deduplicated list of strings.
+
+    Accepts ``None``, a single string, or a list of strings and always returns
+    a list.
+    """
     if dirs is None:
         return []
     if isinstance(dirs, str):
@@ -176,6 +216,14 @@ def _normalize_dirs(dirs: list[str] | str | None) -> list[str]:
 
 
 class Config:
+    """Central configuration object for a Uvicorn server instance.
+
+    Holds all settings related to networking, SSL/TLS, logging, reloading,
+    protocol selection, and worker management.  Call :meth:`load` to resolve
+    the ASGI application and apply middleware before the server starts
+    accepting connections.
+    """
+
     def __init__(
         self,
         app: ASGIApplication | Callable[..., Any] | str,
@@ -346,6 +394,7 @@ class Config:
 
     @property
     def asgi_version(self) -> Literal["2.0", "3.0"]:
+        """Return the ASGI spec version string for the configured interface."""
         mapping: dict[str, Literal["2.0", "3.0"]] = {
             "asgi2": "2.0",
             "asgi3": "3.0",
@@ -355,13 +404,26 @@ class Config:
 
     @property
     def is_ssl(self) -> bool:
+        """Return ``True`` if an SSL key or certificate file has been configured."""
         return bool(self.ssl_keyfile or self.ssl_certfile)
 
     @property
     def use_subprocess(self) -> bool:
+        """Return ``True`` if the server will spawn child processes.
+
+        This is the case when reload is enabled or more than one worker is
+        configured.
+        """
         return bool(self.reload or self.workers > 1)
 
     def configure_logging(self) -> None:
+        """Apply the logging configuration.
+
+        Registers the custom ``TRACE`` log level, processes the
+        :attr:`log_config` (dict, JSON, YAML, or INI file), and adjusts
+        logger levels and handlers according to :attr:`log_level` and
+        :attr:`access_log`.
+        """
         logging.addLevelName(TRACE_LOG_LEVEL, "TRACE")
 
         if self.log_config is not None:
@@ -400,6 +462,19 @@ class Config:
             logging.getLogger("uvicorn.access").propagate = False
 
     def load(self) -> None:
+        """Resolve and prepare the ASGI application for serving.
+
+        This must be called exactly once before the server starts.  It
+        performs the following steps:
+
+        * Creates the SSL context when TLS is configured.
+        * Encodes custom response headers.
+        * Imports the HTTP, WebSocket, and lifespan protocol classes.
+        * Imports (and optionally calls) the ASGI application.
+        * Detects the ASGI interface version when set to ``"auto"``.
+        * Wraps the application in any required middleware (WSGI adapter,
+          ASGI2 adapter, proxy headers, message logger).
+        """
         assert not self.loaded
 
         if self.is_ssl:
@@ -486,6 +561,13 @@ class Config:
         )
 
     def get_loop_factory(self) -> Callable[[], asyncio.AbstractEventLoop] | None:
+        """Return a callable that creates the configured event loop, or ``None``.
+
+        When :attr:`loop` names a built-in factory (e.g. ``"auto"``,
+        ``"uvloop"``), the corresponding factory is imported and returned.
+        A custom import string is also accepted.  Returns ``None`` when the
+        loop setting is ``"none"``.
+        """
         if self.loop in LOOP_FACTORIES:
             loop_factory: Callable[..., Any] | None = import_from_string(LOOP_FACTORIES[self.loop])
         else:
@@ -499,6 +581,12 @@ class Config:
         return loop_factory(use_subprocess=self.use_subprocess)
 
     def bind_socket(self) -> socket.socket:
+        """Create, bind, and return a listening socket.
+
+        Handles UNIX domain sockets, file-descriptor sockets, and standard
+        TCP sockets (IPv4 and IPv6).  Logs the address the server is running
+        on.
+        """
         logger_args: list[str | int]
         if self.uds:  # pragma: py-win32
             path = self.uds
@@ -548,4 +636,5 @@ class Config:
 
     @property
     def should_reload(self) -> bool:
+        """Return ``True`` if auto-reload is enabled and the app is an import string."""
         return isinstance(self.app, str) and self.reload

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -54,6 +54,12 @@ class ServerState:
 
 
 class Server:
+    """The core asyncio server that manages the ASGI application lifecycle.
+
+    Handles binding to sockets, starting and stopping the event loop, signal
+    handling, graceful shutdown, and enforcing request limits.
+    """
+
     def __init__(self, config: Config) -> None:
         self.config = config
         self.server_state = ServerState()
@@ -72,9 +78,11 @@ class Server:
         return self.config.limit_max_requests + random.randint(0, self.config.limit_max_requests_jitter)
 
     def run(self, sockets: list[socket.socket] | None = None) -> None:
+        """Run the server synchronously, creating an event loop via the configured factory."""
         return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
 
     async def serve(self, sockets: list[socket.socket] | None = None) -> None:
+        """Start serving, capturing OS signals for graceful shutdown."""
         with self.capture_signals():
             await self._serve(sockets)
 
@@ -102,6 +110,7 @@ class Server:
             logger.info(message, process_id, extra={"color_message": color_message})
 
     async def startup(self, sockets: list[socket.socket] | None = None) -> None:
+        """Start the lifespan, bind to sockets, and begin accepting connections."""
         await self.lifespan.startup()
         if self.lifespan.should_exit:
             self.should_exit = True
@@ -195,6 +204,7 @@ class Server:
         self.started = True
 
     def _log_started_message(self, listeners: Sequence[socket.SocketType]) -> None:
+        """Log the address(es) the server is listening on."""
         config = self.config
 
         if config.fd is not None:  # pragma: py-win32
@@ -230,6 +240,7 @@ class Server:
             )
 
     async def main_loop(self) -> None:
+        """Poll :meth:`on_tick` every 100 ms until the server should exit."""
         counter = 0
         should_exit = await self.on_tick(counter)
         while not should_exit:
@@ -239,6 +250,12 @@ class Server:
             should_exit = await self.on_tick(counter)
 
     async def on_tick(self, counter: int) -> bool:
+        """Perform periodic bookkeeping and return ``True`` when the server should exit.
+
+        Called every 100 ms. Updates the ``Date`` header once per second,
+        invokes the ``callback_notify`` callback at the configured interval,
+        and checks whether the maximum request limit has been reached.
+        """
         # Update the default headers, once per second.
         if counter % 10 == 0:
             current_time = time.time()
@@ -269,6 +286,13 @@ class Server:
         return False
 
     async def shutdown(self, sockets: list[socket.socket] | None = None) -> None:
+        """Gracefully shut down the server.
+
+        Stops accepting new connections, requests shutdown on existing ones,
+        waits for in-flight tasks to complete (subject to
+        ``timeout_graceful_shutdown``), and finally triggers the lifespan
+        shutdown event.
+        """
         logger.info("Shutting down")
 
         # Stop accepting new connections.
@@ -320,6 +344,12 @@ class Server:
 
     @contextlib.contextmanager
     def capture_signals(self) -> Generator[None, None, None]:
+        """Context manager that installs signal handlers for graceful shutdown.
+
+        Restores the original handlers on exit and re-raises any captured
+        signals so that the calling process observes the expected termination
+        behaviour.
+        """
         # Signals can only be listened to from the main thread.
         if threading.current_thread() is not threading.main_thread():
             yield
@@ -339,6 +369,12 @@ class Server:
             signal.raise_signal(captured_signal)
 
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
+        """Signal handler that triggers graceful or forced shutdown.
+
+        The first signal sets :attr:`should_exit`.  A second ``SIGINT``
+        while already shutting down sets :attr:`force_exit` to skip waiting
+        for in-flight requests.
+        """
         self._captured_signals.append(sig)
         if self.should_exit and sig == signal.SIGINT:
             self.force_exit = True  # pragma: full coverage


### PR DESCRIPTION
# Summary

Add missing docstrings to all public methods, properties, and module-level functions in `uvicorn/config.py` and `uvicorn/server.py`.

These are the two most important user-facing modules in the codebase and currently have no docstrings on most of their public API surface. The additions cover:

- **`config.py`**: `create_ssl_context`, `is_dir`, `resolve_reload_patterns`, `_normalize_dirs`, and all `Config` methods/properties (`configure_logging`, `load`, `get_loop_factory`, `bind_socket`, `asgi_version`, `is_ssl`, `use_subprocess`, `should_reload`).
- **`server.py`**: `Server` class docstring plus `run`, `serve`, `startup`, `shutdown`, `main_loop`, `on_tick`, `capture_signals`, and `handle_exit`.

No logic, behavior, or test changes are included.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.