### PR TITLE
Implement keepalive for websockets-sansio

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -95,8 +95,8 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. There are two versions of `websockets` supported: `websockets` and `websockets-sansio`. Use `'none'` to ignore all websocket requests. **Options:** *'auto', 'none', 'websockets', 'websockets-sansio', 'wsproto'.* **Default:** *'auto'*.
 * `--ws-max-size <int>` - Set the WebSockets max message size, in bytes. Only available with the `websockets` protocol. **Default:** *16777216* (16 MB).
 * `--ws-max-queue <int>` - Set the maximum length of the WebSocket incoming message queue. Only available with the `websockets` protocol. **Default:** *32*.
-* `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Only available with the `websockets` protocol. **Default:** *20.0*.
-* `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Only available with the `websockets` protocol. **Default:** *20.0*.
+* `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Available with the `websockets` and `websockets-sansio` protocols. **Default:** *20.0*.
+* `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Available with the `websockets` and `websockets-sansio` protocols. **Default:** *20.0*.
 * `--ws-per-message-deflate <bool>` - Enable/disable WebSocket per-message-deflate compression. Only available with the `websockets` protocol. **Default:** *True*.
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.
 * `--h11-max-incomplete-event-size <int>` - Set the maximum number of bytes to buffer of an incomplete event. Only available for `h11` HTTP protocol implementation. **Default:** *16384* (16 KB).

--- a/tests/benchmarks/test_ws.py
+++ b/tests/benchmarks/test_ws.py
@@ -48,8 +48,8 @@ async def _ws_send_text_app(scope: Scope, receive: ASGIReceiveCallable, send: AS
     await send({"type": "websocket.close", "code": 1000})
 
 
-_ws_accept_close_config = make_config(_ws_accept_close_app, access_log=False)
-_ws_send_text_config = make_config(_ws_send_text_app, access_log=False)
+_ws_accept_close_config = make_config(_ws_accept_close_app, access_log=False, ws_ping_interval=None)
+_ws_send_text_config = make_config(_ws_send_text_app, access_log=False, ws_ping_interval=None)
 
 
 async def test_bench_ws_handshake(ws_cls: WSProtocolClass) -> None:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1202,3 +1202,91 @@ async def test_lifespan_state(ws_protocol_cls: WSProtocol, http_protocol_cls: HT
         assert is_open
 
     assert expected_states == actual_states
+
+
+async def raw_ws_handshake(host: str, port: int) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Raw TCP websocket handshake that does not automatically respond to pings."""
+    reader, writer = await asyncio.open_connection(host, port)
+    request = (
+        f"GET / HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        f"Connection: Upgrade\r\n"
+        f"Upgrade: websocket\r\n"
+        f"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        f"Sec-WebSocket-Version: 13\r\n"
+        f"\r\n"
+    )
+    writer.write(request.encode())
+    await writer.drain()
+    response = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=2)
+    # Switching Protocols (WebSocket handshake accepted)
+    assert b"101" in response
+    return reader, writer
+
+
+async def test_server_sends_keepalive_ping(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    if ws_protocol_cls.__name__ == "WSProtocol":
+        pytest.skip("wsproto does not support ws_ping_interval.")
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=0.1,
+        ws_ping_timeout=2.0,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        reader, writer = await raw_ws_handshake("127.0.0.1", unused_tcp_port)
+        data = await asyncio.wait_for(reader.read(4096), timeout=2)
+        assert len(data) >= 2
+        # 0x89 = FIN bit (0x80) | ping opcode (0x09)
+        assert data[0] == 0x89, f"Expected ping frame (0x89), got 0x{data[0]:02x}"
+        writer.close()
+
+
+async def test_server_keepalive_ping_timeout(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    if ws_protocol_cls.__name__ == "WSProtocol":
+        pytest.skip("wsproto does not support ws_ping_interval.")
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=0.1,
+        ws_ping_timeout=0.1,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        async with websockets.client.connect(
+            f"ws://127.0.0.1:{unused_tcp_port}",
+            ping_interval=None,
+        ) as websocket:
+            # Suppress all writes so the client never sends pong back.
+            websocket.transport.write = lambda data: None  # type: ignore[method-assign]
+            with pytest.raises(websockets.exceptions.ConnectionClosedError) as exc_info:
+                await asyncio.wait_for(websocket.recv(), timeout=2)
+            assert exc_info.value.rcvd is not None
+            assert exc_info.value.rcvd.code == 1011

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1227,8 +1227,8 @@ async def raw_ws_handshake(host: str, port: int) -> tuple[asyncio.StreamReader, 
 async def test_server_sends_keepalive_ping(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):
-    if ws_protocol_cls.__name__ == "WSProtocol":
-        pytest.skip("wsproto does not support ws_ping_interval.")
+    if ws_protocol_cls.__name__ != "WebSocketsSansIOProtocol":
+        pytest.skip("Keepalive tests only apply to websockets-sansio.")
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         while True:
@@ -1262,8 +1262,8 @@ async def test_server_keepalive_ping_timeout(
     unused_tcp_port: int,
     caplog: pytest.LogCaptureFixture,
 ):
-    if ws_protocol_cls.__name__ == "WSProtocol":
-        pytest.skip("wsproto does not support ws_ping_interval.")
+    if ws_protocol_cls.__name__ != "WebSocketsSansIOProtocol":
+        pytest.skip("Keepalive tests only apply to websockets-sansio.")
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         while True:
@@ -1300,8 +1300,8 @@ async def test_server_keepalive_ping_timeout(
 async def test_server_keepalive_ping_pong(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):
-    if ws_protocol_cls.__name__ == "WSProtocol":
-        pytest.skip("wsproto does not support ws_ping_interval.")
+    if ws_protocol_cls.__name__ != "WebSocketsSansIOProtocol":
+        pytest.skip("Keepalive tests only apply to websockets-sansio.")
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         while True:
@@ -1337,8 +1337,8 @@ async def test_server_keepalive_ping_pong(
 async def test_server_keepalive_close_during_sleep(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):
-    if ws_protocol_cls.__name__ == "WSProtocol":
-        pytest.skip("wsproto does not support ws_ping_interval.")
+    if ws_protocol_cls.__name__ != "WebSocketsSansIOProtocol":
+        pytest.skip("Keepalive tests only apply to websockets-sansio.")
 
     disconnect_received = False
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1205,7 +1205,7 @@ async def test_lifespan_state(ws_protocol_cls: WSProtocol, http_protocol_cls: HT
 
 
 async def raw_ws_handshake(host: str, port: int) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
-    """Raw TCP websocket handshake that does not automatically respond to pings."""
+    """Raw TCP websocket handshake. Does not auto-respond to pings."""
     reader, writer = await asyncio.open_connection(host, port)
     request = (
         f"GET / HTTP/1.1\r\n"
@@ -1257,7 +1257,10 @@ async def test_server_sends_keepalive_ping(
 
 
 async def test_server_keepalive_ping_timeout(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+    ws_protocol_cls: WSProtocol,
+    http_protocol_cls: HTTPProtocol,
+    unused_tcp_port: int,
+    caplog: pytest.LogCaptureFixture,
 ):
     if ws_protocol_cls.__name__ == "WSProtocol":
         pytest.skip("wsproto does not support ws_ping_interval.")
@@ -1277,6 +1280,7 @@ async def test_server_keepalive_ping_timeout(
         lifespan="off",
         ws_ping_interval=0.1,
         ws_ping_timeout=0.1,
+        log_level="trace",
         port=unused_tcp_port,
     )
     async with run_server(config):
@@ -1284,9 +1288,84 @@ async def test_server_keepalive_ping_timeout(
             f"ws://127.0.0.1:{unused_tcp_port}",
             ping_interval=None,
         ) as websocket:
-            # Suppress all writes so the client never sends pong back.
             websocket.transport.write = lambda data: None  # type: ignore[method-assign]
             with pytest.raises(websockets.exceptions.ConnectionClosedError) as exc_info:
                 await asyncio.wait_for(websocket.recv(), timeout=2)
             assert exc_info.value.rcvd is not None
             assert exc_info.value.rcvd.code == 1011
+
+    assert any("keepalive ping timeout" in r.message for r in caplog.records)
+
+
+async def test_server_keepalive_ping_pong(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    if ws_protocol_cls.__name__ == "WSProtocol":
+        pytest.skip("wsproto does not support ws_ping_interval.")
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.receive":
+                _text = message.get("text")
+                assert _text is not None
+                await send({"type": "websocket.send", "text": _text})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=0.1,
+        ws_ping_timeout=0.5,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        async with websockets.client.connect(
+            f"ws://127.0.0.1:{unused_tcp_port}",
+            ping_interval=None,
+        ) as websocket:
+            await asyncio.sleep(0.5)
+            await websocket.send("hello")
+            assert await asyncio.wait_for(websocket.recv(), timeout=1) == "hello"
+
+
+async def test_server_keepalive_close_during_sleep(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    if ws_protocol_cls.__name__ == "WSProtocol":
+        pytest.skip("wsproto does not support ws_ping_interval.")
+
+    disconnect_received = False
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        nonlocal disconnect_received
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                disconnect_received = True
+                break
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=10.0,
+        ws_ping_timeout=10.0,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        async with websockets.client.connect(
+            f"ws://127.0.0.1:{unused_tcp_port}",
+            ping_interval=None,
+        ) as websocket:
+            await websocket.close()
+
+    assert disconnect_received

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1369,3 +1369,31 @@ async def test_server_keepalive_close_during_sleep(
             await websocket.close()
 
     assert disconnect_received
+
+
+async def test_server_eof_received(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
+    if ws_protocol_cls.__name__ != "WebSocketsSansIOProtocol":
+        pytest.skip("Only testing eof_received for websockets-sansio.")
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=ws_protocol_cls,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=None,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        reader, writer = await raw_ws_handshake("127.0.0.1", unused_tcp_port)
+        # TCP half-close: send FIN without a WebSocket close frame.
+        writer.write_eof()
+        await asyncio.sleep(0.1)
+        writer.close()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
+import struct
 import sys
 from asyncio.transports import BaseTransport, Transport
 from http import HTTPStatus
@@ -92,6 +94,13 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.writable = asyncio.Event()
         self.writable.set()
 
+        # Keepalive state
+        self.ping_interval = config.ws_ping_interval
+        self.ping_timeout = config.ws_ping_timeout
+        self.keepalive_task: asyncio.Task[None] | None = None
+        self.pending_pings: dict[bytes, tuple[asyncio.Future[float], float]] = {}
+        self.latency: float = 0
+
         # Buffers
         self.bytes = b""
 
@@ -109,6 +118,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection made", prefix)
 
     def connection_lost(self, exc: Exception | None) -> None:
+        self.stop_keepalive()
         code = 1005 if self.handshake_complete else 1006
         self.queue.put_nowait({"type": "websocket.disconnect", "code": code})
         self.connections.remove(self)
@@ -125,6 +135,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         pass
 
     def shutdown(self) -> None:
+        self.stop_keepalive()
         if self.handshake_complete:
             self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
             self.conn.send_close(1012)
@@ -155,7 +166,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 elif event.opcode == Opcode.PING:
                     self.handle_ping()
                 elif event.opcode == Opcode.PONG:
-                    pass  # pragma: no cover
+                    self.handle_pong(event)
                 elif event.opcode == Opcode.CLOSE:
                     self.handle_close(event)
                 else:
@@ -238,6 +249,83 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         output = self.conn.data_to_send()
         self.transport.write(b"".join(output))
 
+    def handle_pong(self, event: Frame) -> None:
+        data = bytes(event.data)
+        if data not in self.pending_pings:
+            return
+
+        pong_timestamp = self.loop.time()
+
+        ping_ids = []
+        for ping_id, (pong_received, ping_timestamp) in self.pending_pings.items():
+            ping_ids.append(ping_id)
+            latency = pong_timestamp - ping_timestamp
+            if not pong_received.done():
+                pong_received.set_result(latency)
+            if ping_id == data:
+                self.latency = latency
+                break
+
+        for ping_id in ping_ids:
+            del self.pending_pings[ping_id]
+
+    def start_keepalive(self) -> None:
+        if self.ping_interval is not None:
+            self.keepalive_task = self.loop.create_task(self.keepalive())
+
+    def stop_keepalive(self) -> None:
+        if self.keepalive_task is not None:
+            self.keepalive_task.cancel()
+            self.keepalive_task = None
+        for pong_received, _ping_timestamp in self.pending_pings.values():
+            if not pong_received.done():
+                pong_received.cancel()
+        self.pending_pings.clear()
+
+    async def keepalive(self) -> None:
+        assert self.ping_interval is not None
+        latency = 0.0
+        try:
+            while True:
+                await asyncio.sleep(self.ping_interval - latency)
+
+                if self.transport.is_closing():
+                    return
+
+                ping_data: bytes | None = None
+                while ping_data is None or ping_data in self.pending_pings:
+                    ping_data = struct.pack("!I", random.getrandbits(32))
+
+                pong_received: asyncio.Future[float] = self.loop.create_future()
+                ping_timestamp = self.loop.time()
+                self.pending_pings[ping_data] = (pong_received, ping_timestamp)
+
+                self.conn.send_ping(ping_data)
+                output = self.conn.data_to_send()
+                self.transport.write(b"".join(output))
+
+                if self.ping_timeout is not None:
+                    try:
+                        latency = await asyncio.wait_for(pong_received, self.ping_timeout)
+                    except TimeoutError:
+                        self.pending_pings.pop(ping_data, None)
+                        if self.logger.level <= TRACE_LOG_LEVEL:
+                            prefix = "%s:%d - " % self.client if self.client else ""
+                            self.logger.log(
+                                TRACE_LOG_LEVEL,
+                                "%sWebSocket keepalive ping timeout",
+                                prefix,
+                            )
+                        self.conn.fail(1011, "keepalive ping timeout")
+                        output = self.conn.data_to_send()
+                        self.transport.write(b"".join(output))
+                        self.transport.close()
+                        return
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            self.logger.error("keepalive ping failed", exc_info=True)
+
     def handle_close(self, event: Frame) -> None:
         if not self.close_sent and not self.transport.is_closing():
             assert self.conn.close_rcvd is not None
@@ -311,6 +399,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                     self.conn.send_response(self.response)
                     output = self.conn.data_to_send()
                     self.transport.write(b"".join(output))
+                    self.start_keepalive()
 
             elif message["type"] == "websocket.close":
                 self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -307,7 +307,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 if self.ping_timeout is not None:
                     try:
                         latency = await asyncio.wait_for(pong_received, self.ping_timeout)
-                    except TimeoutError:
+                    except (TimeoutError, asyncio.TimeoutError):
                         self.pending_pings.pop(ping_data, None)
                         if self.logger.level <= TRACE_LOG_LEVEL:
                             prefix = "%s:%d - " % self.client if self.client else ""

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -251,7 +251,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     def handle_pong(self, event: Frame) -> None:
         data = bytes(event.data)
-        if data not in self.pending_pings:
+        if data not in self.pending_pings:  # pragma: no cover
             return
 
         pong_timestamp = self.loop.time()
@@ -278,7 +278,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             self.keepalive_task.cancel()
             self.keepalive_task = None
         for pong_received, _ping_timestamp in self.pending_pings.values():
-            if not pong_received.done():
+            if not pong_received.done():  # pragma: no cover
                 pong_received.cancel()
         self.pending_pings.clear()
 
@@ -289,7 +289,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             while True:
                 await asyncio.sleep(self.ping_interval - latency)
 
-                if self.transport.is_closing():
+                if self.transport.is_closing():  # pragma: no cover
                     return
 
                 ping_data: bytes | None = None
@@ -323,7 +323,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                         return
         except asyncio.CancelledError:
             pass
-        except Exception:
+        except Exception:  # pragma: no cover
             self.logger.error("keepalive ping failed", exc_info=True)
 
     def handle_close(self, event: Frame) -> None:


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

`--ws-ping-interval` and `--ws-ping-timeout` are ignored by the `websockets-sansio` implementation. Without pings, idle connections get killed by proxies (nginx, caddy, etc).

The legacy `websockets` implementation inherits keepalive from the library.
See https://github.com/python-websockets/websockets/blob/ea164d2fe0cb699dd52d28bfbe98165fb35cb13c/src/websockets/legacy/protocol.py#L1213

The sans-I/O `ServerProtocol` has `send_ping()` but nobody was calling it.

So I ported `keepalive()`, `handle_pong()`, and the start/stop lifecycle from `websockets.asyncio.connection.Connection` into `WebSocketsSansIOProtocol`. 
https://github.com/python-websockets/websockets/blob/ea164d2fe0cb699dd52d28bfbe98165fb35cb13c/src/websockets/asyncio/connection.py#L808
Two new tests connect via raw TCP to verify ping frames are sent and that the server closes with 1011 on pong timeout. Both fail on sansio before this patch, pass after.
I'm not sure whether this is the right approach though, but I felt that websockets has the most mature implementation for it. But probably in sans-io case we need to indeed implement keepalive ourselves.
Fixes #2883 (there is a reproduction script in it too)

cc @aaugustin Sorry for the ping, I saw you review the original websockets-sansio PR. When using sansio implementation, are we supposed to implement keepalive pings ourselves? I just don't know if porting it from `websockets.asyncio.connection.Connection` is the best way or there is some logic we can re-use here already implemented. Thank you!


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
