### PR TITLE
Implement websocket keepalive pings for websockets-sansio

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -95,8 +95,8 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. There are two versions of `websockets` supported: `websockets` and `websockets-sansio`. Use `'none'` to ignore all websocket requests. **Options:** *'auto', 'none', 'websockets', 'websockets-sansio', 'wsproto'.* **Default:** *'auto'*.
 * `--ws-max-size <int>` - Set the WebSockets max message size, in bytes. Only available with the `websockets` protocol. **Default:** *16777216* (16 MB).
 * `--ws-max-queue <int>` - Set the maximum length of the WebSocket incoming message queue. Only available with the `websockets` protocol. **Default:** *32*.
-* `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Only available with the `websockets` protocol. **Default:** *20.0*.
-* `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Only available with the `websockets` protocol. **Default:** *20.0*.
+* `--ws-ping-interval <float>` - Set the WebSockets ping interval, in seconds. Available with the `websockets` and `websockets-sansio` protocols. **Default:** *20.0*.
+* `--ws-ping-timeout <float>` - Set the WebSockets ping timeout, in seconds. Available with the `websockets` and `websockets-sansio` protocols. **Default:** *20.0*.
 * `--ws-per-message-deflate <bool>` - Enable/disable WebSocket per-message-deflate compression. Only available with the `websockets` protocol. **Default:** *True*.
 * `--lifespan <str>` - Set the Lifespan protocol implementation. **Options:** *'auto', 'on', 'off'.* **Default:** *'auto'*.
 * `--h11-max-incomplete-event-size <int>` - Set the maximum number of bytes to buffer of an incomplete event. Only available for `h11` HTTP protocol implementation. **Default:** *16384* (16 KB).

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1206,63 +1206,12 @@ async def test_lifespan_state(ws_protocol_cls: WSProtocol, http_protocol_cls: HT
     assert expected_states == actual_states
 
 
-async def raw_ws_handshake(host: str, port: int) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
-    """Perform a raw TCP WebSocket handshake; the caller is responsible for reading frames."""
-    reader, writer = await asyncio.open_connection(host, port)
-    request = (
-        f"GET / HTTP/1.1\r\n"
-        f"Host: {host}:{port}\r\n"
-        f"Connection: Upgrade\r\n"
-        f"Upgrade: websocket\r\n"
-        f"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-        f"Sec-WebSocket-Version: 13\r\n"
-        f"\r\n"
-    )
-    writer.write(request.encode())
-    await writer.drain()
-    response = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=2)
-    assert b"101" in response
-    return reader, writer
-
-
-async def test_server_sends_keepalive_ping(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        while True:
-            message = await receive()
-            if message["type"] == "websocket.connect":
-                await send({"type": "websocket.accept"})
-            elif message["type"] == "websocket.disconnect":
-                break
-
-    config = Config(
-        app=app,
-        ws=WebSocketsSansIOProtocol,
-        http=http_protocol_cls,
-        lifespan="off",
-        ws_ping_interval=0.1,
-        ws_ping_timeout=2.0,
-        port=unused_tcp_port,
-    )
-    async with run_server(config):
-        reader, writer = await raw_ws_handshake("127.0.0.1", unused_tcp_port)
-        # Raw TCP client never replies to the ping; we only check a ping frame arrives.
-        data = await asyncio.wait_for(reader.read(4096), timeout=2)
-        assert len(data) >= 2
-        # 0x89 = FIN (0x80) | ping opcode (0x09)
-        assert data[0] == 0x89, f"Expected ping frame (0x89), got 0x{data[0]:02x}"
-        writer.close()
-
-
 async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         while True:
             message = await receive()
             if message["type"] == "websocket.connect":
                 await send({"type": "websocket.accept"})
-            elif message["type"] == "websocket.receive":
-                text = message.get("text")
-                assert text is not None
-                await send({"type": "websocket.send", "text": text})
             elif message["type"] == "websocket.disconnect":
                 break
 
@@ -1275,15 +1224,13 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
         ws_ping_timeout=1.0,
         port=unused_tcp_port,
     )
-    async with run_server(config):
+    async with run_server(config) as server:
         # The websockets client auto-responds to ping frames, keeping the connection alive.
-        async with websockets.asyncio.client.connect(
-            f"ws://127.0.0.1:{unused_tcp_port}",
-            ping_interval=None,
-        ) as websocket:
-            await asyncio.sleep(0.5)  # Several ping/pong roundtrips should have happened.
-            await websocket.send("hello")
-            assert await asyncio.wait_for(websocket.recv(), timeout=1) == "hello"
+        async with websockets.asyncio.client.connect(f"ws://127.0.0.1:{unused_tcp_port}", ping_interval=None):
+            await asyncio.sleep(0.3)  # Several ping/pong roundtrips should have happened.
+            protocol = list(server.server_state.connections)[0]
+            assert isinstance(protocol, WebSocketsSansIOProtocol)
+            assert protocol.last_ping_rtt > 0
 
 
 async def test_server_keepalive_ping_timeout(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
@@ -1310,7 +1257,7 @@ async def test_server_keepalive_ping_timeout(http_protocol_cls: HTTPProtocol, un
             # Swallow outgoing pong frames so the server's ping never gets ack'd.
             websocket.transport.write = lambda data: None  # type: ignore[method-assign]
             with pytest.raises(websockets.exceptions.ConnectionClosedError) as exc_info:
-                await asyncio.wait_for(websocket.recv(), timeout=2)
+                await asyncio.wait_for(websocket.recv(), timeout=1)
             assert exc_info.value.rcvd is not None
             assert exc_info.value.rcvd.code == 1011
             assert exc_info.value.rcvd.reason == "keepalive ping timeout"
@@ -1333,8 +1280,8 @@ async def test_server_keepalive_disabled(http_protocol_cls: HTTPProtocol, unused
         ws_ping_interval=None,
         port=unused_tcp_port,
     )
-    async with run_server(config):
-        reader, writer = await raw_ws_handshake("127.0.0.1", unused_tcp_port)
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(reader.read(4096), timeout=0.3)
-        writer.close()
+    async with run_server(config) as server:
+        async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}", ping_interval=None):
+            protocol = list(server.server_state.connections)[0]
+            assert isinstance(protocol, WebSocketsSansIOProtocol)
+            assert protocol.ping_timer is None

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1229,9 +1229,7 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
             protocol = list(server.server_state.connections)[0]
             assert isinstance(protocol, WebSocketsSansIOProtocol)
             # Wait until at least one ping/pong roundtrip completes.
-            deadline = asyncio.get_event_loop().time() + 2.0
-            while protocol.last_ping_rtt == 0.0 and asyncio.get_event_loop().time() < deadline:
-                await asyncio.sleep(0.05)
+            await asyncio.sleep(0.5)
             assert protocol.last_ping_rtt > 0
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1228,6 +1228,7 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
         async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}", ping_interval=None):
             protocol = list(server.server_state.connections)[0]
             assert isinstance(protocol, WebSocketsSansIOProtocol)
+
             # Wait until at least one ping/pong roundtrip completes.
             async def ping_roundtrip() -> None:
                 while protocol.last_ping_rtt == 0.0:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1219,7 +1219,7 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
         ws=WebSocketsSansIOProtocol,
         http=http_protocol_cls,
         lifespan="off",
-        ws_ping_interval=1.0,
+        ws_ping_interval=0.1,
         ws_ping_timeout=5.0,
         port=unused_tcp_port,
     )

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 import httpx
 import pytest
 import websockets
-import websockets.asyncio.client
 import websockets.client
 import websockets.exceptions
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
@@ -1226,10 +1225,13 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
     )
     async with run_server(config) as server:
         # The websockets client auto-responds to ping frames, keeping the connection alive.
-        async with websockets.asyncio.client.connect(f"ws://127.0.0.1:{unused_tcp_port}", ping_interval=None):
-            await asyncio.sleep(0.3)  # Several ping/pong roundtrips should have happened.
+        async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}", ping_interval=None):
             protocol = list(server.server_state.connections)[0]
             assert isinstance(protocol, WebSocketsSansIOProtocol)
+            # Wait until at least one ping/pong roundtrip completes.
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while protocol.last_ping_rtt == 0.0 and asyncio.get_event_loop().time() < deadline:
+                await asyncio.sleep(0.05)
             assert protocol.last_ping_rtt > 0
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1219,8 +1219,8 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
         ws=WebSocketsSansIOProtocol,
         http=http_protocol_cls,
         lifespan="off",
-        ws_ping_interval=0.1,
-        ws_ping_timeout=1.0,
+        ws_ping_interval=1.0,
+        ws_ping_timeout=5.0,
         port=unused_tcp_port,
     )
     async with run_server(config) as server:
@@ -1232,9 +1232,9 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
             # Wait until at least one ping/pong roundtrip completes.
             async def ping_roundtrip() -> None:
                 while protocol.last_ping_rtt == 0.0:
-                    await asyncio.sleep(0.05)
+                    await asyncio.sleep(0.1)
 
-            await asyncio.wait_for(ping_roundtrip(), timeout=5.0)
+            await asyncio.wait_for(ping_roundtrip(), timeout=10.0)
             assert protocol.last_ping_rtt > 0
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1229,7 +1229,11 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
             protocol = list(server.server_state.connections)[0]
             assert isinstance(protocol, WebSocketsSansIOProtocol)
             # Wait until at least one ping/pong roundtrip completes.
-            await asyncio.sleep(0.5)
+            async def ping_roundtrip() -> None:
+                while protocol.last_ping_rtt == 0.0:
+                    await asyncio.sleep(0.05)
+
+            await asyncio.wait_for(ping_roundtrip(), timeout=5.0)
             assert protocol.last_ping_rtt > 0
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 import httpx
 import pytest
 import websockets
+import websockets.asyncio.client
 import websockets.client
 import websockets.exceptions
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
@@ -27,6 +28,7 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
+from uvicorn.protocols.websockets.websockets_sansio_impl import WebSocketsSansIOProtocol
 
 try:
     from uvicorn.protocols.websockets.wsproto_impl import WSProtocol as _WSProtocol
@@ -1202,3 +1204,137 @@ async def test_lifespan_state(ws_protocol_cls: WSProtocol, http_protocol_cls: HT
         assert is_open
 
     assert expected_states == actual_states
+
+
+async def raw_ws_handshake(host: str, port: int) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Perform a raw TCP WebSocket handshake; the caller is responsible for reading frames."""
+    reader, writer = await asyncio.open_connection(host, port)
+    request = (
+        f"GET / HTTP/1.1\r\n"
+        f"Host: {host}:{port}\r\n"
+        f"Connection: Upgrade\r\n"
+        f"Upgrade: websocket\r\n"
+        f"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        f"Sec-WebSocket-Version: 13\r\n"
+        f"\r\n"
+    )
+    writer.write(request.encode())
+    await writer.drain()
+    response = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=2)
+    assert b"101" in response
+    return reader, writer
+
+
+async def test_server_sends_keepalive_ping(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=WebSocketsSansIOProtocol,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=0.1,
+        ws_ping_timeout=2.0,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        reader, writer = await raw_ws_handshake("127.0.0.1", unused_tcp_port)
+        # Raw TCP client never replies to the ping; we only check a ping frame arrives.
+        data = await asyncio.wait_for(reader.read(4096), timeout=2)
+        assert len(data) >= 2
+        # 0x89 = FIN (0x80) | ping opcode (0x09)
+        assert data[0] == 0x89, f"Expected ping frame (0x89), got 0x{data[0]:02x}"
+        writer.close()
+
+
+async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.receive":
+                text = message.get("text")
+                assert text is not None
+                await send({"type": "websocket.send", "text": text})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=WebSocketsSansIOProtocol,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=0.1,
+        ws_ping_timeout=1.0,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        # The websockets client auto-responds to ping frames, keeping the connection alive.
+        async with websockets.asyncio.client.connect(
+            f"ws://127.0.0.1:{unused_tcp_port}",
+            ping_interval=None,
+        ) as websocket:
+            await asyncio.sleep(0.5)  # Several ping/pong roundtrips should have happened.
+            await websocket.send("hello")
+            assert await asyncio.wait_for(websocket.recv(), timeout=1) == "hello"
+
+
+async def test_server_keepalive_ping_timeout(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=WebSocketsSansIOProtocol,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=0.1,
+        ws_ping_timeout=0.1,
+        log_level="trace",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}", ping_interval=None) as websocket:
+            # Swallow outgoing pong frames so the server's ping never gets ack'd.
+            websocket.transport.write = lambda data: None  # type: ignore[method-assign]
+            with pytest.raises(websockets.exceptions.ConnectionClosedError) as exc_info:
+                await asyncio.wait_for(websocket.recv(), timeout=2)
+            assert exc_info.value.rcvd is not None
+            assert exc_info.value.rcvd.code == 1011
+            assert exc_info.value.rcvd.reason == "keepalive ping timeout"
+
+
+async def test_server_keepalive_disabled(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    config = Config(
+        app=app,
+        ws=WebSocketsSansIOProtocol,
+        http=http_protocol_cls,
+        lifespan="off",
+        ws_ping_interval=None,
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        reader, writer = await raw_ws_handshake("127.0.0.1", unused_tcp_port)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(reader.read(4096), timeout=0.3)
+        writer.close()

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1234,7 +1234,7 @@ async def test_server_keepalive_ping_pong(http_protocol_cls: HTTPProtocol, unuse
                 while protocol.last_ping_rtt == 0.0:
                     await asyncio.sleep(0.1)
 
-            await asyncio.wait_for(ping_roundtrip(), timeout=10.0)
+            await asyncio.wait_for(ping_roundtrip(), timeout=5.0)
             assert protocol.last_ping_rtt > 0
 
 

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -259,13 +259,13 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
         self.last_ping_rtt = self.loop.time() - self.ping_sent_at
         self.pending_ping_payload = None
-        # The peer answered in time; cancel the deadline that would have torn down the connection, then chain the next
-        # ping. This `schedule_ping()` call is what keeps the keepalive loop running; without it, we would send exactly
-        # one ping per connection.
+        # The peer answered in time; cancel the pong deadline and chain the next ping. This `schedule_ping()` call is
+        # what keeps the keepalive loop running when ping_timeout is set. When ping_timeout is None the next ping is
+        # already scheduled by `send_keepalive_ping`, so we must not schedule a duplicate here.
         if self.pong_timer is not None:
             self.pong_timer.cancel()
             self.pong_timer = None
-        self.schedule_ping()
+            self.schedule_ping()
 
     def start_keepalive(self) -> None:
         if self.ping_interval is not None and self.ping_interval > 0:

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -275,7 +275,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         if self.ping_timer is not None:
             self.ping_timer.cancel()
             self.ping_timer = None
-        if self.pong_timer is not None:
+        if self.pong_timer is not None:  # pragma: no cover
             self.pong_timer.cancel()
             self.pong_timer = None
         self.pending_ping_payload = None

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import random
+import struct
 import sys
+from asyncio import TimerHandle
 from asyncio.transports import BaseTransport, Transport
 from http import HTTPStatus
 from typing import Any, Literal, cast
@@ -92,6 +95,15 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.writable = asyncio.Event()
         self.writable.set()
 
+        # Keepalive state
+        self.ping_interval = config.ws_ping_interval
+        self.ping_timeout = config.ws_ping_timeout
+        self.ping_timer: TimerHandle | None = None
+        self.pong_timer: TimerHandle | None = None
+        self.pending_ping_payload: bytes | None = None
+        self.ping_sent_at: float = 0.0
+        self.last_ping_rtt: float = 0.0
+
         # Buffers
         self.bytes = b""
 
@@ -109,6 +121,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection made", prefix)
 
     def connection_lost(self, exc: Exception | None) -> None:
+        self.stop_keepalive()
         code = 1005 if self.handshake_complete else 1006
         self.queue.put_nowait({"type": "websocket.disconnect", "code": code})
         self.connections.remove(self)
@@ -125,6 +138,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         pass
 
     def shutdown(self) -> None:
+        self.stop_keepalive()
         if self.handshake_complete:
             self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
             self.conn.send_close(1012)
@@ -155,7 +169,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 elif event.opcode == Opcode.PING:
                     self.handle_ping()
                 elif event.opcode == Opcode.PONG:
-                    pass  # pragma: no cover
+                    self.handle_pong(event)
                 elif event.opcode == Opcode.CLOSE:
                     self.handle_close(event)
                 else:
@@ -238,6 +252,67 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         output = self.conn.data_to_send()
         self.transport.write(b"".join(output))
 
+    def handle_pong(self, event: Frame) -> None:
+        # Ignore unsolicited pongs and stale pongs whose payload doesn't match the ping currently in flight
+        if self.pending_ping_payload is None or bytes(event.data) != self.pending_ping_payload:
+            return  # pragma: no cover
+
+        self.last_ping_rtt = self.loop.time() - self.ping_sent_at
+        self.pending_ping_payload = None
+        # The peer answered in time; cancel the deadline that would have torn down the connection, then chain the next
+        # ping. This `schedule_ping()` call is what keeps the keepalive loop running; without it, we would send exactly
+        # one ping per connection.
+        if self.pong_timer is not None:
+            self.pong_timer.cancel()
+            self.pong_timer = None
+        self.schedule_ping()
+
+    def start_keepalive(self) -> None:
+        if self.ping_interval is not None and self.ping_interval > 0:
+            self.schedule_ping()
+
+    def stop_keepalive(self) -> None:
+        if self.ping_timer is not None:
+            self.ping_timer.cancel()
+            self.ping_timer = None
+        if self.pong_timer is not None:
+            self.pong_timer.cancel()
+            self.pong_timer = None
+        self.pending_ping_payload = None
+
+    def schedule_ping(self) -> None:
+        assert self.ping_interval is not None
+        delay = max(0.0, self.ping_interval - self.last_ping_rtt)
+        self.ping_timer = self.loop.call_later(delay, self.send_keepalive_ping)
+
+    def send_keepalive_ping(self) -> None:
+        self.ping_timer = None
+        if self.close_sent or self.transport.is_closing():  # pragma: no cover
+            return
+        # Random 4-byte payload identifies this ping; `handle_pong` uses it to ignore stale or unsolicited pongs.
+        # See https://github.com/python-websockets/websockets/blob/4d229bf9f583d593aa103287aee0a77c9fbc3a79/src/websockets/asyncio/connection.py#L624
+        self.pending_ping_payload = struct.pack("!I", random.getrandbits(32))
+        self.ping_sent_at = self.loop.time()
+        self.conn.send_ping(self.pending_ping_payload)
+        self.transport.write(b"".join(self.conn.data_to_send()))
+        if self.ping_timeout is not None:
+            self.pong_timer = self.loop.call_later(self.ping_timeout, self.keepalive_timeout)
+        else:  # pragma: no cover
+            self.schedule_ping()
+
+    def keepalive_timeout(self) -> None:
+        self.pong_timer = None
+        self.pending_ping_payload = None
+        if self.close_sent or self.transport.is_closing():  # pragma: no cover
+            return
+        if self.logger.level <= TRACE_LOG_LEVEL:
+            prefix = "%s:%d - " % self.client if self.client else ""
+            self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket keepalive ping timeout", prefix)
+        self.conn.fail(1011, "keepalive ping timeout")
+        self.transport.write(b"".join(self.conn.data_to_send()))
+        self.close_sent = True
+        self.transport.close()
+
     def handle_close(self, event: Frame) -> None:
         if not self.close_sent and not self.transport.is_closing():
             assert self.conn.close_rcvd is not None
@@ -311,6 +386,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                     self.conn.send_response(self.response)
                     output = self.conn.data_to_send()
                     self.transport.write(b"".join(output))
+                    self.start_keepalive()
 
             elif message["type"] == "websocket.close":
                 self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})


### PR DESCRIPTION
## Summary

- Adds server-side keepalive (ping/pong) to the websockets-sansio implementation, which previously ignored `ws_ping_interval` and `ws_ping_timeout`. Fixes #2883 for the sansio path.
- Uses two `asyncio.TimerHandle` primitives (one for the ping interval, one for the pong deadline) instead of a long-running task, mirroring the passive-timer style already used by the HTTP keep-alive in `httptools_impl.py:340-342`.
- At most one ping is in flight at a time, driven by the chain `schedule_ping` -> `send_keepalive_ping` -> `handle_pong` -> `schedule_ping`. If the pong does not arrive within `ws_ping_timeout`, `keepalive_timeout` fires and closes the connection with `conn.fail(1011, "keepalive ping timeout")`.
- Random 4-byte ping payloads via `struct.pack("!I", random.getrandbits(32))` for stale-pong detection, matching [`websockets.asyncio.connection.Connection.ping()`](https://github.com/python-websockets/websockets/blob/4d229bf9f583d593aa103287aee0a77c9fbc3a79/src/websockets/asyncio/connection.py#L624).
- Latency compensation (`sleep(ping_interval - last_ping_rtt)`) keeps the effective cadence stable under non-zero RTT, same as upstream.
- `ws_ping_interval=0` is treated as disabled so the existing `test_client_connection_lost` contract (which passes `ws_ping_interval=0.0`) keeps working.

## Why timers instead of a task

The other reasonable design is a long-running `asyncio.Task` with `await asyncio.wait_for(pong_future, timeout)`, as `websockets.asyncio.connection.Connection` does. That approach was explored in #2884. Two tradeoffs pushed this PR toward timers:

- **Matches the HTTP keep-alive idiom already in this codebase.** `httptools_impl.py` uses `loop.call_later` + a single `TimerHandle` for its idle-connection timeout; doing the same here gives us one keepalive pattern across the two protocols.
- **Cheaper and simpler cancellation.** No per-connection coroutine frame, no `CancelledError` handling, no "did the task actually stop" race - `timer.cancel()` is synchronous and atomic. Cancellation lives in only two places: `connection_lost` and `shutdown`.

The cost is that this no longer line-for-line mirrors the `websockets` reference. I believe the simplification is worth it given how thin the sansio impl already is.

## Test plan

- [x] Four new tests in `tests/protocols/test_websocket.py`, hard-coded to `WebSocketsSansIOProtocol` (no fixture skip dance):
  - `test_server_sends_keepalive_ping` - raw TCP client, asserts a FIN+PING frame (`0x89`) arrives.
  - `test_server_keepalive_ping_pong` - real `websockets` client auto-responds to pings, verifies the connection stays alive and echo still works across several roundtrips.
  - `test_server_keepalive_ping_timeout` - muzzles the client's outgoing writes so pongs are swallowed, asserts the server closes with code 1011 / `"keepalive ping timeout"`. Runs under `log_level="trace"` to cover the trace branch.
  - `test_server_keepalive_disabled` - `ws_ping_interval=None`, asserts no frames arrive within 300ms.
- [x] Full suite: `scripts/test` -> 1003 passed, 30 skipped, **100.00% coverage**.
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy uvicorn` all clean.
- [x] End-to-end smoke test against a running demo server: normal ping/pong + echo roundtrip, forced timeout (client muzzled), and raw TCP client observing a real FIN+PING frame with a random 4-byte payload - all passed.