### PR TITLE
fix code block rendering on docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ docs = [
     "mkdocs-material==9.7.1",
     "mkdocstrings-python==2.0.2",
     "mkdocs-llmstxt==0.5.0",
+    "pygments<2.20.0"
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -1246,11 +1246,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -1739,6 +1739,7 @@ docs = [
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings-python" },
+    { name = "pygments" },
 ]
 
 [package.metadata]
@@ -1783,6 +1784,7 @@ docs = [
     { name = "mkdocs-llmstxt", specifier = "==0.5.0" },
     { name = "mkdocs-material", specifier = "==9.7.1" },
     { name = "mkdocstrings-python", specifier = "==2.0.2" },
+    { name = "pygments", specifier = "<2.20.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

Code blocks were rendering the language identifier as plain text on [uvicorn.dev](https://uvicorn.dev/) across a few pages (Installation, Welcome, ASGI, Settings, ) like:
```
bash pip install uvicorn
```
instead of a proper highlighted code block.

Downgrading from `pygments==2.20.0` to `2.19.2` fixes the rendering.

**Warning⚠️:** While this fixes the rendering issue, upgrading to Pygments 2.20.0  currently [breaks MkDocs builds](https://github.com/mkdocs/mkdocs/issues/4098) and Pygments versions below 2.20.0 are affected by [CVE-2026-4539](https://nvd.nist.gov/vuln/detail/CVE-2026-4539).

Doing this for now to get the docs working, until MkDocs or Pygments comes up with a proper fix.

# Checklist
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.