### PR TITLE
Add Cloudflare Pages docs preview on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,53 @@ jobs:
         run: scripts/coverage
         shell: bash
 
+  docs-preview:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    environment:
+      name: cloudflare
+      url: ${{ steps.deploy.outputs.deployment-url }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: scripts/install
+
+      - name: Build docs
+        run: uv run mkdocs build
+
+      - name: Deploy preview to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: >
+            pages deploy ./site
+            --project-name uvicorn
+            --commit-hash ${{ github.event.pull_request.head.sha }}
+            --branch ${{ github.head_ref }}
+
+      - name: Comment preview URL on PR
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          message: |
+            :book: Docs preview: ${{ steps.deploy.outputs.deployment-url }}
+          comment-tag: docs-preview
+
   # https://github.com/marketplace/actions/alls-green#why
   check:
     if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
 
   docs-preview:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     permissions:
@@ -73,7 +73,7 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.12"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: scripts/install


### PR DESCRIPTION
## Summary

- Deploy docs to Cloudflare Pages on every PR using the PR branch name, which creates a preview deployment
- Automatically comment the preview URL on the PR (updates the same comment on subsequent pushes)

## Test plan

- [ ] Open a PR that touches docs and verify the preview URL appears as a comment
- [ ] Push again to the same PR and verify the comment is updated, not duplicated