### PR TITLE
Raise helpful `ImportError` when PyYAML is missing for YAML log config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -366,6 +366,15 @@ def test_log_config_yaml(
     mocked_logging_config_module.dictConfig.assert_called_once_with(logging_config)
 
 
+def test_log_config_yaml_missing_pyyaml(mocked_logging_config_module: MagicMock, mocker: MockerFixture) -> None:
+    """
+    Test that a helpful error is raised when PyYAML is not installed.
+    """
+    mocker.patch.dict(sys.modules, {"yaml": None})
+    with pytest.raises(ImportError, match=r"Install the PyYAML package or uvicorn\[standard\]"):
+        Config(app=asgi_app, log_config="log_config.yaml")
+
+
 @pytest.mark.parametrize("config_file", ["log_config.ini", configparser.ConfigParser(), io.StringIO()])
 def test_log_config_file(
     mocked_logging_config_module: MagicMock,

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -375,9 +375,12 @@ class Config:
                     loaded_config = json.load(file)
                     logging.config.dictConfig(loaded_config)
             elif isinstance(self.log_config, str) and self.log_config.endswith((".yaml", ".yml")):
-                # Install the PyYAML package or the uvicorn[standard] optional
-                # dependencies to enable this functionality.
-                import yaml
+                try:
+                    import yaml
+                except ImportError as e:
+                    raise ImportError(
+                        "Install the PyYAML package or uvicorn[standard] to use `--log-config` with YAML files."
+                    ) from e
 
                 with open(self.log_config) as file:
                     loaded_config = yaml.safe_load(file)


### PR DESCRIPTION
## Summary

- Wrap the YAML `import yaml` in a `try/except ImportError` and re-raise with a message pointing users at `PyYAML` / `uvicorn[standard]`.
- Previously users got a bare `ModuleNotFoundError: No module named 'yaml'` with no hint.

Split out from #2786.

Co-authored-by: Nuno André <mail@nunoand.re>

## Test plan

- [x] New `test_log_config_yaml_missing_pyyaml` patches `sys.modules["yaml"] = None` and asserts the helpful message.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I take full ownership of it.