### PR TITLE
Accept `log_level` strings case-insensitively

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -462,6 +462,13 @@ def test_config_log_effective_level(log_level: int, uvicorn_logger_level: int) -
     assert logging.getLogger("uvicorn.asgi").getEffectiveLevel() == effective_level
 
 
+@pytest.mark.parametrize("log_level", ["INFO", "Info", "info"])
+def test_config_log_level_case_insensitive(log_level: str) -> None:
+    config = Config(app=asgi_app, log_level=log_level)
+    config.load()
+    assert logging.getLogger("uvicorn.error").level == logging.INFO
+
+
 def test_ws_max_size() -> None:
     config = Config(app=asgi_app, ws_max_size=1000)
     config.load()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -389,7 +389,7 @@ class Config:
 
         if self.log_level is not None:
             if isinstance(self.log_level, str):
-                log_level = LOG_LEVELS[self.log_level]
+                log_level = LOG_LEVELS[self.log_level.lower()]
             else:
                 log_level = self.log_level
             logging.getLogger("uvicorn.error").setLevel(log_level)


### PR DESCRIPTION
## Summary

- Lowercase the `log_level` string before the `LOG_LEVELS` lookup so `"INFO"`, `"Info"`, and `"info"` are all accepted.
- Previously anything other than lowercase raised `KeyError` from the programmatic API (the CLI `click.Choice` already enforced lowercase).

Split out from #2786.

Co-authored-by: Nuno André <mail@nunoand.re>

## Test plan

- [x] New parametrized `test_config_log_level_case_insensitive` covers `"INFO"`, `"Info"`, `"info"`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I take full ownership of it.