### PR TITLE
Deliver chunked body when Upgrade header is rejected (#2722)

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -134,6 +134,32 @@ UPGRADE_HTTP2_REQUEST = b"\r\n".join(
     ]
 )
 
+UPGRADE_HTTP2_CHUNKED_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Transfer-Encoding: chunked\r\n",
+        b"Content-Type: application/json\r\n",
+        b"\r\n",
+        b"3\r\nabc\r\n0\r\n\r\n",
+    ]
+)
+
+UPGRADE_HTTP2_CONTENT_LENGTH_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Content-Length: 5\r\n",
+        b"Content-Type: application/json\r\n",
+        b"\r\n",
+        b"hello",
+    ]
+)
+
 INVALID_REQUEST_TEMPLATE = b"\r\n".join(
     [
         b"%s",
@@ -944,6 +970,50 @@ async def test_http2_upgrade_request(http_protocol_cls: type[HTTPProtocol], ws_p
     await protocol.loop.run_one()
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Hello, world" in protocol.transport.buffer
+
+
+async def test_http2_upgrade_chunked_body_is_preserved(http_protocol_cls: type[HTTPProtocol]):
+    """Rejected `Upgrade: h2c` requests must still deliver a chunked body
+    to the ASGI app (see #2722)."""
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        body = b""
+        more_body = True
+        while more_body:
+            message = await receive()
+            assert message["type"] == "http.request"
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+        response = Response(b"Body: " + body, media_type="text/plain")
+        await response(scope, receive, send)
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CHUNKED_POST_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: abc" in protocol.transport.buffer
+
+
+async def test_http2_upgrade_content_length_body_is_preserved(http_protocol_cls: type[HTTPProtocol]):
+    """Rejected `Upgrade: h2c` requests must still deliver a content-length
+    body to the ASGI app (see #2722)."""
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        body = b""
+        more_body = True
+        while more_body:
+            message = await receive()
+            assert message["type"] == "http.request"
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+        response = Response(b"Body: " + body, media_type="text/plain")
+        await response(scope, receive, send)
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CONTENT_LENGTH_POST_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: hello" in protocol.transport.buffer
 
 
 async def asgi3app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -42,6 +42,38 @@ def _get_status_line(status_code: int) -> bytes:
 STATUS_LINE = {status_code: _get_status_line(status_code) for status_code in range(100, 600)}
 
 
+class _BodyOnlyParserTarget:
+    """Callback target for a parser that replays a request with the Upgrade
+    headers stripped. Header callbacks are ignored (the scope has already
+    been set up); body and message-complete events are forwarded to the
+    existing ASGI cycle on the owning protocol.
+    """
+
+    def __init__(self, protocol: HttpToolsProtocol) -> None:
+        self._protocol = protocol
+
+    def on_message_begin(self) -> None: ...
+    def on_url(self, url: bytes) -> None: ...
+    def on_header(self, name: bytes, value: bytes) -> None: ...
+    def on_headers_complete(self) -> None: ...
+
+    def on_body(self, body: bytes) -> None:
+        cycle = self._protocol.cycle
+        if cycle is None or cycle.response_complete:
+            return
+        cycle.body += body
+        if len(cycle.body) > HIGH_WATER_LIMIT:
+            self._protocol.flow.pause_reading()
+        cycle.message_event.set()
+
+    def on_message_complete(self) -> None:
+        cycle = self._protocol.cycle
+        if cycle is None or cycle.response_complete:
+            return
+        cycle.more_body = False
+        cycle.message_event.set()
+
+
 class HttpToolsProtocol(asyncio.Protocol):
     def __init__(
         self,
@@ -176,11 +208,18 @@ class HttpToolsProtocol(asyncio.Protocol):
             self.logger.warning(msg)
             self.send_400_response(msg)
             return
-        except httptools.HttpParserUpgrade:
+        except httptools.HttpParserUpgrade as exc:
             if self._should_upgrade():
                 self.handle_websocket_upgrade()
-            else:
-                self._unsupported_upgrade_warning()
+                return
+            self._unsupported_upgrade_warning()
+            # Per RFC 7230 §6.7 a server MAY ignore an unsupported Upgrade
+            # header and continue to process the request. httptools aborts
+            # body parsing as soon as the upgrade is detected, so swap in a
+            # fresh parser that feeds any trailing body bytes back to the
+            # existing ASGI cycle (see #2722).
+            header_end = exc.args[0] if exc.args else len(data)
+            self._recover_after_rejected_upgrade(data[header_end:])
 
     def handle_websocket_upgrade(self) -> None:
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -304,7 +343,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             self.pipeline.appendleft((self.cycle, app))
 
     def on_body(self, body: bytes) -> None:
-        if (self.parser.should_upgrade() and self._should_upgrade()) or self.cycle.response_complete:
+        if self.parser.should_upgrade() or self.cycle.response_complete:
             return
         self.cycle.body += body
         if len(self.cycle.body) > HIGH_WATER_LIMIT:
@@ -312,10 +351,41 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.cycle.message_event.set()
 
     def on_message_complete(self) -> None:
-        if (self.parser.should_upgrade() and self._should_upgrade()) or self.cycle.response_complete:
+        if self.parser.should_upgrade() or self.cycle.response_complete:
             return
         self.cycle.more_body = False
         self.cycle.message_event.set()
+
+    def _recover_after_rejected_upgrade(self, trailing: bytes) -> None:
+        if self.cycle is None:
+            return
+        # Replay the request against a fresh parser with Upgrade/Connection
+        # tokens stripped, then forward body events to the already-running
+        # ASGI cycle via a minimal callback shim.
+        method = self.scope["method"].encode("ascii")
+        replay = [method, b" ", self.url, b" HTTP/1.1\r\n"]
+        for name, value in self.headers:
+            if name == b"upgrade":
+                continue
+            if name == b"connection":
+                kept = [t.strip() for t in value.split(b",") if t.strip().lower() != b"upgrade"]
+                if not kept:
+                    continue
+                value = b", ".join(kept)
+            replay.extend([name, b": ", value, b"\r\n"])
+        replay.append(b"\r\n")
+        target = _BodyOnlyParserTarget(self)
+        self.parser = httptools.HttpRequestParser(target)
+        try:
+            self.parser.set_dangerous_leniencies(lenient_data_after_close=True)
+        except AttributeError:  # pragma: no cover
+            pass
+        try:
+            self.parser.feed_data(b"".join(replay) + trailing)
+        except httptools.HttpParserError:
+            if self.cycle is not None and not self.cycle.response_complete:
+                self.cycle.more_body = False
+                self.cycle.message_event.set()
 
     def on_response_complete(self) -> None:
         # Callback for pipelined HTTP requests to be started.


### PR DESCRIPTION
# Summary

Fixes #2722.

When httptools receives an `Upgrade` header that Uvicorn does not handle
(e.g. `Upgrade: h2c` from Java's `RestClient`), it raises
`HttpParserUpgrade` before any `on_body`/`on_message_complete` event is
delivered for the request body. The ASGI app therefore receives an empty
body even though the client sent one, violating RFC 7230 §6.7, which
allows a server to ignore an unsupported `Upgrade` and process the
request normally.

This patch:
- Widens the `on_body` / `on_message_complete` guards to skip while the
  parser is in upgrade state (previously they only skipped when the
  upgrade would be accepted as WebSocket), so the cycle is not marked
  complete with an empty body.
- After the upgrade warning, swaps in a fresh `HttpRequestParser` backed
  by a small `_BodyOnlyParserTarget` and replays the request with the
  `Upgrade` / `Connection: Upgrade` tokens stripped. The trailing body
  bytes from the current chunk are fed immediately; any remaining body
  bytes in subsequent `data_received` calls flow through the new parser
  naturally. The existing ASGI cycle is reused, so no second response is
  ever sent.

A previous attempt at this (#2857) signalled message completion without
replaying the body, which prevented hangs but still dropped the payload;
this change actually delivers the body.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.