### PR TITLE
fix: preserve IPv6 transport addresses

### DIFF
--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -71,6 +71,9 @@ def test_get_local_addr():
     transport = MockTransport({"sockname": ("123.45.6.7", 123)})
     assert get_local_addr(transport) == ("123.45.6.7", 123)
 
+    transport = MockTransport({"sockname": ("::1", 123, 0, 0)})
+    assert get_local_addr(transport) == ("::1", 123)
+
     transport = MockTransport({})
     assert get_local_addr(transport) is None
 
@@ -81,6 +84,9 @@ def test_get_remote_addr():
 
     transport = MockTransport({"peername": ("123.45.6.7", 123)})
     assert get_remote_addr(transport) == ("123.45.6.7", 123)
+
+    transport = MockTransport({"peername": ("::1", 123, 0, 0)})
+    assert get_remote_addr(transport) == ("::1", 123)
 
 
 @pytest.mark.parametrize(

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -10,6 +10,14 @@ from uvicorn._types import WWWScope
 class ClientDisconnected(OSError): ...
 
 
+def _normalize_addr(info: tuple[object, ...] | list[object] | str) -> tuple[str, int | None] | None:
+    if isinstance(info, str):
+        return (info, None)
+    if isinstance(info, list | tuple) and len(info) >= 2:
+        return (str(info[0]), int(info[1]))
+    return None
+
+
 def get_remote_addr(transport: asyncio.Transport) -> tuple[str, int] | None:
     socket_info: socket.socket | None = transport.get_extra_info("socket")
     if socket_info is not None:
@@ -22,9 +30,10 @@ def get_remote_addr(transport: asyncio.Transport) -> tuple[str, int] | None:
             return None
 
     info = transport.get_extra_info("peername")
-    if info is not None and isinstance(info, list | tuple) and len(info) == 2:
-        return (str(info[0]), int(info[1]))
-    return None
+    if info is None:
+        return None
+    normalized = _normalize_addr(info)
+    return normalized if normalized is not None and normalized[1] is not None else None
 
 
 def get_local_addr(transport: asyncio.Transport) -> tuple[str, int | None] | None:
@@ -37,11 +46,9 @@ def get_local_addr(transport: asyncio.Transport) -> tuple[str, int | None] | Non
             return (info, None)
         return None
     info = transport.get_extra_info("sockname")
-    if info is not None and isinstance(info, list | tuple) and len(info) == 2:
-        return (str(info[0]), int(info[1]))
-    if isinstance(info, str):
-        return (info, None)
-    return None
+    if info is None:
+        return None
+    return _normalize_addr(info)
 
 
 def is_ssl(transport: asyncio.Transport) -> bool:


### PR DESCRIPTION

**Repo:** encode/uvicorn (⭐ 8800)
**Type:** bugfix
**Files changed:** 2
**Lines:** +21/-8

## What
Normalize `peername` and `sockname` values returned from transport metadata so Uvicorn preserves host and port information for IPv6 fallback tuples, not just two-item IPv4 tuples. The patch centralizes that normalization in `uvicorn/protocols/utils.py` and adds regression tests covering IPv6 transport metadata in `tests/protocols/test_utils.py`.

## Why
When `transport.get_extra_info("socket")` is unavailable, Uvicorn falls back to `peername` and `sockname`. On asyncio transports, IPv6 addresses can be exposed there as 4-tuples like `("::1", 123, 0, 0)`. The previous `len(...) == 2` check dropped those addresses entirely, which can remove client/server address information from request scope and logs. This fix keeps the existing behavior for IPv4 and Unix sockets while correctly handling the IPv6 form.

## Testing
Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/protocols/test_utils.py -o addopts=''` and the targeted test file passed (`6 passed`). Ran `ruff check uvicorn/protocols/utils.py tests/protocols/test_utils.py` and it passed. `uv run` was avoided because the sandbox blocks network access and the default cache location.

## Risk
Low / The change is narrowly scoped to address normalization and is covered by focused regression tests for the new IPv6 fallback case.
