### PR TITLE
Version 0.45.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,24 @@
 toc_depth: 2
 ---
 
+## 0.45.0 (April 21, 2026)
+
+### Added
+
+* Add `--reset-contextvars` flag to isolate ASGI request context (#2912)
+* Accept `os.PathLike` for `log_config` (#2905)
+* Accept `log_level` strings case-insensitively (#2907)
+
+### Changed
+
+* Revert "Emit `http.disconnect` on server shutdown for streaming responses" (#2913)
+* Revert "Explicitly start ASGI run with empty context" (#2911)
+
+### Fixed
+
+* Preserve forwarded client ports in proxy headers middleware (#2903)
+* Raise helpful `ImportError` when PyYAML is missing for YAML log config (#2906)
+
 ## 0.44.0 (April 6, 2026)
 
 ### Added

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,7 +9,6 @@ toc_depth: 2
 * Add `--reset-contextvars` flag to isolate ASGI request context (#2912)
 * Accept `os.PathLike` for `log_config` (#2905)
 * Accept `log_level` strings case-insensitively (#2907)
-* Preserve forwarded client ports in proxy headers middleware (#2903)
 
 ### Changed
 
@@ -18,6 +17,7 @@ toc_depth: 2
 
 ### Fixed
 
+* Preserve forwarded client ports in proxy headers middleware (#2903)
 * Raise helpful `ImportError` when PyYAML is missing for YAML log config (#2906)
 
 ## 0.44.0 (April 6, 2026)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,7 @@ toc_depth: 2
 * Add `--reset-contextvars` flag to isolate ASGI request context (#2912)
 * Accept `os.PathLike` for `log_config` (#2905)
 * Accept `log_level` strings case-insensitively (#2907)
+* Preserve forwarded client ports in proxy headers middleware (#2903)
 
 ### Changed
 
@@ -17,7 +18,6 @@ toc_depth: 2
 
 ### Fixed
 
-* Preserve forwarded client ports in proxy headers middleware (#2903)
 * Raise helpful `ImportError` when PyYAML is missing for YAML log config (#2906)
 
 ## 0.44.0 (April 6, 2026)

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.44.0"
+__version__ = "0.45.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## Summary

- New: `--reset-contextvars` flag (#2912), `os.PathLike` for `log_config` (#2905), case-insensitive `log_level` strings (#2907)
- Reverts: `http.disconnect` on server shutdown (#2913), empty context for ASGI runs (#2911)
- Fixes: forwarded client ports in proxy headers (#2903), helpful `ImportError` for missing PyYAML (#2906)

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.