### PR TITLE
Version 0.46.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,7 +9,7 @@ toc_depth: 2
 * Support `ws_max_size` in `wsproto` implementation (#2915)
 * Support `ws_ping_interval` and `ws_ping_timeout` in `wsproto` implementation (#2916)
 
-### Fixed
+### Changed
 
 * Use `bytearray` for incoming WebSocket message buffer in `websockets-sansio` (#2917)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,17 @@
 toc_depth: 2
 ---
 
+## 0.46.0 (April 23, 2026)
+
+### Added
+
+* Support `ws_max_size` in `wsproto` implementation (#2915)
+* Support `ws_ping_interval` and `ws_ping_timeout` in `wsproto` implementation (#2916)
+
+### Fixed
+
+* Use `bytearray` for incoming WebSocket message buffer in `websockets-sansio` (#2917)
+
 ## 0.45.0 (April 21, 2026)
 
 ### Added

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.45.0"
+__version__ = "0.46.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## Summary

Cut release 0.46.0.

### Added

- Support `ws_max_size` in `wsproto` implementation (#2915)
- Support `ws_ping_interval` and `ws_ping_timeout` in `wsproto` implementation (#2916)

### Fixed

- Use `bytearray` for incoming WebSocket message buffer in `websockets-sansio` (#2917)

## Test plan

- [x] Release notes entry added under `## 0.46.0 (April 23, 2026)`
- [x] `__version__` bumped to `0.46.0`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.