### PR TITLE
Handle HTTP half-closed connections

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -639,6 +639,21 @@ async def test_value_returned(http_protocol_cls: type[HTTPProtocol]):
     assert protocol.transport.is_closing()
 
 
+async def test_half_closed_connection_still_sends_response(http_protocol_cls: type[HTTPProtocol]):
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await asyncio.sleep(0)
+        await send({"type": "http.response.start", "status": 200})
+        await send({"type": "http.response.body", "body": b"Hello", "more_body": False})
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(SIMPLE_GET_REQUEST)
+    assert protocol.eof_received() is True
+    await protocol.loop.run_one()
+
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Hello" in protocol.transport.buffer
+
+
 async def test_early_disconnect(http_protocol_cls: type[HTTPProtocol]):
     got_disconnect_event = False
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -128,8 +128,10 @@ class H11Protocol(asyncio.Protocol):
             self.transport.close()
             self._unset_keepalive_if_required()
 
-    def eof_received(self) -> None:
-        pass
+    def eof_received(self) -> bool:
+        # A half-closed TCP connection means the client finished sending
+        # the request body, not that it stopped reading the response.
+        return True
 
     def _unset_keepalive_if_required(self) -> None:
         if self.timeout_keep_alive_task is not None:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -131,8 +131,10 @@ class HttpToolsProtocol(asyncio.Protocol):
 
         self.parser = None
 
-    def eof_received(self) -> None:
-        pass
+    def eof_received(self) -> bool:
+        # A half-closed TCP connection means the client finished sending
+        # the request body, not that it stopped reading the response.
+        return True
 
     def _unset_keepalive_if_required(self) -> None:
         if self.timeout_keep_alive_task is not None:


### PR DESCRIPTION
Fixes #1264

# Summary

Treat TCP half-close (`eof_received`) as "client finished sending request bytes", not as a disconnect from the response path.

This keeps the HTTP transport open for both h11 and httptools when the client calls `shutdown(SHUT_WR)`, so the ASGI app can still finish and send its response.

# Validation

- `ruff format uvicorn/protocols/http/h11_impl.py uvicorn/protocols/http/httptools_impl.py tests/protocols/test_http.py`
- `ruff check uvicorn/protocols/http/h11_impl.py uvicorn/protocols/http/httptools_impl.py tests/protocols/test_http.py`
- `pytest tests/protocols/test_http.py -k 'half_closed_connection_still_sends_response'`

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. Not needed for this protocol-level bug fix.