### PR TITLE
Treat `fd=0` as a valid file descriptor with reload/workers

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import socket
+import subprocess
 import sys
 from collections.abc import Callable, Iterator
 from contextlib import closing
@@ -550,6 +551,31 @@ def test_bind_fd_works_with_reload_or_workers(reload: bool, workers: int):  # pr
     assert sock.family == socket.AF_UNIX
     assert sock.getsockname() == ""
     sock.close()
+    fdsock.close()
+
+
+@pytest.mark.parametrize(
+    "reload, workers",
+    [
+        (True, 1),
+        (False, 2),
+    ],
+    ids=["--reload=True --workers=1", "--reload=False --workers=2"],
+)
+@pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
+def test_bind_stdin_works_with_reload_or_workers(reload: bool, workers: int):  # pragma: py-win32
+    fdsock = socket.socket(socket.AF_INET)
+    fdsock.bind(("127.0.0.1", 0))
+    code = f"""
+from uvicorn.config import Config
+config = Config(app="tests.test_config:asgi_app", fd=0, reload={reload}, workers={workers})
+config.load()
+sock = config.bind_socket()
+assert sock.getsockname() == {fdsock.getsockname()}
+sock.close()
+    """
+    code = ";".join(code.strip().splitlines())
+    subprocess.check_call([sys.executable, "-c", code], stdin=fdsock.fileno())
     fdsock.close()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import socket
-import subprocess
 import sys
 from collections.abc import Callable, Iterator
 from contextlib import closing
@@ -554,6 +553,19 @@ def test_bind_fd_works_with_reload_or_workers(reload: bool, workers: int):  # pr
     fdsock.close()
 
 
+@pytest.fixture
+def stdin_socket() -> Iterator[socket.socket]:  # pragma: py-win32
+    with closing(socket.socket(socket.AF_INET)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        saved_stdin = os.dup(0)
+        os.dup2(sock.fileno(), 0)
+        try:
+            yield sock
+        finally:
+            os.dup2(saved_stdin, 0)
+            os.close(saved_stdin)
+
+
 @pytest.mark.parametrize(
     "reload, workers",
     [
@@ -563,20 +575,13 @@ def test_bind_fd_works_with_reload_or_workers(reload: bool, workers: int):  # pr
     ids=["--reload=True --workers=1", "--reload=False --workers=2"],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
-def test_bind_stdin_works_with_reload_or_workers(reload: bool, workers: int):  # pragma: py-win32
-    fdsock = socket.socket(socket.AF_INET)
-    fdsock.bind(("127.0.0.1", 0))
-    code = f"""
-from uvicorn.config import Config
-config = Config(app="tests.test_config:asgi_app", fd=0, reload={reload}, workers={workers})
-config.load()
-sock = config.bind_socket()
-assert sock.getsockname() == {fdsock.getsockname()}
-sock.close()
-    """
-    code = ";".join(code.strip().splitlines())
-    subprocess.check_call([sys.executable, "-c", code], stdin=fdsock.fileno())
-    fdsock.close()
+def test_bind_stdin_works_with_reload_or_workers(
+    reload: bool, workers: int, stdin_socket: socket.socket
+):  # pragma: py-win32
+    config = Config(app=asgi_app, fd=0, reload=reload, workers=workers)
+    config.load()
+    with closing(config.bind_socket()) as sock:
+        assert sock.getsockname() == stdin_socket.getsockname()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -142,17 +142,13 @@ async def test_limit_max_requests_jitter(
     config = Config(
         app=app, limit_max_requests=1, limit_max_requests_jitter=2, port=unused_tcp_port, http=http_protocol_cls
     )
-    server = Server(config=config)
-    limit = server.limit_max_requests
-    assert limit is not None
-    assert 1 <= limit <= 3
-    task = asyncio.create_task(server.serve())
-    while not server.started:
-        await asyncio.sleep(0.01)
-    async with httpx.AsyncClient() as client:
-        for _ in range(limit + 1):
-            await client.get(f"http://127.0.0.1:{unused_tcp_port}")
-    await task
+    async with run_server(config) as server:
+        limit = server.limit_max_requests
+        assert limit is not None
+        assert 1 <= limit <= 3
+        async with httpx.AsyncClient() as client:
+            tasks = [client.get(f"http://127.0.0.1:{unused_tcp_port}") for _ in range(limit + 1)]
+            await asyncio.gather(*tasks)
     assert f"Maximum request limit of {limit} exceeded. Terminating process." in caplog.text
 
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -537,7 +537,7 @@ class Config:
 
     def bind_socket(self) -> socket.socket:
         logger_args: list[str | int]
-        if self.uds:  # pragma: py-win32
+        if self.uds is not None:  # pragma: py-win32
             path = self.uds
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             try:
@@ -552,7 +552,7 @@ class Config:
             sock_name_format = "%s"
             color_message = "Uvicorn running on " + click.style(sock_name_format, bold=True) + " (Press CTRL+C to quit)"
             logger_args = [self.uds]
-        elif self.fd:  # pragma: py-win32
+        elif self.fd is not None:  # pragma: py-win32
             sock = socket.fromfd(self.fd, socket.AF_UNIX, socket.SOCK_STREAM)
             message = "Uvicorn running on socket %s (Press CTRL+C to quit)"
             fd_name_format = "%s"


### PR DESCRIPTION
# Summary

Passing a socket as stdin (`--fd=0`) currently does not work in modes that use subprocesses (i.e. with `--reload` and `--workers`), because `config.fd` is checked for truthiness instead of for `None`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
