### PR TITLE
Use process supervisor with `workers=1`

### DIFF
--- a/docs/concepts/event-loop.md
+++ b/docs/concepts/event-loop.md
@@ -14,7 +14,7 @@ By default, Uvicorn uses `--loop auto`, which automatically selects:
 Since `uvloop` is not compatible with Windows or PyPy, it is not available on these platforms.
 
 On Windows, the asyncio implementation uses the standard [`ProactorEventLoop`][asyncio.ProactorEventLoop] in single-process mode.
-When running with `--reload` or multiple workers, it uses [`SelectorEventLoop`][asyncio.SelectorEventLoop] instead.
+When running with `--reload` or `--workers`, it uses [`SelectorEventLoop`][asyncio.SelectorEventLoop] instead.
 
 ??? info "Why can `ProactorEventLoop` fail with multiple processes on Windows?"
     If you want to know more about it, you can read the issue [#cpython/122240](https://github.com/python/cpython/issues/122240).

--- a/docs/concepts/lifespan.md
+++ b/docs/concepts/lifespan.md
@@ -5,8 +5,8 @@ This allows you to run **startup** and **shutdown** events for your application.
 The lifespan protocol is useful for initializing resources that need to be available throughout
 the lifetime of the application, such as database connections, caches, or other services.
 
-Keep in mind that the lifespan is executed **only once per application instance**. If you have
-multiple workers, each worker will execute the lifespan independently.
+Keep in mind that the lifespan is executed **only once per application instance**. If you use
+workers, each worker will execute the lifespan independently.
 
 ## Lifespan Architecture
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -253,7 +253,7 @@ uvicorn.run(
 )
 ```
 
-The factory is called inside each worker process, so it works with `--reload` and `--workers > 1`. The factory itself must be picklable in those modes (a top-level function is fine; lambdas and local closures are not). The `ssl_*` settings on `Config` are only consumed by `default_ssl_context_factory()`; if you build the context yourself without calling it, those settings are ignored.
+The factory is called inside each worker process, so it works with `--reload` and `--workers`. The factory itself must be picklable in those modes (a top-level function is fine; lambdas and local closures are not). The `ssl_*` settings on `Config` are only consumed by `default_ssl_context_factory()`; if you build the context yourself without calling it, those settings are ignored.
 
 ## Proxies and Forwarded Headers
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -74,7 +74,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 
 ## Production
 
-* `--workers <int>` - Number of worker processes. Defaults to the `$WEB_CONCURRENCY` environment variable if available, or 1. Not valid with `--reload`.
+* `--workers <int>` - Number of worker processes. Defaults to the `$WEB_CONCURRENCY` environment variable if available. Not valid with `--reload`.
 * `--env-file <path>` - Environment configuration file for the ASGI application. **Default:** *None*.
 * `--timeout-worker-healthcheck <int>` - Maximum number of seconds to wait for a worker to respond to a healthcheck. **Default:** *5*.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -513,14 +513,14 @@ def test_ws_max_queue() -> None:
 @pytest.mark.parametrize(
     "reload, workers",
     [
-        (True, 1),
+        (True, None),
         (False, 2),
     ],
-    ids=["--reload=True --workers=1", "--reload=False --workers=2"],
+    ids=["--reload=True --workers=None", "--reload=False --workers=2"],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
 def test_bind_unix_socket_works_with_reload_or_workers(
-    tmp_path: Path, reload: bool, workers: int, short_socket_name: str
+    tmp_path: Path, reload: bool, workers: int | None, short_socket_name: str
 ):  # pragma: py-win32
     config = Config(app=asgi_app, uds=short_socket_name, reload=reload, workers=workers)
     config.load()
@@ -534,13 +534,13 @@ def test_bind_unix_socket_works_with_reload_or_workers(
 @pytest.mark.parametrize(
     "reload, workers",
     [
-        (True, 1),
+        (True, None),
         (False, 2),
     ],
-    ids=["--reload=True --workers=1", "--reload=False --workers=2"],
+    ids=["--reload=True --workers=None", "--reload=False --workers=2"],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
-def test_bind_fd_works_with_reload_or_workers(reload: bool, workers: int):  # pragma: py-win32
+def test_bind_fd_works_with_reload_or_workers(reload: bool, workers: int | None):  # pragma: py-win32
     fdsock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     fd = fdsock.fileno()
     config = Config(app=asgi_app, fd=fd, reload=reload, workers=workers)
@@ -569,14 +569,14 @@ def stdin_socket() -> Iterator[socket.socket]:  # pragma: py-win32
 @pytest.mark.parametrize(
     "reload, workers",
     [
-        (True, 1),
+        (True, None),
         (False, 2),
     ],
-    ids=["--reload=True --workers=1", "--reload=False --workers=2"],
+    ids=["--reload=True --workers=None", "--reload=False --workers=2"],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
 def test_bind_stdin_works_with_reload_or_workers(
-    reload: bool, workers: int, stdin_socket: socket.socket
+    reload: bool, workers: int | None, stdin_socket: socket.socket
 ):  # pragma: py-win32
     config = Config(app=asgi_app, fd=0, reload=reload, workers=workers)
     config.load()
@@ -587,24 +587,24 @@ def test_bind_stdin_works_with_reload_or_workers(
 @pytest.mark.parametrize(
     "reload, workers, expected",
     [
-        (True, 1, True),
-        (False, 2, True),
-        (False, 1, False),
+        (True, None, True),
+        (False, 1, True),
+        (False, None, False),
     ],
     ids=[
-        "--reload=True --workers=1",
-        "--reload=False --workers=2",
+        "--reload=True --workers=None",
         "--reload=False --workers=1",
+        "--reload=False --workers=None",
     ],
 )
-def test_config_use_subprocess(reload: bool, workers: int, expected: bool):
+def test_config_use_subprocess(reload: bool, workers: int | None, expected: bool):
     config = Config(app=asgi_app, reload=reload, workers=workers)
     config.load()
     assert config.use_subprocess == expected
 
 
 def test_warn_when_using_reload_and_workers(caplog: pytest.LogCaptureFixture) -> None:
-    Config(app=asgi_app, reload=True, workers=2)
+    Config(app=asgi_app, reload=True, workers=1)
     assert len(caplog.records) == 1
     assert '"workers" flag is ignored when reloading is enabled.' in caplog.records[0].message
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -252,7 +252,7 @@ class Config:
         self.interface = interface
         self.reload = reload
         self.reload_delay = reload_delay
-        self.workers = workers or 1
+        self.workers = workers
         self.proxy_headers = proxy_headers
         self.server_header = server_header
         self.date_header = date_header
@@ -336,7 +336,7 @@ class Config:
             logger.info("Loading environment from '%s'", env_file)
             load_dotenv(dotenv_path=env_file)
 
-        if workers is None and "WEB_CONCURRENCY" in os.environ:
+        if self.workers is None and "WEB_CONCURRENCY" in os.environ:
             self.workers = int(os.environ["WEB_CONCURRENCY"])
 
         self.forwarded_allow_ips: list[str] | str
@@ -345,7 +345,7 @@ class Config:
         else:
             self.forwarded_allow_ips = forwarded_allow_ips  # pragma: full coverage
 
-        if self.reload and self.workers > 1:
+        if self.reload and self.workers is not None:
             logger.warning('"workers" flag is ignored when reloading is enabled.')
 
     @property
@@ -363,7 +363,7 @@ class Config:
 
     @property
     def use_subprocess(self) -> bool:
-        return bool(self.reload or self.workers > 1)
+        return self.reload or self.workers is not None
 
     def configure_logging(self) -> None:
         logging.addLevelName(TRACE_LOG_LEVEL, "TRACE")

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -114,7 +114,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     default=None,
     type=int,
     help="Number of worker processes. Defaults to the $WEB_CONCURRENCY environment"
-    " variable if available, or 1. Not valid with --reload.",
+    " variable if available. Not valid with --reload.",
 )
 @click.option(
     "--loop",
@@ -407,7 +407,7 @@ def main(
     reload_includes: list[str],
     reload_excludes: list[str],
     reload_delay: float,
-    workers: int,
+    workers: int | None,
     env_file: str,
     log_config: str,
     log_level: str,
@@ -601,7 +601,7 @@ def run(
         h11_max_incomplete_event_size=h11_max_incomplete_event_size,
         reset_contextvars=reset_contextvars,
     )
-    if (config.reload or config.workers > 1) and not isinstance(app, str):
+    if config.use_subprocess and not isinstance(app, str):
         logger = logging.getLogger("uvicorn.error")
         logger.warning("You must pass the application as an import string to enable 'reload' or 'workers'.")
         sys.exit(1)
@@ -613,7 +613,7 @@ def run(
         if config.should_reload:
             sock = config.bind_socket()
             ChangeReload(config, target=server.run, sockets=[sock]).run()
-        elif config.workers > 1:
+        elif config.workers is not None:
             sock = config.bind_socket()
             Multiprocess(config, target=server.run, sockets=[sock]).run()
         else:
@@ -621,10 +621,10 @@ def run(
     except KeyboardInterrupt:  # pragma: full coverage
         pass
     finally:
-        if config.uds and os.path.exists(config.uds):
+        if config.uds is not None and os.path.exists(config.uds):
             os.remove(config.uds)  # pragma: py-win32
 
-    if not server.started and not config.should_reload and config.workers == 1:
+    if not (server.started or config.use_subprocess):
         sys.exit(STARTUP_FAILURE)
 
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -137,9 +137,9 @@ class Server:
                 return fromshare(sock_data)
 
             self.servers: list[asyncio.base_events.Server] = []
+            is_windows = platform.system() == "Windows"
             for sock in sockets:
-                is_windows = platform.system() == "Windows"
-                if config.workers > 1 and is_windows:  # pragma: py-not-win32
+                if config.workers is not None and is_windows:  # pragma: py-not-win32
                     sock = _share_socket(sock)  # type: ignore[assignment]
                 server = await loop.create_server(create_protocol, sock=sock, ssl=config.ssl, backlog=config.backlog)
                 self.servers.append(server)

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -111,7 +111,7 @@ class Multiprocess:
         self.target = target
         self.sockets = sockets
 
-        self.processes_num = config.workers
+        self.processes_num = config.workers or 1
         self.processes: list[Process] = []
 
         self.should_exit = threading.Event()


### PR DESCRIPTION
# Summary

This enables process monitoring, so uvicorn will automatically restart the process if it dies or gets stuck, the same way as it does with multiple workers. Other features, like handling SIGHUP, SIGTTIN, SIGTTOU also work.

For cases where you don't need supervision, don't pass `--workers`. This is still the default.

Discussion: https://github.com/Kludex/uvicorn/discussions/2926

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
