### PR TITLE
Fix typo in `docs/deployment/index.md`.

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -82,7 +82,7 @@ The default process manager monitors the status of child processes and automatic
 
 You can also manage child processes by sending specific signals to the main process. (Not supported on Windows.)
 
-- `SIGHUP`: Work processeses are graceful restarted one after another. If you update the code, the new worker process will use the new code.
+- `SIGHUP`: Work processes are graceful restarted one after another. If you update the code, the new worker process will use the new code.
 - `SIGTTIN`: Increase the number of worker processes by one.
 - `SIGTTOU`: Decrease the number of worker processes by one.
 


### PR DESCRIPTION
# Summary

While reading https://uvicorn.dev/deployment/#built-in, I noticed a typo saying "processes**es**" instead of "processes".

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
    - Doesn't apply here :)
- [x] I've updated the documentation accordingly.
    - This updates documentation _only_ :)
