### PR TITLE
Drop unused contents/actions permissions from zizmor workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,8 +14,6 @@ jobs:
 
     permissions:
       security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
-      contents: read # Only needed for private repos. Needed to clone the repo.
-      actions: read # Only needed for private repos. Needed for upload-sarif to read workflow run info.
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- The `contents: read` and `actions: read` lines are only needed for private repos; uvicorn is public, so both are unnecessary.
- `security-events: write` is the only permission `zizmorcore/zizmor-action` actually requires to upload SARIF.

## Test plan

- [ ] zizmor workflow still runs and uploads SARIF to code scanning on this PR.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.