### PR TITLE
Default `ssl_ciphers` to `None` and use OpenSSL defaults

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -134,7 +134,7 @@ The [SSL context](https://docs.python.org/3/library/ssl.html#ssl.SSLContext) can
 * `--ssl-version <int>` - The SSL version to use. **Default:** *ssl.PROTOCOL_TLS_SERVER*.
 * `--ssl-cert-reqs <int>` - Whether client certificate is required. **Default:** *ssl.CERT_NONE*.
 * `--ssl-ca-certs <str>` - The CA certificates file.
-* `--ssl-ciphers <str>` - The ciphers to use. **Default:** *"TLSv1"*.
+* `--ssl-ciphers <str>` - The ciphers to use. **Default:** OpenSSL's safe defaults.
 
 To understand more about the SSL context options, please refer to the [Python documentation](https://docs.python.org/3/library/ssl.html).
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -199,6 +199,20 @@ def test_ssl_context_factory_must_return_ssl_context() -> None:
         config.load()
 
 
+def test_ssl_ciphers_applied_when_set(
+    tls_certificate_server_cert_path: str,
+    tls_certificate_private_key_path: str,
+) -> None:
+    config = Config(
+        app=app,
+        ssl_keyfile=tls_certificate_private_key_path,
+        ssl_certfile=tls_certificate_server_cert_path,
+        ssl_ciphers="HIGH",
+    )
+    config.load()
+    assert isinstance(config.ssl, ssl.SSLContext)
+
+
 def test_is_ssl_true_when_only_factory_set() -> None:
     def ssl_context_factory(config: Config, default_ssl_context_factory: DefaultFactory) -> ssl.SSLContext:
         return ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)  # pragma: no cover

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -224,7 +224,7 @@ class Config:
         ssl_version: int = SSL_PROTOCOL_VERSION,
         ssl_cert_reqs: int = ssl.CERT_NONE,
         ssl_ca_certs: str | os.PathLike[str] | None = None,
-        ssl_ciphers: str = "TLSv1",
+        ssl_ciphers: str | None = None,
         ssl_context_factory: Callable[[Config, Callable[[], ssl.SSLContext]], ssl.SSLContext] | None = None,
         headers: list[tuple[str, str]] | None = None,
         factory: bool = False,

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -340,8 +340,8 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
 @click.option(
     "--ssl-ciphers",
     type=str,
-    default="TLSv1",
-    help="Ciphers to use (see stdlib ssl module's)",
+    default=None,
+    help="Ciphers to use (see stdlib ssl module's). Defaults to OpenSSL's safe defaults.",
     show_default=True,
 )
 @click.option(
@@ -430,7 +430,7 @@ def main(
     ssl_version: int,
     ssl_cert_reqs: int,
     ssl_ca_certs: str,
-    ssl_ciphers: str,
+    ssl_ciphers: str | None,
     headers: list[str],
     use_colors: bool,
     app_dir: str,
@@ -537,7 +537,7 @@ def run(
     ssl_version: int = SSL_PROTOCOL_VERSION,
     ssl_cert_reqs: int = ssl.CERT_NONE,
     ssl_ca_certs: str | os.PathLike[str] | None = None,
-    ssl_ciphers: str = "TLSv1",
+    ssl_ciphers: str | None = None,
     ssl_context_factory: Callable[[Config, Callable[[], ssl.SSLContext]], ssl.SSLContext] | None = None,
     headers: list[tuple[str, str]] | None = None,
     use_colors: bool | None = None,


### PR DESCRIPTION
## Summary

- Change the default of `ssl_ciphers` (Config, `run()`, and `--ssl-ciphers`) from `"TLSv1"` to `None`.
- When `None`, `create_ssl_context()` already skips `ctx.set_ciphers(...)`, so OpenSSL's current safe defaults apply.
- Update the docs entry in `docs/settings.md` to match.

The previous `"TLSv1"` value is an OpenSSL cipher *string* (not a protocol selector) that resolves to every cipher available in TLS 1.0 - an outdated baseline that doesn't track modern best practice. Letting OpenSSL pick its defaults keeps the cipher list current as the library evolves, without uvicorn freezing a string in place.

## Test plan

- [x] `uv run pytest tests/test_ssl.py tests/test_config.py tests/test_main.py` - 143 passed
- [x] `uv run ruff check uvicorn && uv run ruff format --check uvicorn`
- [x] `uv run mypy uvicorn`
- [ ] CI green

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.