### PR TITLE
Ignore duplicate forwarding headers in `ProxyHeadersMiddleware`

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -10,7 +10,7 @@ import websockets.client
 
 from tests.response import Response
 from tests.utils import run_server
-from uvicorn._types import ASGIReceiveCallable, ASGIReceiveEvent, ASGISendCallable, ASGISendEvent, Scope
+from uvicorn._types import ASGIReceiveCallable, ASGIReceiveEvent, ASGISendCallable, ASGISendEvent, HTTPScope, Scope
 from uvicorn.config import Config
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware, _TrustedHosts
 
@@ -556,61 +556,65 @@ async def test_proxy_headers_empty_x_forwarded_for() -> None:
     assert response.text == "https://127.0.0.1:123"
 
 
+def _make_http_scope(headers: list[tuple[bytes, bytes]], scheme: str = "http") -> HTTPScope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": scheme,
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers,
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 80),
+    }
+
+
+async def _noop_receive() -> ASGIReceiveEvent:
+    return {"type": "http.disconnect"}
+
+
+async def _noop_send(message: ASGISendEvent) -> None:
+    return None
+
+
 @pytest.mark.anyio
 async def test_proxy_headers_duplicate_x_forwarded_for_is_ignored() -> None:
-    client: tuple[str, int] | None = ("127.0.0.1", 12345)
+    captured: dict[str, tuple[str, int] | None] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
         assert scope["type"] == "http"
-        nonlocal client
-        client = scope["client"]
+        captured["client"] = scope["client"]
 
-    async def receive() -> ASGIReceiveEvent: ...
-
-    async def send(message: ASGISendEvent) -> None: ...
-
-    app = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
-    await app(
-        {
-            "type": "http",  # type: ignore[typeddict-item]
-            "scheme": "http",
-            "client": client,
-            "headers": [
-                (b"x-forwarded-for", b"198.51.100.23, 127.0.0.1"),
-                (b"x-forwarded-for", b"203.0.113.66"),
-            ],
-        },
-        receive,
-        send,
+    middleware = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
+    scope = _make_http_scope(
+        [
+            (b"x-forwarded-for", b"198.51.100.23, 127.0.0.1"),
+            (b"x-forwarded-for", b"203.0.113.66"),
+        ]
     )
-    assert client == ("127.0.0.1", 12345)
+    await middleware(scope, _noop_receive, _noop_send)
+    assert captured["client"] == ("127.0.0.1", 12345)
 
 
 @pytest.mark.anyio
 async def test_proxy_headers_duplicate_x_forwarded_proto_is_ignored() -> None:
-    scheme = "http"
+    captured: dict[str, str] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
         assert scope["type"] == "http"
-        nonlocal scheme
-        scheme = scope["scheme"]
+        captured["scheme"] = scope["scheme"]
 
-    async def receive() -> ASGIReceiveEvent: ...
-
-    async def send(message: ASGISendEvent) -> None: ...
-
-    app = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
-    await app(
-        {
-            "type": "http",  # type: ignore[typeddict-item]
-            "scheme": scheme,
-            "client": ("127.0.0.1", 12345),
-            "headers": [
-                (b"x-forwarded-proto", b"http"),
-                (b"x-forwarded-proto", b"https"),
-            ],
-        },
-        receive,
-        send,
+    middleware = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
+    scope = _make_http_scope(
+        [
+            (b"x-forwarded-proto", b"http"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+        scheme="http",
     )
-    assert scheme == "http"
+    await middleware(scope, _noop_receive, _noop_send)
+    assert captured["scheme"] == "http"

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -10,7 +10,7 @@ import websockets.client
 
 from tests.response import Response
 from tests.utils import run_server
-from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
+from uvicorn._types import ASGIReceiveCallable, ASGIReceiveEvent, ASGISendCallable, ASGISendEvent, Scope
 from uvicorn.config import Config
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware, _TrustedHosts
 
@@ -554,3 +554,63 @@ async def test_proxy_headers_empty_x_forwarded_for() -> None:
         response = await client.get("/", headers=headers)
     assert response.status_code == 200
     assert response.text == "https://127.0.0.1:123"
+
+
+@pytest.mark.anyio
+async def test_proxy_headers_duplicate_x_forwarded_for_is_ignored() -> None:
+    client: tuple[str, int] | None = ("127.0.0.1", 12345)
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        nonlocal client
+        client = scope["client"]
+
+    async def receive() -> ASGIReceiveEvent: ...
+
+    async def send(message: ASGISendEvent) -> None: ...
+
+    app = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
+    await app(
+        {
+            "type": "http",  # type: ignore[typeddict-item]
+            "scheme": "http",
+            "client": client,
+            "headers": [
+                (b"x-forwarded-for", b"198.51.100.23, 127.0.0.1"),
+                (b"x-forwarded-for", b"203.0.113.66"),
+            ],
+        },
+        receive,
+        send,
+    )
+    assert client == ("127.0.0.1", 12345)
+
+
+@pytest.mark.anyio
+async def test_proxy_headers_duplicate_x_forwarded_proto_is_ignored() -> None:
+    scheme = "http"
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        nonlocal scheme
+        scheme = scope["scheme"]
+
+    async def receive() -> ASGIReceiveEvent: ...
+
+    async def send(message: ASGISendEvent) -> None: ...
+
+    app = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
+    await app(
+        {
+            "type": "http",  # type: ignore[typeddict-item]
+            "scheme": scheme,
+            "client": ("127.0.0.1", 12345),
+            "headers": [
+                (b"x-forwarded-proto", b"http"),
+                (b"x-forwarded-proto", b"https"),
+            ],
+        },
+        receive,
+        send,
+    )
+    assert scheme == "http"

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -573,11 +573,11 @@ def _make_http_scope(headers: list[tuple[bytes, bytes]], scheme: str = "http") -
     }
 
 
-async def _noop_receive() -> ASGIReceiveEvent:
+async def _noop_receive() -> ASGIReceiveEvent:  # pragma: no cover
     return {"type": "http.disconnect"}
 
 
-async def _noop_send(message: ASGISendEvent) -> None:
+async def _noop_send(message: ASGISendEvent) -> None:  # pragma: no cover
     return None
 
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -32,10 +32,17 @@ class ProxyHeadersMiddleware:
         client_host = client_addr[0] if client_addr else None
 
         if client_host in self.trusted_hosts:
-            headers = dict(scope["headers"])
+            x_forwarded_proto_values: list[bytes] = []
+            x_forwarded_for_values: list[bytes] = []
+            for name, value in scope["headers"]:
+                if name == b"x-forwarded-proto":
+                    x_forwarded_proto_values.append(value)
+                elif name == b"x-forwarded-for":
+                    x_forwarded_for_values.append(value)
 
-            if b"x-forwarded-proto" in headers:
-                x_forwarded_proto = headers[b"x-forwarded-proto"].decode("latin1").strip()
+            # Only consume the header when exactly one copy is present to avoid spoofing issues.
+            if len(x_forwarded_proto_values) == 1:
+                x_forwarded_proto = x_forwarded_proto_values[0].decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":
@@ -43,8 +50,8 @@ class ProxyHeadersMiddleware:
                     else:
                         scope["scheme"] = x_forwarded_proto
 
-            if b"x-forwarded-for" in headers:
-                x_forwarded_for = headers[b"x-forwarded-for"].decode("latin1")
+            if len(x_forwarded_for_values) == 1:
+                x_forwarded_for = x_forwarded_for_values[0].decode("latin1")
                 host, port = self.trusted_hosts.get_trusted_client_address(x_forwarded_for)
 
                 if host:


### PR DESCRIPTION
## Summary

`ProxyHeadersMiddleware` converted `scope["headers"]` to a `dict` before reading `X-Forwarded-For` and `X-Forwarded-Proto`. ASGI preserves the headers as a list of `(name, value)` tuples, and duplicate names are allowed - passing such a list to `dict()` silently keeps only the last value.

When duplicate forwarding headers reached the middleware, only the last value was used to populate `scope["client"]` and `scope["scheme"]`, even though the previous proxy in the chain may have appended its own value while passing a client-supplied duplicate through. The result was ambiguous and surprising.

## Changes

- Iterate `scope["headers"]` once, collecting each forwarding header into its own list.
- Only consume `X-Forwarded-For` / `X-Forwarded-Proto` when exactly one copy is present. If more than one copy is seen, the middleware ignores the forwarded value and leaves `scope["client"]` / `scope["scheme"]` untouched.
- Added two regression tests driving the middleware directly with crafted ASGI scopes.

## Test plan

- [x] `uv run pytest tests/middleware/test_proxy_headers.py` - 263 passed
- [x] `uv run ruff check uvicorn/middleware/proxy_headers.py tests/middleware/test_proxy_headers.py`
- [x] `uv run ruff format --check uvicorn/middleware/proxy_headers.py tests/middleware/test_proxy_headers.py`
- [x] `uv run mypy uvicorn/middleware/proxy_headers.py`
- [x] Confirmed the new regression tests fail on `main` without the middleware change

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.