### PR TITLE
Force-kill reload worker that does not exit within grace period

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -399,3 +399,38 @@ def test_base_reloader_closes_sockets_on_shutdown():
     assert sock.fileno() != -1
     reloader.shutdown()
     assert sock.fileno() == -1
+
+
+def test_restart_kills_worker_that_does_not_exit(mocker: MockerFixture):
+    """A worker that doesn't exit after ``terminate()`` is force-killed instead of
+    blocking the reloader forever on an unbounded ``join()``."""
+    config = Config(app="tests.test_config:asgi_app", reload=True, timeout_graceful_shutdown=1)
+    reloader = BaseReload(config, target=run, sockets=[])
+
+    old_process = mocker.MagicMock()
+    old_process.is_alive.return_value = True
+    reloader.process = old_process
+    new_process = mocker.patch("uvicorn.supervisors.basereload.get_subprocess").return_value
+
+    reloader.restart()
+
+    old_process.join.assert_any_call(1)
+    old_process.kill.assert_called_once()
+    # A fresh worker is started after the old one is dealt with.
+    assert reloader.process is new_process
+    new_process.start.assert_called_once()
+
+
+def test_shutdown_does_not_kill_worker_that_exits(mocker: MockerFixture):
+    """When the worker exits within the grace period it is not force-killed."""
+    config = Config(app="tests.test_config:asgi_app", reload=True)
+    reloader = BaseReload(config, target=run, sockets=[])
+
+    process = mocker.MagicMock()
+    process.is_alive.return_value = False
+    reloader.process = process
+
+    reloader.shutdown()
+
+    process.join.assert_called_once_with(5)
+    process.kill.assert_not_called()

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -401,28 +401,25 @@ def test_base_reloader_closes_sockets_on_shutdown():
     assert sock.fileno() == -1
 
 
-def test_restart_kills_worker_that_does_not_exit(mocker: MockerFixture):
-    """A worker that doesn't exit after ``terminate()`` is force-killed instead of
+def test_join_process_kills_worker_that_does_not_exit(mocker: MockerFixture):
+    """A worker that is still alive after the grace period is force-killed instead of
     blocking the reloader forever on an unbounded ``join()``."""
     config = Config(app="tests.test_config:asgi_app", reload=True, timeout_graceful_shutdown=1)
     reloader = BaseReload(config, target=run, sockets=[])
 
-    old_process = mocker.MagicMock()
-    old_process.is_alive.return_value = True
-    reloader.process = old_process
-    new_process = mocker.patch("uvicorn.supervisors.basereload.get_subprocess").return_value
+    process = mocker.MagicMock()
+    process.is_alive.return_value = True
+    reloader.process = process
 
-    reloader.restart()
+    reloader._join_process()
 
-    old_process.join.assert_any_call(1)
-    old_process.kill.assert_called_once()
-    # A fresh worker is started after the old one is dealt with.
-    assert reloader.process is new_process
-    new_process.start.assert_called_once()
+    process.join.assert_any_call(1)
+    process.kill.assert_called_once()
 
 
-def test_shutdown_does_not_kill_worker_that_exits(mocker: MockerFixture):
-    """When the worker exits within the grace period it is not force-killed."""
+def test_join_process_does_not_kill_worker_that_exits(mocker: MockerFixture):
+    """When the worker exits within the grace period it is not force-killed, and the
+    default grace period is used when ``timeout_graceful_shutdown`` is unset."""
     config = Config(app="tests.test_config:asgi_app", reload=True)
     reloader = BaseReload(config, target=run, sockets=[])
 
@@ -430,7 +427,7 @@ def test_shutdown_does_not_kill_worker_that_exits(mocker: MockerFixture):
     process.is_alive.return_value = False
     reloader.process = process
 
-    reloader.shutdown()
+    reloader._join_process()
 
     process.join.assert_called_once_with(5)
     process.kill.assert_not_called()

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -20,6 +20,10 @@ HANDLED_SIGNALS = (
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
 
+# Fallback grace period (seconds) to wait for a worker to exit after it has been
+# asked to terminate, used when ``timeout_graceful_shutdown`` is not configured.
+DEFAULT_PROCESS_JOIN_TIMEOUT = 5
+
 logger = logging.getLogger("uvicorn.error")
 
 
@@ -84,6 +88,18 @@ class BaseReload:
         self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
         self.process.start()
 
+    def _join_process(self) -> None:
+        # A worker that is still serving a long-lived connection (SSE, WebSocket,
+        # chunked streaming) won't exit until that connection closes, so wait only
+        # for the configured grace period and force-kill it if it overstays. An
+        # unbounded ``join()`` here would block the reloader forever.
+        timeout = self.config.timeout_graceful_shutdown or DEFAULT_PROCESS_JOIN_TIMEOUT
+        self.process.join(timeout)
+        if self.process.is_alive():
+            logger.warning("Worker did not stop within %ss, killing it.", timeout)
+            self.process.kill()
+            self.process.join()
+
     def restart(self) -> None:
         if sys.platform == "win32":  # pragma: py-not-win32
             self.is_restarting = True
@@ -95,7 +111,7 @@ class BaseReload:
             sys.stdout.flush()
         else:  # pragma: py-win32
             self.process.terminate()
-        self.process.join()
+        self._join_process()
 
         self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
         self.process.start()
@@ -105,7 +121,7 @@ class BaseReload:
             self.should_exit.set()  # pragma: py-not-win32
         else:
             self.process.terminate()  # pragma: py-win32
-        self.process.join()
+        self._join_process()
 
         for sock in self.sockets:
             sock.close()


### PR DESCRIPTION
# Summary

Fixes #2943.

`BaseReload.restart()` and `BaseReload.shutdown()` call `self.process.join()` with no timeout. A worker that is still serving a long-lived connection (SSE, WebSocket, chunked streaming) does not exit when it receives `SIGTERM` — it waits for those connections to drain first. As a result `join()` blocks indefinitely: the reload path never reaches `get_subprocess(...)`, no new worker is started, and hot-reload silently hangs.

## Reproduce

1. Run an app under `--reload` with an endpoint that holds a connection open (e.g. an SSE stream).
2. Keep a client connected.
3. Edit a watched file.

`WatchFiles detected changes ...` is logged and the worker receives `SIGTERM`, but the new worker never appears — the reloader is stuck on `process.join()`.

## Fix

Wait for the worker for `timeout_graceful_shutdown` seconds (falling back to 5s when it isn't configured) and send `SIGKILL` if it's still alive afterwards. Reusing `timeout_graceful_shutdown` keeps the grace period consistent with the server's own shutdown timeout and adds no new config surface. This mirrors the `terminate()` / `kill()` escalation the multiprocess supervisor already uses.

The join + force-kill logic is shared between `restart()` and `shutdown()` via a small helper.

## Test plan

- [x] Added `test_restart_kills_worker_that_does_not_exit` and `test_shutdown_does_not_kill_worker_that_exits`; both fail on `main` (the old `join()` is unbounded and never escalates to `kill()`).
- [x] `scripts/test` — full suite passes, `basereload.py` stays at 100% coverage.
- [x] `scripts/check` — ruff format, ruff check and mypy all pass.