### PR TITLE
Version 0.48.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,16 @@
 toc_depth: 2
 ---
 
+## 0.48.0 (May 24, 2026)
+
+### Changed
+
+* Default `ssl_ciphers` to `None` and use OpenSSL defaults (#2940)
+
+### Fixed
+
+* Ignore duplicate forwarding headers in `ProxyHeadersMiddleware` (#2944)
+
 ## 0.47.0 (May 14, 2026)
 
 ### Added

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## Summary

Release 0.48.0.

### Changed

* Default `ssl_ciphers` to `None` and use OpenSSL defaults (#2940)

### Fixed

* Ignore duplicate forwarding headers in `ProxyHeadersMiddleware` (#2944)

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.