### PR TITLE
Pin CodSpeed action to a SHA matching its version comment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30 # v4
+        uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:
           mode: instrumentation
           run: uv run pytest tests/benchmarks/ --codspeed -n 0


### PR DESCRIPTION
## Summary

Resolves the open `zizmor/ref-version-mismatch` code-scanning alert on `.github/workflows/benchmark.yml`.

The `CodSpeedHQ/action` step was pinned to `db35df7...` with a `# v4` comment. That SHA is actually `v4.13.1`, not the current `v4` tag (which resolves to `v4.15.1`), so the comment was misleading and zizmor flagged the mismatch. Repointed to `v4.15.1` (`3194d9a...`) with a precise version comment.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.