### PR TITLE
Fix: Install signal handlers immediately

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -326,8 +326,11 @@ class Server:
             return
         # always use signal.signal, even if loop.add_signal_handler is available
         # this allows to restore previous signal handlers later on
-        original_handlers = {sig: signal.signal(sig, self.handle_exit) for sig in HANDLED_SIGNALS}
+        original_handlers = {}
         try:
+            original_handlers = {
+                sig: signal.signal(sig, self.handle_exit) for sig in HANDLED_SIGNALS
+            }
             yield
         finally:
             for sig, handler in original_handlers.items():


### PR DESCRIPTION
This PR fixes a bug where CTRL^C would not work while the server was starting up. This was because the signal handlers were not being installed until after the on_startup functions had completed.

This PR fixes the issue by installing the signal handlers immediately, before the on_startup functions are called.