### PR TITLE
Skip docs preview deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         shell: bash
 
   docs-preview:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Dependabot PRs run with the `dependabot[bot]` actor, which GitHub denies access to repository secrets. The `docs-preview` job's condition only checks that the PR branch lives in this repo (true for Dependabot), so the job runs and the Cloudflare Pages deploy fails with `✘ [ERROR] Not logged in.` because `secrets.CLOUDFLARE_API_TOKEN` is empty.

Exclude `dependabot[bot]` from the job - it cannot, and should not, deploy a preview.

Surfaced by #2960.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the `docs-preview` job for Dependabot PRs to avoid failing Cloudflare Pages deploys when secrets are not available. Adds `github.actor != 'dependabot[bot]'` to the job condition so only non-Dependabot PRs deploy a docs preview.

<sup>Written for commit f190cb1721fb3f03af02a2852c3be250b5b7f4f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/2961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

