### PR TITLE
Gate docs preview deploy on Cloudflare token presence

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      HAS_CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
 
     permissions:
       contents: read
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy preview to Cloudflare Pages
         id: deploy
-        if: ${{ env.CLOUDFLARE_API_TOKEN != '' }}
+        if: ${{ env.HAS_CLOUDFLARE_TOKEN == 'true' }}
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,11 @@ jobs:
         shell: bash
 
   docs-preview:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
     permissions:
       contents: read
@@ -83,6 +86,7 @@ jobs:
 
       - name: Deploy preview to Cloudflare Pages
         id: deploy
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' }}
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -93,6 +97,7 @@ jobs:
             --branch ${{ github.head_ref }}
 
       - name: Comment preview URL on PR
+        if: ${{ steps.deploy.outcome == 'success' }}
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |


### PR DESCRIPTION
The `docs-preview` job was skipped for Dependabot via `github.actor != 'dependabot[bot]'`. That guard is fragile: it tracks *who pushed last*, not *whether the deploy secrets exist*. The moment a human merges `main` into a Dependabot branch (as happened on #2960), `github.actor` flips to the merger, the job runs, and the Cloudflare deploy fails with an empty account id - the request hits `/accounts//pages/projects/uvicorn` and Cloudflare returns error 7003.

This gates the actual precondition instead: the deploy step runs only when `CLOUDFLARE_API_TOKEN` is present. `secrets` can't be referenced in a step `if:`, so the token is surfaced into a job-level `env` first. The preview-URL comment is also gated on the deploy having succeeded, so a skipped deploy doesn't post an empty URL.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.