### PR TITLE
Migrate docs deploy from Cloudflare Pages to Workers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,17 +84,14 @@ jobs:
       - name: Build docs
         run: uv run zensical build
 
-      - name: Deploy preview to Cloudflare Pages
+      - name: Deploy preview to Cloudflare Workers
         id: deploy
         if: ${{ env.HAS_CLOUDFLARE_TOKEN == 'true' }}
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: >
-            pages deploy ./site
-            --project-name uvicorn
-            --commit-hash ${{ github.event.pull_request.head.sha }}
-            --branch ${{ github.head_ref }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: versions upload --tag pr-${{ github.event.pull_request.number }}
 
       - name: Comment preview URL on PR
         if: ${{ steps.deploy.outcome == 'success' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,11 +105,8 @@ jobs:
           name: documentation
           path: site/
 
-      - uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          command: >
-            pages deploy ./site
-            --project-name uvicorn
-            --commit-hash ${{ github.sha }}
-            --branch main
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "uvicorn"
+compatibility_date = "2026-05-22"
+workers_dev = true
+
+[assets]
+directory = "./site"
+not_found_handling = "404-page"


### PR DESCRIPTION
Mirrors the Cloudflare Workers setup now used in Starlette, replacing the Cloudflare Pages deploy.

- Adds `wrangler.toml` serving `./site` as Worker static assets (`not_found_handling = "404-page"`).
- PR previews: `versions upload --tag pr-<number>` (preview URL in `steps.deploy.outputs.deployment-url`), keeping the existing token-presence gate from #2966.
- Production publish: `wrangler deploy`.
- Bumps `cloudflare/wrangler-action` to v4 and passes `accountId` explicitly - Workers requires it, whereas Pages inferred it.

## Required before merge

The `cloudflare` GitHub environment needs a **`CLOUDFLARE_ACCOUNT_ID`** secret in addition to `CLOUDFLARE_API_TOKEN`, and the API token needs the **Workers Scripts: Edit** permission. The `uvicorn` Worker is created on first `deploy`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.