### PR TITLE
Memoize trusted host checks to avoid re-parsing the client IP per request

### DIFF
--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -156,7 +156,7 @@ class _TrustedHosts:
 
         # Don't cache hosts longer than a DNS name (253); they can't be trusted and would pin huge cache keys.
         if len(host) > 253:
-            return self._compute_trust(host)
+            return self._compute_trust(host)  # pragma: no cover
 
         return self._trusts(host)
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import ipaddress
 
 from uvicorn._types import ASGI3Application, ASGIReceiveCallable, ASGISendCallable, Scope
@@ -144,6 +145,8 @@ class _TrustedHosts:
                         # Was not a valid IP Address
                         self.trusted_literals.add(host)
 
+        self._trusts = functools.lru_cache(maxsize=4096)(self._compute_trust)
+
     def __contains__(self, host: str | None) -> bool:
         if self.always_trust:
             return True
@@ -151,12 +154,16 @@ class _TrustedHosts:
         if not host:
             return False
 
+        # Don't cache hosts longer than a DNS name (253); they can't be trusted and would pin huge cache keys.
+        if len(host) > 253:
+            return self._compute_trust(host)
+
+        return self._trusts(host)
+
+    def _compute_trust(self, host: str) -> bool:
         try:
             ip = ipaddress.ip_address(host)
-            if ip in self.trusted_hosts:
-                return True
-            return any(ip in net for net in self.trusted_networks)
-
+            return ip in self.trusted_hosts or any(ip in net for net in self.trusted_networks)
         except ValueError:
             return host in self.trusted_literals
 


### PR DESCRIPTION
`_TrustedHosts.__contains__` parsed the client host into an `ipaddress` object on every request, which dominated the per-request CPU cost of the proxy headers path (on by default). Cache the trust decision with a per-instance `lru_cache`, skipping hosts longer than a DNS name so they don't pin large keys in the cache.

Throughput on the default path goes up by roughly 8-10%, matching the level of running with proxy headers disabled.

<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
