### PR TITLE
Consume duplicate forwarding headers in ProxyHeadersMiddleware

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -262,6 +262,7 @@ Uvicorn currently supports the following headers:
 - `X-Forwarded-Proto`([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto))
 
 Uvicorn can use these headers to correctly set the client and protocol in the request.
+When a proxy chain emits one field per hop, Uvicorn combines repeated fields in order, treating them as the equivalent comma-separated list ([RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)).
 However as anyone can set these headers you must configure which "clients" you will trust to have set them correctly.
 
 Uvicorn can be configured to trust IP Addresses (e.g. `127.0.0.1`), IP Networks (e.g. `10.100.0.0/16`),
@@ -276,13 +277,6 @@ For more information, check [`ProxyHeadersMiddleware`](https://github.com/Kludex
 
 Currently if the `ProxyHeadersMiddleware` is able to retrieve a trusted client value then the client's port will be set to `0`.
 This is because port information is lost when using these headers.
-
-### Repeated Headers
-
-Some proxy chains emit one `X-Forwarded-For` (or `X-Forwarded-Proto`) field per hop instead of a single comma-separated one.
-Uvicorn combines repeated fields in order, treating them as the equivalent comma-separated list ([RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)).
-For `X-Forwarded-For` the usual trust walk applies, so the leftmost untrusted host is reported as the client.
-For `X-Forwarded-Proto` the leftmost value is used, as it reflects the protocol the client used to reach the first proxy.
 
 ### UNIX Domain Sockets (UDS)
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -262,7 +262,7 @@ Uvicorn currently supports the following headers:
 - `X-Forwarded-Proto`([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto))
 
 Uvicorn can use these headers to correctly set the client and protocol in the request.
-When a proxy chain emits one field per hop, Uvicorn combines repeated fields in order, treating them as the equivalent comma-separated list ([RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)).
+When a proxy chain sends a header once per hop, repeated `X-Forwarded-For` fields are combined in order (as the equivalent comma-separated list, [RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)), while for `X-Forwarded-Proto` the last field is used.
 However as anyone can set these headers you must configure which "clients" you will trust to have set them correctly.
 
 Uvicorn can be configured to trust IP Addresses (e.g. `127.0.0.1`), IP Networks (e.g. `10.100.0.0/16`),

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -277,6 +277,13 @@ For more information, check [`ProxyHeadersMiddleware`](https://github.com/Kludex
 Currently if the `ProxyHeadersMiddleware` is able to retrieve a trusted client value then the client's port will be set to `0`.
 This is because port information is lost when using these headers.
 
+### Repeated Headers
+
+Some proxy chains emit one `X-Forwarded-For` (or `X-Forwarded-Proto`) field per hop instead of a single comma-separated one.
+Uvicorn combines repeated fields in order, treating them as the equivalent comma-separated list ([RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)).
+For `X-Forwarded-For` the usual trust walk applies, so the leftmost untrusted host is reported as the client.
+For `X-Forwarded-Proto` the leftmost value is used, as it reflects the protocol the client used to reach the first proxy.
+
 ### UNIX Domain Sockets (UDS)
 
 Although it is common for UNIX Domain Sockets to be used for communicating between various HTTP servers, they can mess with some of the expected received values as they will be various non-address strings or missing values.

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -262,7 +262,6 @@ Uvicorn currently supports the following headers:
 - `X-Forwarded-Proto`([MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto))
 
 Uvicorn can use these headers to correctly set the client and protocol in the request.
-When a proxy chain sends a header once per hop, repeated `X-Forwarded-For` fields are combined in order (as the equivalent comma-separated list, [RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)), while for `X-Forwarded-Proto` the last field is used.
 However as anyone can set these headers you must configure which "clients" you will trust to have set them correctly.
 
 Uvicorn can be configured to trust IP Addresses (e.g. `127.0.0.1`), IP Networks (e.g. `10.100.0.0/16`),
@@ -270,6 +269,8 @@ or Literals (e.g. `/path/to/socket.sock`). When running from CLI these are confi
 
 !!! Warning "Only trust clients you can actually trust!"
     Incorrectly trusting other clients can lead to malicious actors spoofing their apparent client address to your application.
+
+A proxy chain may send a header once per hop rather than as a single comma-separated value. Repeated `X-Forwarded-For` fields are combined in order (as the equivalent comma-separated list, [RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)), while for `X-Forwarded-Proto` the last field is used.
 
 For more information, check [`ProxyHeadersMiddleware`](https://github.com/Kludex/uvicorn/blob/main/uvicorn/middleware/proxy_headers.py).
 

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -583,9 +583,6 @@ async def _noop_send(message: ASGISendEvent) -> None:  # pragma: no cover
 
 @pytest.mark.anyio
 async def test_proxy_headers_duplicate_x_forwarded_for_is_combined() -> None:
-    # Repeated X-Forwarded-For fields are equivalent to one comma-separated list (RFC 9110, 5.3).
-    # The proxy chain here is 203.0.113.66 -> 198.51.100.23 -> 127.0.0.1, so the leftmost
-    # untrusted host is the real client.
     captured: dict[str, tuple[str, int] | None] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -605,7 +602,6 @@ async def test_proxy_headers_duplicate_x_forwarded_for_is_combined() -> None:
 
 @pytest.mark.anyio
 async def test_proxy_headers_duplicate_x_forwarded_proto_uses_leftmost() -> None:
-    # The leftmost value is the protocol the client used to reach the first proxy.
     captured: dict[str, str] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -602,15 +602,22 @@ async def test_proxy_headers_duplicate_x_forwarded_for_is_combined() -> None:
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "proto_headers",
+    ("proto_headers", "expected"),
     [
-        [(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"http")],
-        [(b"x-forwarded-proto", b"https, http")],
-        [(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"ws, http")],
+        # Separate fields, single comma field, and a mix all combine to the same rightmost token.
+        ([(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"http")], "http"),
+        ([(b"x-forwarded-proto", b"https, http")], "http"),
+        ([(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"ws, http")], "http"),
+        # A spoofed leftmost value is ignored in the upgrade direction too.
+        ([(b"x-forwarded-proto", b"http"), (b"x-forwarded-proto", b"https")], "https"),
+        ([(b"x-forwarded-proto", b"http,  https ")], "https"),
+        # A trailing empty field is ignored and the original scheme is kept.
+        ([(b"x-forwarded-proto", b"https,")], "http"),
     ],
 )
 async def test_proxy_headers_duplicate_x_forwarded_proto_uses_rightmost(
     proto_headers: list[tuple[bytes, bytes]],
+    expected: str,
 ) -> None:
     captured: dict[str, str] = {}
 
@@ -621,7 +628,7 @@ async def test_proxy_headers_duplicate_x_forwarded_proto_uses_rightmost(
     middleware = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
     scope = _make_http_scope(proto_headers, scheme="http")
     await middleware(scope, _noop_receive, _noop_send)
-    assert captured["scheme"] == "http"
+    assert captured["scheme"] == expected
 
 
 @pytest.mark.anyio

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -582,7 +582,10 @@ async def _noop_send(message: ASGISendEvent) -> None:  # pragma: no cover
 
 
 @pytest.mark.anyio
-async def test_proxy_headers_duplicate_x_forwarded_for_is_ignored() -> None:
+async def test_proxy_headers_duplicate_x_forwarded_for_is_combined() -> None:
+    # Repeated X-Forwarded-For fields are equivalent to one comma-separated list (RFC 9110, 5.3).
+    # The proxy chain here is 203.0.113.66 -> 198.51.100.23 -> 127.0.0.1, so the leftmost
+    # untrusted host is the real client.
     captured: dict[str, tuple[str, int] | None] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -592,16 +595,17 @@ async def test_proxy_headers_duplicate_x_forwarded_for_is_ignored() -> None:
     middleware = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
     scope = _make_http_scope(
         [
-            (b"x-forwarded-for", b"198.51.100.23, 127.0.0.1"),
-            (b"x-forwarded-for", b"203.0.113.66"),
+            (b"x-forwarded-for", b"203.0.113.66, 198.51.100.23"),
+            (b"x-forwarded-for", b"127.0.0.1"),
         ]
     )
     await middleware(scope, _noop_receive, _noop_send)
-    assert captured["client"] == ("127.0.0.1", 12345)
+    assert captured["client"] == ("198.51.100.23", 0)
 
 
 @pytest.mark.anyio
-async def test_proxy_headers_duplicate_x_forwarded_proto_is_ignored() -> None:
+async def test_proxy_headers_duplicate_x_forwarded_proto_uses_leftmost() -> None:
+    # The leftmost value is the protocol the client used to reach the first proxy.
     captured: dict[str, str] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -611,10 +615,36 @@ async def test_proxy_headers_duplicate_x_forwarded_proto_is_ignored() -> None:
     middleware = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
     scope = _make_http_scope(
         [
+            (b"x-forwarded-proto", b"https"),
             (b"x-forwarded-proto", b"http"),
+        ],
+        scheme="http",
+    )
+    await middleware(scope, _noop_receive, _noop_send)
+    assert captured["scheme"] == "https"
+
+
+@pytest.mark.anyio
+async def test_proxy_headers_haproxy_behind_alb() -> None:
+    # Reproduces https://github.com/Kludex/uvicorn/discussions/2968: two proxies in the chain
+    # (an ALB and HAProxy) each append their own X-Forwarded-For and X-Forwarded-Proto field.
+    captured: dict[str, object] = {}
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        captured["client"] = scope["client"]
+        captured["scheme"] = scope["scheme"]
+
+    middleware = ProxyHeadersMiddleware(app, trusted_hosts=["127.0.0.1", "10.0.0.1"])
+    scope = _make_http_scope(
+        [
+            (b"x-forwarded-for", b"1.2.3.4"),
+            (b"x-forwarded-for", b"10.0.0.1"),
+            (b"x-forwarded-proto", b"https"),
             (b"x-forwarded-proto", b"https"),
         ],
         scheme="http",
     )
     await middleware(scope, _noop_receive, _noop_send)
-    assert captured["scheme"] == "http"
+    assert captured["client"] == ("1.2.3.4", 0)
+    assert captured["scheme"] == "https"

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -604,18 +604,11 @@ async def test_proxy_headers_duplicate_x_forwarded_for_is_combined() -> None:
 @pytest.mark.parametrize(
     ("proto_headers", "expected"),
     [
-        # Separate fields, single comma field, and a mix all combine to the same rightmost token.
         ([(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"http")], "http"),
-        ([(b"x-forwarded-proto", b"https, http")], "http"),
-        ([(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"ws, http")], "http"),
-        # A spoofed leftmost value is ignored in the upgrade direction too.
         ([(b"x-forwarded-proto", b"http"), (b"x-forwarded-proto", b"https")], "https"),
-        ([(b"x-forwarded-proto", b"http,  https ")], "https"),
-        # A trailing empty field is ignored and the original scheme is kept.
-        ([(b"x-forwarded-proto", b"https,")], "http"),
     ],
 )
-async def test_proxy_headers_duplicate_x_forwarded_proto_uses_rightmost(
+async def test_proxy_headers_duplicate_x_forwarded_proto_uses_last(
     proto_headers: list[tuple[bytes, bytes]],
     expected: str,
 ) -> None:

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -601,7 +601,17 @@ async def test_proxy_headers_duplicate_x_forwarded_for_is_combined() -> None:
 
 
 @pytest.mark.anyio
-async def test_proxy_headers_duplicate_x_forwarded_proto_uses_rightmost() -> None:
+@pytest.mark.parametrize(
+    "proto_headers",
+    [
+        [(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"http")],
+        [(b"x-forwarded-proto", b"https, http")],
+        [(b"x-forwarded-proto", b"https"), (b"x-forwarded-proto", b"ws, http")],
+    ],
+)
+async def test_proxy_headers_duplicate_x_forwarded_proto_uses_rightmost(
+    proto_headers: list[tuple[bytes, bytes]],
+) -> None:
     captured: dict[str, str] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -609,13 +619,7 @@ async def test_proxy_headers_duplicate_x_forwarded_proto_uses_rightmost() -> Non
         captured["scheme"] = scope["scheme"]
 
     middleware = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
-    scope = _make_http_scope(
-        [
-            (b"x-forwarded-proto", b"https"),
-            (b"x-forwarded-proto", b"http"),
-        ],
-        scheme="http",
-    )
+    scope = _make_http_scope(proto_headers, scheme="http")
     await middleware(scope, _noop_receive, _noop_send)
     assert captured["scheme"] == "http"
 

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -601,7 +601,7 @@ async def test_proxy_headers_duplicate_x_forwarded_for_is_combined() -> None:
 
 
 @pytest.mark.anyio
-async def test_proxy_headers_duplicate_x_forwarded_proto_uses_leftmost() -> None:
+async def test_proxy_headers_duplicate_x_forwarded_proto_uses_rightmost() -> None:
     captured: dict[str, str] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -617,13 +617,11 @@ async def test_proxy_headers_duplicate_x_forwarded_proto_uses_leftmost() -> None
         scheme="http",
     )
     await middleware(scope, _noop_receive, _noop_send)
-    assert captured["scheme"] == "https"
+    assert captured["scheme"] == "http"
 
 
 @pytest.mark.anyio
 async def test_proxy_headers_haproxy_behind_alb() -> None:
-    # Reproduces https://github.com/Kludex/uvicorn/discussions/2968: two proxies in the chain
-    # (an ALB and HAProxy) each append their own X-Forwarded-For and X-Forwarded-Proto field.
     captured: dict[str, object] = {}
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -32,17 +32,18 @@ class ProxyHeadersMiddleware:
         client_host = client_addr[0] if client_addr else None
 
         if client_host in self.trusted_hosts:
-            # Keep the last X-Forwarded-Proto: it is from the closest proxy and the hardest to spoof.
-            x_forwarded_proto_value: bytes | None = None
+            x_forwarded_proto_values: list[bytes] = []
             x_forwarded_for_values: list[bytes] = []
             for name, value in scope["headers"]:
                 if name == b"x-forwarded-proto":
-                    x_forwarded_proto_value = value
+                    x_forwarded_proto_values.append(value)
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            if x_forwarded_proto_value is not None:
-                x_forwarded_proto = x_forwarded_proto_value.decode("latin1").strip()
+            # Repeated fields are equivalent to a single comma-separated list (RFC 9110, 5.3).
+            # The last value is from the closest proxy and the hardest for a client to spoof.
+            if x_forwarded_proto_values:
+                x_forwarded_proto = b",".join(x_forwarded_proto_values).rsplit(b",", 1)[-1].decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -40,10 +40,10 @@ class ProxyHeadersMiddleware:
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # Repeated fields are equivalent to a single comma-separated list (RFC 9110, 5.3),
-            # so the rightmost value comes from the last field, after splitting it on commas.
+            # When a proxy chain sends one field per hop, the last is from the closest (trusted)
+            # proxy, so a client cannot spoof the scheme via an earlier field.
             if x_forwarded_proto_values:
-                x_forwarded_proto = x_forwarded_proto_values[-1].rsplit(b",", 1)[-1].decode("latin1").strip()
+                x_forwarded_proto = x_forwarded_proto_values[-1].decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -41,10 +41,9 @@ class ProxyHeadersMiddleware:
                     x_forwarded_for_values.append(value)
 
             # Repeated fields are equivalent to a single comma-separated list (RFC 9110, 5.3),
-            # so join the values in order before parsing.
+            # so the rightmost value comes from the last field, after splitting it on commas.
             if x_forwarded_proto_values:
-                joined_proto = b", ".join(x_forwarded_proto_values).decode("latin1")
-                x_forwarded_proto = joined_proto.rsplit(",", 1)[-1].strip()
+                x_forwarded_proto = x_forwarded_proto_values[-1].rsplit(b",", 1)[-1].decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -40,10 +40,9 @@ class ProxyHeadersMiddleware:
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # Repeated fields are equivalent to a single comma-separated list (RFC 9110, 5.3), so the
-            # rightmost value is the last comma token of the last field: the closest, least spoofable proxy.
+            # Keep the last field, written by the closest proxy and the hardest for a client to spoof.
             if x_forwarded_proto_values:
-                x_forwarded_proto = x_forwarded_proto_values[-1].rsplit(b",", 1)[-1].decode("latin1").strip()
+                x_forwarded_proto = x_forwarded_proto_values[-1].decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -40,7 +40,7 @@ class ProxyHeadersMiddleware:
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # The last field is from the closest (trusted) proxy, so it cannot be spoofed.
+            # Prefer the last field: it is the closest proxy and the hardest for a client to spoof.
             if x_forwarded_proto_values:
                 x_forwarded_proto = x_forwarded_proto_values[-1].decode("latin1").strip()
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -32,17 +32,17 @@ class ProxyHeadersMiddleware:
         client_host = client_addr[0] if client_addr else None
 
         if client_host in self.trusted_hosts:
-            x_forwarded_proto_values: list[bytes] = []
+            # Keep the last X-Forwarded-Proto: it is from the closest proxy and the hardest to spoof.
+            x_forwarded_proto_value: bytes | None = None
             x_forwarded_for_values: list[bytes] = []
             for name, value in scope["headers"]:
                 if name == b"x-forwarded-proto":
-                    x_forwarded_proto_values.append(value)
+                    x_forwarded_proto_value = value
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # Prefer the last field: it is the closest proxy and the hardest for a client to spoof.
-            if x_forwarded_proto_values:
-                x_forwarded_proto = x_forwarded_proto_values[-1].decode("latin1").strip()
+            if x_forwarded_proto_value is not None:
+                x_forwarded_proto = x_forwarded_proto_value.decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -32,17 +32,17 @@ class ProxyHeadersMiddleware:
         client_host = client_addr[0] if client_addr else None
 
         if client_host in self.trusted_hosts:
-            x_forwarded_proto_values: list[bytes] = []
+            # Keep the last X-Forwarded-Proto: it is from the closest proxy and the hardest to spoof.
+            x_forwarded_proto_value: bytes | None = None
             x_forwarded_for_values: list[bytes] = []
             for name, value in scope["headers"]:
                 if name == b"x-forwarded-proto":
-                    x_forwarded_proto_values.append(value)
+                    x_forwarded_proto_value = value
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # Keep the last field, written by the closest proxy and the hardest for a client to spoof.
-            if x_forwarded_proto_values:
-                x_forwarded_proto = x_forwarded_proto_values[-1].decode("latin1").strip()
+            if x_forwarded_proto_value is not None:
+                x_forwarded_proto = x_forwarded_proto_value.decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -40,8 +40,7 @@ class ProxyHeadersMiddleware:
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # When a proxy chain sends one field per hop, the last is from the closest (trusted)
-            # proxy, so a client cannot spoof the scheme via an earlier field.
+            # The last field is from the closest (trusted) proxy, so it cannot be spoofed.
             if x_forwarded_proto_values:
                 x_forwarded_proto = x_forwarded_proto_values[-1].decode("latin1").strip()
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -32,7 +32,6 @@ class ProxyHeadersMiddleware:
         client_host = client_addr[0] if client_addr else None
 
         if client_host in self.trusted_hosts:
-            # Keep the last X-Forwarded-Proto: it is from the closest proxy and the hardest to spoof.
             x_forwarded_proto_value: bytes | None = None
             x_forwarded_for_values: list[bytes] = []
             for name, value in scope["headers"]:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -40,10 +40,10 @@ class ProxyHeadersMiddleware:
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # Repeated fields are equivalent to a single comma-separated list (RFC 9110, 5.3).
-            # The last value is from the closest proxy and the hardest for a client to spoof.
+            # Repeated fields are equivalent to a single comma-separated list (RFC 9110, 5.3), so the
+            # rightmost value is the last comma token of the last field: the closest, least spoofable proxy.
             if x_forwarded_proto_values:
-                x_forwarded_proto = b",".join(x_forwarded_proto_values).rsplit(b",", 1)[-1].decode("latin1").strip()
+                x_forwarded_proto = x_forwarded_proto_values[-1].rsplit(b",", 1)[-1].decode("latin1").strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -40,9 +40,12 @@ class ProxyHeadersMiddleware:
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
 
-            # Only consume the header when exactly one copy is present to avoid spoofing issues.
-            if len(x_forwarded_proto_values) == 1:
-                x_forwarded_proto = x_forwarded_proto_values[0].decode("latin1").strip()
+            # Repeated fields are equivalent to a single comma-separated list (RFC 9110, 5.3),
+            # so join the values in order before parsing.
+            if x_forwarded_proto_values:
+                joined_proto = b", ".join(x_forwarded_proto_values).decode("latin1")
+                # The leftmost value is the protocol the client used to reach the first proxy.
+                x_forwarded_proto = joined_proto.split(",", 1)[0].strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":
@@ -50,8 +53,8 @@ class ProxyHeadersMiddleware:
                     else:
                         scope["scheme"] = x_forwarded_proto
 
-            if len(x_forwarded_for_values) == 1:
-                x_forwarded_for = x_forwarded_for_values[0].decode("latin1")
+            if x_forwarded_for_values:
+                x_forwarded_for = b", ".join(x_forwarded_for_values).decode("latin1")
                 host, port = self.trusted_hosts.get_trusted_client_address(x_forwarded_for)
 
                 if host:

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -44,8 +44,7 @@ class ProxyHeadersMiddleware:
             # so join the values in order before parsing.
             if x_forwarded_proto_values:
                 joined_proto = b", ".join(x_forwarded_proto_values).decode("latin1")
-                # The leftmost value is the protocol the client used to reach the first proxy.
-                x_forwarded_proto = joined_proto.split(",", 1)[0].strip()
+                x_forwarded_proto = joined_proto.rsplit(",", 1)[-1].strip()
 
                 if x_forwarded_proto in {"http", "https", "ws", "wss"}:
                     if scope["type"] == "websocket":


### PR DESCRIPTION
## Summary

[#2944](https://github.com/Kludex/uvicorn/pull/2944) made `ProxyHeadersMiddleware` ignore `X-Forwarded-For` / `X-Forwarded-Proto` entirely whenever the header appeared more than once. As reported in [#2968](https://github.com/Kludex/uvicorn/discussions/2968), proxy chains where each hop appends its own field (e.g. HAProxy behind an ALB) suddenly stopped having their reverse proxy trusted, silently breaking client-IP logging and rate limiting.

Instead of dropping duplicates, we handle each header according to its actual format.

## Changes

- **`X-Forwarded-For`**: repeated fields are equivalent to a single comma-separated list ([RFC 9110, 5.3](https://www.rfc-editor.org/rfc/rfc9110#section-5.3)), so we join them in order and run the existing reverse trust walk. The leftmost untrusted host is the client, preserving the spoofing protection #2944 was after.
- **`X-Forwarded-Proto`**: we keep the last field, written by the closest (trusted) proxy and the hardest for a client to spoof. This restores the long-standing pre-#2944 behavior (`dict(headers)` kept the last field) without the silent drop on duplicates.
- Updated the duplicate-header regression tests to assert this behavior, and added a test reproducing the HAProxy-behind-ALB scenario from #2968.
- Documented repeated-header handling in the deployment docs.

## Test plan

- [x] `uv run pytest tests/middleware/test_proxy_headers.py` - 265 passed
- [x] `uv run ruff check uvicorn/middleware/proxy_headers.py tests/middleware/test_proxy_headers.py`
- [x] `uv run ruff format --check uvicorn/middleware/proxy_headers.py tests/middleware/test_proxy_headers.py`
- [x] `uv run mypy uvicorn/middleware/proxy_headers.py`

Closes #2968

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


