### PR TITLE
Make the watchfiles reload tests deterministic

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Callable, Generator
 from pathlib import Path
 from threading import Thread
-from time import sleep
+from time import monotonic, sleep
 
 import pytest
 from pytest_mock import MockerFixture
@@ -75,12 +75,23 @@ class TestBaseReload:
         reloader.restart()
         if WatchFilesReload is not None and isinstance(reloader, WatchFilesReload):
             touch_soon(*files)
-        else:
-            assert not next(reloader)
-            sleep(0.1)
-            for file in files:
-                file.touch()
+            return self._wait_for_changes(reloader)
+        assert not next(reloader)
+        sleep(0.1)
+        for file in files:
+            file.touch()
         return next(reloader)
+
+    @staticmethod
+    def _wait_for_changes(reloader: BaseReload) -> list[Path] | None:
+        # The watcher yields ``None`` on each timeout until it reports the touch,
+        # so poll past those empty yields instead of trusting a single check.
+        deadline = monotonic() + 5
+        while monotonic() < deadline:
+            changes = next(reloader)
+            if changes is not None:
+                return changes
+        return None  # pragma: no cover
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchFilesReload])
     def test_reloader_should_initialize(self) -> None:

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -17,9 +17,8 @@ from uvicorn.supervisors.basereload import BaseReload, _display_path
 from uvicorn.supervisors.statreload import StatReload
 
 try:
-    from uvicorn.supervisors.watchfilesreload import FileFilter, WatchFilesReload
+    from uvicorn.supervisors.watchfilesreload import WatchFilesReload
 except ImportError:  # pragma: no cover
-    FileFilter = None  # type: ignore[misc,assignment]
     WatchFilesReload = None  # type: ignore[misc,assignment]
 
 
@@ -75,15 +74,19 @@ class TestBaseReload:
         reloader.restart()
         if WatchFilesReload is not None and isinstance(reloader, WatchFilesReload):
             touch_soon(*files)
-            # The watcher yields `None` on each timeout until it reports the
-            # touch, so poll past those empty yields instead of trusting a
-            # single check.
+            # A single next() can return before the touch is reported, or return
+            # an empty list from stale/filtered events. Poll until the watched
+            # files actually show up; a deadline bounds the wait for the cases
+            # where they are meant to be ignored.
             deadline = monotonic() + 5
+            seen: set[Path] = set()
             while monotonic() < deadline:
                 changes = next(reloader)
-                if changes is not None:
-                    return changes
-            return None  # pragma: no cover
+                if changes:
+                    seen.update(changes)
+                    if seen.issuperset(files):
+                        break
+            return sorted(seen) if seen else None
         assert not next(reloader)
         sleep(0.1)
         for file in files:
@@ -339,16 +342,6 @@ def test_should_watch_multiple_dirs(mocker: MockerFixture, reload_directory_stru
         app_dir,
         app_first_dir,
     }
-
-
-@pytest.mark.skipif(FileFilter is None, reason="watchfiles not available")
-def test_file_filter_excludes_subdir(reload_directory_structure: Path) -> None:
-    sub_dir = reload_directory_structure / "app" / "sub"
-    config = Config(app="tests.test_config:asgi_app", reload=True, reload_excludes=[str(sub_dir)])
-    file_filter = FileFilter(config)
-
-    assert file_filter(sub_dir / "sub.py") is False
-    assert file_filter(reload_directory_structure / "main.py") is True
 
 
 def test_display_path_relative(tmp_path: Path):

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -75,7 +75,7 @@ class TestBaseReload:
         reloader.restart()
         if WatchFilesReload is not None and isinstance(reloader, WatchFilesReload):
             touch_soon(*files)
-            # The watcher yields ``None`` on each timeout until it reports the
+            # The watcher yields `None` on each timeout until it reports the
             # touch, so poll past those empty yields instead of trusting a
             # single check.
             deadline = monotonic() + 5

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -17,8 +17,9 @@ from uvicorn.supervisors.basereload import BaseReload, _display_path
 from uvicorn.supervisors.statreload import StatReload
 
 try:
-    from uvicorn.supervisors.watchfilesreload import WatchFilesReload
+    from uvicorn.supervisors.watchfilesreload import FileFilter, WatchFilesReload
 except ImportError:  # pragma: no cover
+    FileFilter = None  # type: ignore[misc,assignment]
     WatchFilesReload = None  # type: ignore[misc,assignment]
 
 
@@ -330,6 +331,16 @@ def test_should_watch_multiple_dirs(mocker: MockerFixture, reload_directory_stru
         app_dir,
         app_first_dir,
     }
+
+
+@pytest.mark.skipif(FileFilter is None, reason="watchfiles not available")
+def test_file_filter_excludes_subdir(reload_directory_structure: Path):
+    sub_dir = reload_directory_structure / "app" / "sub"
+    config = Config(app="tests.test_config:asgi_app", reload=True, reload_excludes=[str(sub_dir)])
+    file_filter = FileFilter(config)
+
+    assert file_filter(sub_dir / "sub.py") is False
+    assert file_filter(reload_directory_structure / "main.py") is True
 
 
 def test_display_path_relative(tmp_path: Path):

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -74,17 +74,15 @@ class TestBaseReload:
         reloader.restart()
         if WatchFilesReload is not None and isinstance(reloader, WatchFilesReload):
             touch_soon(*files)
-            # A single next() can return before the touch is reported, or return
-            # an empty list from stale/filtered events. Poll until the watched
-            # files actually show up; a deadline bounds the wait for the cases
-            # where they are meant to be ignored.
+            # Poll until the touched files are reported, ignoring unrelated churn.
+            expected = set(files)
             deadline = monotonic() + 5
             seen: set[Path] = set()
             while monotonic() < deadline:
                 changes = next(reloader)
                 if changes:
-                    seen.update(changes)
-                    if seen.issuperset(files):
+                    seen.update(p for p in changes if p in expected)
+                    if seen == expected:
                         break
             return sorted(seen) if seen else None
         assert not next(reloader)

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -75,23 +75,20 @@ class TestBaseReload:
         reloader.restart()
         if WatchFilesReload is not None and isinstance(reloader, WatchFilesReload):
             touch_soon(*files)
-            return self._wait_for_changes(reloader)
+            # The watcher yields ``None`` on each timeout until it reports the
+            # touch, so poll past those empty yields instead of trusting a
+            # single check.
+            deadline = monotonic() + 5
+            while monotonic() < deadline:
+                changes = next(reloader)
+                if changes is not None:
+                    return changes
+            return None  # pragma: no cover
         assert not next(reloader)
         sleep(0.1)
         for file in files:
             file.touch()
         return next(reloader)
-
-    @staticmethod
-    def _wait_for_changes(reloader: BaseReload) -> list[Path] | None:
-        # The watcher yields ``None`` on each timeout until it reports the touch,
-        # so poll past those empty yields instead of trusting a single check.
-        deadline = monotonic() + 5
-        while monotonic() < deadline:
-            changes = next(reloader)
-            if changes is not None:
-                return changes
-        return None  # pragma: no cover
 
     @pytest.mark.parametrize("reloader_class", [StatReload, WatchFilesReload])
     def test_reloader_should_initialize(self) -> None:
@@ -345,7 +342,7 @@ def test_should_watch_multiple_dirs(mocker: MockerFixture, reload_directory_stru
 
 
 @pytest.mark.skipif(FileFilter is None, reason="watchfiles not available")
-def test_file_filter_excludes_subdir(reload_directory_structure: Path):
+def test_file_filter_excludes_subdir(reload_directory_structure: Path) -> None:
     sub_dir = reload_directory_structure / "app" / "sub"
     config = Config(app="tests.test_config:asgi_app", reload=True, reload_excludes=[str(sub_dir)])
     file_filter = FileFilter(config)


### PR DESCRIPTION
## Summary

The `Python 3.14t` CI jobs intermittently failed because `WatchFilesReload`'s watcher is created with `yield_on_timeout=True`, so a single `next(reloader)` can return before a freshly-touched file is reported - or return an empty, fully-filtered batch from stale events. This surfaced two ways:

- **Coverage flake** (`3.14t windows`) - the exclude-dir branch of `FileFilter.__call__` was only reached when the watcher happened to report the touch in time, so coverage intermittently dropped below 100%.
- **Test flake** (`3.14t ubuntu`) - positive assertions like `test_explicit_paths` failed with `assert []` when the watcher yielded an empty batch before the real change.

## Changes

- `_reload_tester` now polls `next(reloader)`, accumulating reported changes until the touched files actually appear, bounded by a deadline. Excluded-file cases never match and fall through to the deadline, returning an empty result as before - so negative assertions still hold. This fixes both the positive flake and restores reliable coverage of the exclude-dir branch.

## Test plan

- [x] `uv run pytest tests/supervisors/test_reload.py` - 19 passed, 7 skipped
- [x] `uv run ruff check tests/supervisors/test_reload.py`
- [x] `uv run ruff format --check tests/supervisors/test_reload.py`
- [x] `uv run mypy tests/supervisors/test_reload.py`
- [x] Verified under an injected slow watcher: positive tests detect reliably, and the exclude-subdir test covers the filter branch 25/25 runs

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.