### PR TITLE
Version 0.49.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ toc_depth: 2
 ### Changed
 
 * Bump `httptools` minimum version to 0.8.0 (#2962)
-* Consume duplicate forwarding headers in `ProxyHeadersMiddleware` (#2971)
+* Consume duplicate forwarding headers in `ProxyHeadersMiddleware` (reverses the 0.48.0 behavior of ignoring them) (#2971)
 
 ## 0.48.0 (May 24, 2026)
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,13 @@
 toc_depth: 2
 ---
 
+## 0.49.0 (June 3, 2026)
+
+### Changed
+
+* Bump `httptools` minimum version to 0.8.0 (#2962)
+* Consume duplicate forwarding headers in `ProxyHeadersMiddleware` (#2971)
+
 ## 0.48.0 (May 24, 2026)
 
 ### Changed

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.48.0"
+__version__ = "0.49.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## 0.49.0

### Changed

* Bump `httptools` minimum version to 0.8.0 (#2962)
* Consume duplicate forwarding headers in `ProxyHeadersMiddleware` (#2971)

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
