### PR TITLE
Exclude flaky watchfiles exclude-dir branch from coverage

### DIFF
--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -42,7 +42,7 @@ class FileFilter:
 
                 for exclude_dir in self.exclude_dirs:
                     if exclude_dir in path.parents:
-                        return False
+                        return False  # pragma: no cover
 
                 for exclude_pattern in self.excludes:
                     if path.match(exclude_pattern):


### PR DESCRIPTION
The `exclude_dir in path.parents` branch in `FileFilter.__call__` is only reached when a `watchfiles`-driven reload test reports a change under an excluded directory. Those `WatchFilesReload` tests are timing-dependent and flaky on Windows/macOS, so on slow runners (e.g. `3.14t` free-threaded Windows) the branch isn't hit, coverage drops to 99.97%, and the job fails `fail_under=100` with exit code 2 even though every test passes.

The two sibling lines in the same function already carry coverage pragmas for this reason. Mark this one too so the timing-dependent branch can't break CI.

Example: https://github.com/Kludex/uvicorn/actions/runs/26915843081/job/79405179296

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.