### PR TITLE
Deflake multiprocess, reload, and signal supervisor tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,8 @@ def reload_directory_structure(tmp_path_factory: pytest.TempPathFactory):
     │   └── file.txt
     └── main.py
     """
-    root = tmp_path_factory.mktemp("reload_directory")
+    # Resolve symlinks (e.g. /tmp -> /private/tmp on macOS) so paths match what watchfiles reports.
+    root = tmp_path_factory.mktemp("reload_directory").resolve()
     apps = ["app", "app_first", "app_second", "app_third"]
 
     root_file = root / "main.py"

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -57,6 +57,13 @@ def test_process_ping_pong_timeout() -> None:
     assert not process.ping(0.1)
 
 
+def test_process_ping_broken_pipe() -> None:
+    process = Process(Config(app=app), target=lambda x: None, sockets=[])
+    process.parent_conn.close()
+    process.child_conn.close()
+    assert not process.ping(0.1)
+
+
 @new_console_in_windows
 def test_multiprocess_run() -> None:
     """

--- a/tests/supervisors/test_signal.py
+++ b/tests/supervisors/test_signal.py
@@ -74,8 +74,12 @@ async def test_sigint_abort_req(unused_tcp_port: int, caplog):
             with pytest.raises(httpx.RemoteProtocolError):
                 await req
 
-        # req.result()
-    assert "Cancel 1 running task(s), timeout graceful shutdown exceeded" in caplog.messages
+    message = "Cancel 1 running task(s), timeout graceful shutdown exceeded"
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 5
+    while message not in caplog.messages and loop.time() < deadline:
+        await asyncio.sleep(0.1)  # pragma: no cover
+    assert message in caplog.messages
 
 
 @pytest.mark.anyio

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import pickle
 import signal
 import threading
 from collections.abc import Callable
@@ -36,11 +37,15 @@ class Process:
         self.process = get_subprocess(config, self.target, sockets)
 
     def ping(self, timeout: float = 5) -> bool:
-        self.parent_conn.send(b"ping")
-        if self.parent_conn.poll(timeout):
-            self.parent_conn.recv()
-            return True
-        return False
+        try:
+            self.parent_conn.send(b"ping")
+            if self.parent_conn.poll(timeout):
+                self.parent_conn.recv()
+                return True
+            return False
+        except (OSError, EOFError, pickle.UnpicklingError):
+            # The worker died and closed its side of the pipe.
+            return False
 
     def pong(self) -> None:
         self.child_conn.recv()


### PR DESCRIPTION
Three distinct flakes were failing the Test Suite on `main`, almost always on free-threaded CI (`3.14t`):

**Reload tests (`test_explicit_paths`, `test_should_reload_*`)** - `watchfiles` reports canonical paths, but `reload_directory_structure` created its temp dir unresolved. On macOS `/tmp` is a symlink to `/private/tmp`, so the watcher's reported paths never matched the test's expected paths, and `_reload_tester` polled until its 5s timeout and returned `None`. Resolving the fixture root fixes the path comparison.

**`test_multiprocess_health_check`** - after the test kills a worker, the supervisor's health check calls `ping()`, which `recv()`s from the dead worker's broken pipe and raises `EOFError` / `UnpicklingError` instead of reporting the worker as down. `ping()` now treats a broken pipe as not-alive (a genuine robustness fix, not just a test fix), covered by a new `test_process_ping_broken_pipe`.

**`test_sigint_abort_req`** - the test asserted the "Cancel N running task(s)" log immediately, but on slow runners the graceful-shutdown timeout hadn't elapsed yet. It now waits for the message.

Verified locally by running each suite 15-20x with no failures, and full-suite coverage stays at 100% (the only local gap is `test_socket_bind`, which needs port 8000 free).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.