### PR TITLE
Build a fresh `asgi` scope dict per request

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -16,7 +16,6 @@ from uvicorn._types import (
     ASGI3Application,
     ASGIReceiveEvent,
     ASGISendEvent,
-    ASGIVersions,
     HTTPRequestEvent,
     HTTPResponseBodyEvent,
     HTTPResponseStartEvent,
@@ -64,7 +63,7 @@ class H11Protocol(asyncio.Protocol):
         )
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
-        self.scope_asgi: ASGIVersions = {"version": config.asgi_version, "spec_version": "2.3"}
+        self.asgi_version = config.asgi_version
         self.limit_concurrency = config.limit_concurrency
         self.app_state = app_state
 
@@ -205,7 +204,7 @@ class H11Protocol(asyncio.Protocol):
                 full_raw_path = self.root_path.encode("ascii") + raw_path
                 self.scope = {
                     "type": "http",
-                    "asgi": self.scope_asgi,
+                    "asgi": {"version": self.asgi_version, "spec_version": "2.3"},
                     "http_version": event.http_version.decode("ascii"),
                     "server": self.server,
                     "client": self.client,

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -18,7 +18,6 @@ from uvicorn._types import (
     ASGI3Application,
     ASGIReceiveEvent,
     ASGISendEvent,
-    ASGIVersions,
     HTTPRequestEvent,
     HTTPScope,
 )
@@ -71,7 +70,7 @@ class HttpToolsProtocol(asyncio.Protocol):
 
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
-        self.scope_asgi: ASGIVersions = {"version": config.asgi_version, "spec_version": "2.3"}
+        self.asgi_version = config.asgi_version
         self.limit_concurrency = config.limit_concurrency
         self.app_state = app_state
 
@@ -226,7 +225,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.headers = []
         self.scope = {  # type: ignore[typeddict-item]
             "type": "http",
-            "asgi": self.scope_asgi,
+            "asgi": {"version": self.asgi_version, "spec_version": "2.3"},
             "http_version": "1.1",
             "server": self.server,
             "client": self.client,

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -20,7 +20,6 @@ from websockets.typing import Subprotocol
 from uvicorn._types import (
     ASGI3Application,
     ASGISendEvent,
-    ASGIVersions,
     WebSocketConnectEvent,
     WebSocketDisconnectEvent,
     WebSocketReceiveEvent,
@@ -70,7 +69,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
         self.app = cast(ASGI3Application, config.loaded_app)
         self.loop = _loop or asyncio.get_event_loop()
         self.root_path = config.root_path
-        self.scope_asgi: ASGIVersions = {"version": config.asgi_version, "spec_version": "2.4"}
+        self.asgi_version = config.asgi_version
         self.app_state = app_state
 
         # Shared server state
@@ -180,7 +179,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
 
         self.scope = {
             "type": "websocket",
-            "asgi": self.scope_asgi,
+            "asgi": {"version": self.asgi_version, "spec_version": "2.4"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -20,7 +20,6 @@ from websockets.server import ServerProtocol
 from uvicorn._types import (
     ASGIReceiveEvent,
     ASGISendEvent,
-    ASGIVersions,
     WebSocketScope,
 )
 from uvicorn.config import Config
@@ -57,7 +56,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.loop = _loop or asyncio.get_event_loop()
         self.logger = logging.getLogger("uvicorn.error")
         self.root_path = config.root_path
-        self.scope_asgi: ASGIVersions = {"version": config.asgi_version, "spec_version": "2.4"}
+        self.asgi_version = config.asgi_version
         self.app_state = app_state
 
         # Shared server state
@@ -199,7 +198,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         raw_path, _, query_string = event.path.partition("?")
         self.scope: WebSocketScope = {
             "type": "websocket",
-            "asgi": self.scope_asgi,
+            "asgi": {"version": self.asgi_version, "spec_version": "2.4"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -18,7 +18,6 @@ from wsproto.utilities import LocalProtocolError, RemoteProtocolError
 from uvicorn._types import (
     ASGI3Application,
     ASGISendEvent,
-    ASGIVersions,
     WebSocketEvent,
     WebSocketReceiveEvent,
     WebSocketScope,
@@ -82,7 +81,7 @@ class WSProtocol(asyncio.Protocol):
         self.loop = _loop or asyncio.get_event_loop()
         self.logger = logging.getLogger("uvicorn.error")
         self.root_path = config.root_path
-        self.scope_asgi: ASGIVersions = {"version": config.asgi_version, "spec_version": "2.4"}
+        self.asgi_version = config.asgi_version
         self.app_state = app_state
 
         # Shared server state
@@ -213,7 +212,7 @@ class WSProtocol(asyncio.Protocol):
         full_raw_path = self.root_path.encode("ascii") + raw_path.encode("ascii")
         self.scope: WebSocketScope = {
             "type": "websocket",
-            "asgi": self.scope_asgi,
+            "asgi": {"version": self.asgi_version, "spec_version": "2.4"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,


### PR DESCRIPTION
Follow-up to #2976.

That PR cached the whole `asgi` scope sub-dict as a single shared instance per connection. As [Codex pointed out on the PR](https://github.com/Kludex/uvicorn/pull/2976), this means a request that mutates `scope["asgi"]` would leak that state into later requests on the same keep-alive connection - the previous per-request dict gave each request its own.

`scope["asgi"]` is server-provided metadata that apps are only meant to read, so this is unlikely in practice, but uvicorn is foundational enough that "provably zero behaviour change" is worth more than the few percent it costs.

This keeps the real win - caching the `asgi_version` value avoids the per-request `config.asgi_version` property call (that property rebuilds a mapping dict and does a lookup on every access) - while building a fresh, independent `asgi` dict per request, so per-request isolation is fully restored.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
