### PR TITLE
Avoid copying single-frame WebSocket payloads in websockets-sansio

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -792,8 +792,12 @@ async def test_fragmented_message_reassembly(
         await send({"type": "websocket.accept"})
         message = await receive()
         assert message["type"] == "websocket.receive"
-        payload = message.get("text") if opcode is Opcode.TEXT else message.get("bytes")
-        assert isinstance(payload, str if opcode is Opcode.TEXT else bytes)
+        if opcode is Opcode.TEXT:
+            payload: str | bytes | None = message.get("text")
+            assert isinstance(payload, str)
+        else:
+            payload = message.get("bytes")
+            assert isinstance(payload, bytes)
         received.append(payload)
         await send({"type": "websocket.close"})
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -777,13 +777,12 @@ async def test_fragmented_message_exceeding_max_size(
     assert exc_info.value.rcvd.code == 1009
 
 
-@pytest.mark.parametrize("opcode", [Opcode.TEXT, Opcode.BINARY])
-async def test_fragmented_message_reassembly(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int, opcode: Opcode
+async def test_fragmented_binary_message_reassembly(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):
-    """Server reassembles a fragmented message and delivers it to the app intact."""
+    """Server reassembles a fragmented binary message and delivers it to the app intact."""
 
-    received: list[str | bytes] = []
+    received: list[bytes] = []
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         assert scope["type"] == "websocket"
@@ -792,8 +791,8 @@ async def test_fragmented_message_reassembly(
         await send({"type": "websocket.accept"})
         message = await receive()
         assert message["type"] == "websocket.receive"
-        payload = message.get("text") if opcode is Opcode.TEXT else message.get("bytes")
-        assert isinstance(payload, str if opcode is Opcode.TEXT else bytes)
+        payload = message.get("bytes")
+        assert isinstance(payload, bytes)
         received.append(payload)
         await send({"type": "websocket.close"})
 
@@ -801,13 +800,43 @@ async def test_fragmented_message_reassembly(
     async with run_server(config):
         async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}") as ws:
             payload = b"A" * 512
-            await ws.write_frame(False, opcode, payload)
+            await ws.write_frame(False, Opcode.BINARY, payload)
             for _ in range(4):
                 await ws.write_frame(False, Opcode.CONT, payload)
             await ws.write_frame(True, Opcode.CONT, payload)
 
-    expected = "A" * 512 * 6 if opcode is Opcode.TEXT else b"A" * 512 * 6
-    assert received == [expected]
+    assert received == [b"A" * 512 * 6]
+
+
+async def test_fragmented_text_message_reassembly(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    """Server reassembles a fragmented text message and delivers it to the app intact."""
+
+    received: list[str] = []
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "websocket"
+        connect = await receive()
+        assert connect["type"] == "websocket.connect"
+        await send({"type": "websocket.accept"})
+        message = await receive()
+        assert message["type"] == "websocket.receive"
+        payload = message.get("text")
+        assert isinstance(payload, str)
+        received.append(payload)
+        await send({"type": "websocket.close"})
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
+    async with run_server(config):
+        async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}") as ws:
+            payload = b"A" * 512
+            await ws.write_frame(False, Opcode.TEXT, payload)
+            for _ in range(4):
+                await ws.write_frame(False, Opcode.CONT, payload)
+            await ws.write_frame(True, Opcode.CONT, payload)
+
+    assert received == ["A" * 512 * 6]
 
 
 async def test_server_reject_connection(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -777,12 +777,13 @@ async def test_fragmented_message_exceeding_max_size(
     assert exc_info.value.rcvd.code == 1009
 
 
-async def test_fragmented_binary_message_reassembly(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+@pytest.mark.parametrize("opcode", [Opcode.TEXT, Opcode.BINARY])
+async def test_fragmented_message_reassembly(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int, opcode: Opcode
 ):
-    """Server reassembles a fragmented binary message and delivers it to the app intact."""
+    """Server reassembles a fragmented message and delivers it to the app intact."""
 
-    received: list[bytes] = []
+    received: list[str | bytes] = []
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         assert scope["type"] == "websocket"
@@ -791,8 +792,8 @@ async def test_fragmented_binary_message_reassembly(
         await send({"type": "websocket.accept"})
         message = await receive()
         assert message["type"] == "websocket.receive"
-        payload = message.get("bytes")
-        assert isinstance(payload, bytes)
+        payload = message.get("text") if opcode is Opcode.TEXT else message.get("bytes")
+        assert isinstance(payload, str if opcode is Opcode.TEXT else bytes)
         received.append(payload)
         await send({"type": "websocket.close"})
 
@@ -800,43 +801,13 @@ async def test_fragmented_binary_message_reassembly(
     async with run_server(config):
         async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}") as ws:
             payload = b"A" * 512
-            await ws.write_frame(False, Opcode.BINARY, payload)
+            await ws.write_frame(False, opcode, payload)
             for _ in range(4):
                 await ws.write_frame(False, Opcode.CONT, payload)
             await ws.write_frame(True, Opcode.CONT, payload)
 
-    assert received == [b"A" * 512 * 6]
-
-
-async def test_fragmented_text_message_reassembly(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
-):
-    """Server reassembles a fragmented text message and delivers it to the app intact."""
-
-    received: list[str] = []
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        assert scope["type"] == "websocket"
-        connect = await receive()
-        assert connect["type"] == "websocket.connect"
-        await send({"type": "websocket.accept"})
-        message = await receive()
-        assert message["type"] == "websocket.receive"
-        payload = message.get("text")
-        assert isinstance(payload, str)
-        received.append(payload)
-        await send({"type": "websocket.close"})
-
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
-    async with run_server(config):
-        async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}") as ws:
-            payload = b"A" * 512
-            await ws.write_frame(False, Opcode.TEXT, payload)
-            for _ in range(4):
-                await ws.write_frame(False, Opcode.CONT, payload)
-            await ws.write_frame(True, Opcode.CONT, payload)
-
-    assert received == ["A" * 512 * 6]
+    expected = "A" * 512 * 6 if opcode is Opcode.TEXT else b"A" * 512 * 6
+    assert received == [expected]
 
 
 async def test_server_reject_connection(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -777,12 +777,13 @@ async def test_fragmented_message_exceeding_max_size(
     assert exc_info.value.rcvd.code == 1009
 
 
+@pytest.mark.parametrize("opcode", [Opcode.TEXT, Opcode.BINARY])
 async def test_fragmented_message_reassembly(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int, opcode: Opcode
 ):
     """Server reassembles a fragmented message and delivers it to the app intact."""
 
-    received: list[bytes] = []
+    received: list[str | bytes] = []
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         assert scope["type"] == "websocket"
@@ -791,8 +792,8 @@ async def test_fragmented_message_reassembly(
         await send({"type": "websocket.accept"})
         message = await receive()
         assert message["type"] == "websocket.receive"
-        payload = message.get("bytes")
-        assert payload is not None
+        payload = message.get("text") if opcode is Opcode.TEXT else message.get("bytes")
+        assert isinstance(payload, str if opcode is Opcode.TEXT else bytes)
         received.append(payload)
         await send({"type": "websocket.close"})
 
@@ -800,12 +801,13 @@ async def test_fragmented_message_reassembly(
     async with run_server(config):
         async with websockets.connect(f"ws://127.0.0.1:{unused_tcp_port}") as ws:
             payload = b"A" * 512
-            await ws.write_frame(False, Opcode.BINARY, payload)
+            await ws.write_frame(False, opcode, payload)
             for _ in range(4):
                 await ws.write_frame(False, Opcode.CONT, payload)
             await ws.write_frame(True, Opcode.CONT, payload)
 
-    assert received == [b"A" * 512 * 6]
+    expected = "A" * 512 * 6 if opcode is Opcode.TEXT else b"A" * 512 * 6
+    assert received == [expected]
 
 
 async def test_server_reject_connection(

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -165,9 +165,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 if event.opcode == Opcode.CONT:
                     self.handle_cont(event)  # pragma: no cover
                 elif event.opcode == Opcode.TEXT:
-                    self.handle_data(event, "text")
+                    self.handle_text(event)
                 elif event.opcode == Opcode.BINARY:
-                    self.handle_data(event, "bytes")
+                    self.handle_bytes(event)
                 elif event.opcode == Opcode.PING:
                     self.handle_ping()
                 elif event.opcode == Opcode.PONG:
@@ -223,8 +223,15 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         if event.fin:
             self.send_receive_event_to_app(self.bytes)
 
-    def handle_data(self, event: Frame, data_type: Literal["text", "bytes"]) -> None:
-        self.curr_msg_data_type = data_type
+    def handle_text(self, event: Frame) -> None:
+        self.curr_msg_data_type = "text"
+        if event.fin:
+            self.send_receive_event_to_app(event.data)
+        else:
+            self.bytes = bytearray(event.data)
+
+    def handle_bytes(self, event: Frame) -> None:
+        self.curr_msg_data_type = "bytes"
         if event.fin:
             self.send_receive_event_to_app(event.data)
         else:

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -106,7 +106,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.last_ping_rtt: float = 0.0
 
         # Incoming message state
-        self.bytes = bytearray()
+        self.frames: list[bytes] = []
         self.curr_msg_data_type: Literal["text", "bytes"] = "bytes"
 
     def connection_made(self, transport: BaseTransport) -> None:
@@ -219,25 +219,25 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.tasks.add(task)
 
     def handle_cont(self, event: Frame) -> None:
-        self.bytes.extend(event.data)
+        self.frames.append(event.data)
         if event.fin:
-            self.send_receive_event_to_app(bytes(self.bytes))
+            self.send_receive_event_to_app()
 
     def handle_text(self, event: Frame) -> None:
         self.curr_msg_data_type = "text"
+        self.frames = [event.data]
         if event.fin:
-            self.send_receive_event_to_app(event.data)
-        else:
-            self.bytes = bytearray(event.data)
+            self.send_receive_event_to_app()
 
     def handle_bytes(self, event: Frame) -> None:
         self.curr_msg_data_type = "bytes"
+        self.frames = [event.data]
         if event.fin:
-            self.send_receive_event_to_app(event.data)
-        else:
-            self.bytes = bytearray(event.data)
+            self.send_receive_event_to_app()
 
-    def send_receive_event_to_app(self, data: bytes) -> None:
+    def send_receive_event_to_app(self) -> None:
+        data = self.frames[0] if len(self.frames) == 1 else b"".join(self.frames)
+        self.frames = []
         if self.curr_msg_data_type == "text":
             try:
                 self.queue.put_nowait({"type": "websocket.receive", "text": data.decode()})

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -221,7 +221,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
     def handle_cont(self, event: Frame) -> None:
         self.bytes.extend(event.data)
         if event.fin:
-            self.send_receive_event_to_app(self.bytes)
+            self.send_receive_event_to_app(bytes(self.bytes))
 
     def handle_text(self, event: Frame) -> None:
         self.curr_msg_data_type = "text"
@@ -237,7 +237,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         else:
             self.bytes = bytearray(event.data)
 
-    def send_receive_event_to_app(self, data: bytes | bytearray) -> None:
+    def send_receive_event_to_app(self, data: bytes) -> None:
         if self.curr_msg_data_type == "text":
             try:
                 self.queue.put_nowait({"type": "websocket.receive", "text": data.decode()})
@@ -247,7 +247,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 self.handle_parser_exception()
                 return
         else:
-            self.queue.put_nowait({"type": "websocket.receive", "bytes": bytes(data)})
+            self.queue.put_nowait({"type": "websocket.receive", "bytes": data})
         if not self.read_paused:
             self.read_paused = True
             self.transport.pause_reading()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -220,31 +220,33 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
     def handle_cont(self, event: Frame) -> None:
         self.bytes.extend(event.data)
         if event.fin:
-            self.send_receive_event_to_app()
+            self.send_receive_event_to_app(self.bytes)
 
     def handle_text(self, event: Frame) -> None:
-        self.bytes = bytearray(event.data)
         self.curr_msg_data_type: Literal["text", "bytes"] = "text"
         if event.fin:
-            self.send_receive_event_to_app()
+            self.send_receive_event_to_app(event.data)
+        else:
+            self.bytes = bytearray(event.data)
 
     def handle_bytes(self, event: Frame) -> None:
-        self.bytes = bytearray(event.data)
         self.curr_msg_data_type = "bytes"
         if event.fin:
-            self.send_receive_event_to_app()
+            self.send_receive_event_to_app(event.data)
+        else:
+            self.bytes = bytearray(event.data)
 
-    def send_receive_event_to_app(self) -> None:
+    def send_receive_event_to_app(self, data: bytes | bytearray) -> None:
         if self.curr_msg_data_type == "text":
             try:
-                self.queue.put_nowait({"type": "websocket.receive", "text": self.bytes.decode()})
+                self.queue.put_nowait({"type": "websocket.receive", "text": data.decode()})
             except UnicodeDecodeError:  # pragma: no cover
                 self.logger.exception("Invalid UTF-8 sequence received from client.")
                 self.conn.send_close(1007)
                 self.handle_parser_exception()
                 return
         else:
-            self.queue.put_nowait({"type": "websocket.receive", "bytes": bytes(self.bytes)})
+            self.queue.put_nowait({"type": "websocket.receive", "bytes": bytes(data)})
         if not self.read_paused:
             self.read_paused = True
             self.transport.pause_reading()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -105,8 +105,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.ping_sent_at: float = 0.0
         self.last_ping_rtt: float = 0.0
 
-        # Buffers
+        # Incoming message state
         self.bytes = bytearray()
+        self.curr_msg_data_type: Literal["text", "bytes"] = "bytes"
 
     def connection_made(self, transport: BaseTransport) -> None:
         """Called when a connection is made."""
@@ -164,9 +165,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 if event.opcode == Opcode.CONT:
                     self.handle_cont(event)  # pragma: no cover
                 elif event.opcode == Opcode.TEXT:
-                    self.handle_text(event)
+                    self.handle_data(event, "text")
                 elif event.opcode == Opcode.BINARY:
-                    self.handle_bytes(event)
+                    self.handle_data(event, "bytes")
                 elif event.opcode == Opcode.PING:
                     self.handle_ping()
                 elif event.opcode == Opcode.PONG:
@@ -222,15 +223,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         if event.fin:
             self.send_receive_event_to_app(self.bytes)
 
-    def handle_text(self, event: Frame) -> None:
-        self.curr_msg_data_type: Literal["text", "bytes"] = "text"
-        if event.fin:
-            self.send_receive_event_to_app(event.data)
-        else:
-            self.bytes = bytearray(event.data)
-
-    def handle_bytes(self, event: Frame) -> None:
-        self.curr_msg_data_type = "bytes"
+    def handle_data(self, event: Frame, data_type: Literal["text", "bytes"]) -> None:
+        self.curr_msg_data_type = data_type
         if event.fin:
             self.send_receive_event_to_app(event.data)
         else:


### PR DESCRIPTION
## Summary

#2917 switched the incoming message buffer to a `bytearray` to make fragmented reassembly O(n), but it left two copies on the single-frame path - the common case: `bytearray(event.data)` on arrival plus `bytes(self.bytes)` at enqueue, with both buffers alive at once (2x peak memory per message).

This replaces the `bytearray` with a `frames: list[bytes]` accumulator joined on message completion:

- Single-frame messages: zero copies - `event.data` goes straight from the parser into the queue, peak memory 1x the payload.
- Fragmented messages: one copy total via `b"".join` (the `bytearray` copied each fragment in and the whole buffer out again) - ~3x faster reassembly for a 1 MiB message in 256 fragments.
- The buffer is released on every delivery, so no payload is retained between messages.

Follow-up to https://github.com/Kludex/uvicorn/pull/2917#discussion_r3126649364.

## Test

Parametrized `test_fragmented_message_reassembly` over TEXT/BINARY opcodes - the fragmented text path had no coverage - and asserted the delivered payload types.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
