### PR TITLE
Load the app in the workers instead of the parent process

### DIFF
--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -7,6 +7,7 @@ import socket
 import threading
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -14,7 +15,7 @@ import pytest
 from uvicorn import Config
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.supervisors import Multiprocess
-from uvicorn.supervisors.multiprocess import Process
+from uvicorn.supervisors.multiprocess import WORKER_BOOT_ERROR, Process
 
 
 def new_console_in_windows(test_function: Callable[[], Any]) -> Callable[[], Any]:  # pragma: no cover
@@ -90,6 +91,33 @@ def test_multiprocess_health_check() -> None:
         time.sleep(0.1)
     supervisor.signal_queue.append(signal.SIGINT)
     supervisor.join_all()
+
+
+def test_multiprocess_shuts_down_on_worker_boot_failure() -> None:
+    """A worker that fails to load the app exits the supervisor instead of being restarted forever.
+
+    Regression for https://github.com/encode/uvicorn/discussions/2440: the bad import string is
+    only detectable in the worker, as the parent doesn't import the app module anymore
+    (https://github.com/Kludex/uvicorn/discussions/2980).
+    """
+    config = Config(app="tests.supervisors.test_multiprocess:app_does_not_exist", workers=2)
+    supervisor = Multiprocess(config, target=run, sockets=[])
+    with pytest.raises(SystemExit) as exc_info:
+        supervisor.run()
+    assert exc_info.value.code == WORKER_BOOT_ERROR
+
+
+def test_multiprocess_shuts_down_on_app_module_crash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exception in the app module body is a boot failure, not a reason to restart the worker."""
+    module = tmp_path / "crash_on_import_app.py"
+    module.write_text("raise RuntimeError('boom')\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    config = Config(app="crash_on_import_app:app", workers=2)
+    supervisor = Multiprocess(config, target=run, sockets=[])
+    with pytest.raises(SystemExit) as exc_info:
+        supervisor.run()
+    assert exc_info.value.code == WORKER_BOOT_ERROR
 
 
 @new_console_in_windows

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -12,10 +12,11 @@ from typing import Any
 
 import pytest
 
-from uvicorn import Config
+from uvicorn import Config, Server
+from uvicorn._subprocess import WORKER_BOOT_ERROR
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.supervisors import Multiprocess
-from uvicorn.supervisors.multiprocess import WORKER_BOOT_ERROR, Process
+from uvicorn.supervisors.multiprocess import Process
 
 
 def new_console_in_windows(test_function: Callable[[], Any]) -> Callable[[], Any]:  # pragma: no cover
@@ -101,7 +102,7 @@ def test_multiprocess_shuts_down_on_worker_boot_failure() -> None:
     (https://github.com/Kludex/uvicorn/discussions/2980).
     """
     config = Config(app="tests.supervisors.test_multiprocess:app_does_not_exist", workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, target=Server(config).run, sockets=[])
     with pytest.raises(SystemExit) as exc_info:
         supervisor.run()
     assert exc_info.value.code == WORKER_BOOT_ERROR
@@ -114,7 +115,7 @@ def test_multiprocess_shuts_down_on_app_module_crash(tmp_path: Path, monkeypatch
     monkeypatch.syspath_prepend(str(tmp_path))
 
     config = Config(app="crash_on_import_app:app", workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, target=Server(config).run, sockets=[])
     with pytest.raises(SystemExit) as exc_info:
         supervisor.run()
     assert exc_info.value.code == WORKER_BOOT_ERROR

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import socket
 import sys
 from logging import WARNING
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
@@ -14,7 +15,7 @@ from uvicorn import Server
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.config import Config
 from uvicorn.main import run
-from uvicorn.supervisors import Multiprocess
+from uvicorn.supervisors import ChangeReload, Multiprocess
 
 pytestmark = pytest.mark.anyio
 
@@ -88,25 +89,28 @@ def test_run_invalid_app_config_combination(caplog: pytest.LogCaptureFixture) ->
     )
 
 
-def test_run_fails_fast_in_parent_on_bad_app_path(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("kwargs", "supervisor_cls"),
+    [
+        pytest.param({"workers": 2}, Multiprocess, id="multiprocess"),
+        pytest.param({"reload": True}, ChangeReload, id="reload"),
+    ],
+)
+def test_run_does_not_import_app_in_parent_with_subprocesses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, Any], supervisor_cls: type
 ) -> None:
-    """Bad app path with `--workers > 1` exits in the parent.
+    """Subprocess workers import the app themselves; the parent holding its own copy is pure
+    memory overhead (https://github.com/Kludex/uvicorn/discussions/2980)."""
+    module = tmp_path / "lazy_parent_app.py"
+    module.write_text("app = object()\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(supervisor_cls, "run", lambda self: None)
 
-    Regression for https://github.com/encode/uvicorn/discussions/2440: without
-    parent-side validation the supervisor restarts dying workers forever.
-    """
+    with socket.socket() as sock:
+        monkeypatch.setattr(Config, "bind_socket", lambda self: sock)
+        run("lazy_parent_app:app", **kwargs)
 
-    def fail(*args: object, **kwargs: object) -> None:  # pragma: no cover
-        pytest.fail("parent reached supervisor; should have exited on bad app path")
-
-    monkeypatch.setattr(Config, "bind_socket", fail)
-    monkeypatch.setattr(Multiprocess, "run", fail)
-
-    with pytest.raises(SystemExit) as exit_exception:
-        run("tests.test_main:nonexistent_attr", workers=2)
-    assert exit_exception.value.code == 1
-    assert any("Error loading ASGI app" in record.message for record in caplog.records)
+    assert "lazy_parent_app" not in sys.modules
 
 
 def test_run_imports_app_before_starting_event_loop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uvicorn/_subprocess.py
+++ b/uvicorn/_subprocess.py
@@ -5,6 +5,7 @@ starting child processes.
 
 from __future__ import annotations
 
+import logging
 import multiprocessing
 import os
 import sys
@@ -16,6 +17,10 @@ from uvicorn.config import Config
 
 multiprocessing.allow_connection_pickling()
 spawn = multiprocessing.get_context("spawn")
+
+logger = logging.getLogger("uvicorn.error")
+
+WORKER_BOOT_ERROR = 3
 
 
 def get_subprocess(
@@ -82,3 +87,8 @@ def subprocess_started(
         # suppress the exception to avoid a traceback from subprocess.Popen
         # the parent already expects us to end, so no vital information is lost
         pass
+    except SystemExit:
+        sys.exit(WORKER_BOOT_ERROR)
+    except Exception:
+        logger.exception("Exception in worker process")
+        sys.exit(WORKER_BOOT_ERROR)

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -606,7 +606,9 @@ def run(
         logger.warning("You must pass the application as an import string to enable 'reload' or 'workers'.")
         sys.exit(1)
 
-    config.load_app()
+    # Subprocess workers import the app themselves; loading it in the parent only wastes memory (#2980).
+    if not config.use_subprocess:
+        config.load_app()
     server = Server(config=config)
 
     try:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import click
 
-from uvicorn._subprocess import get_subprocess
+from uvicorn._subprocess import WORKER_BOOT_ERROR, get_subprocess
 from uvicorn.config import Config
 
 SIGNALS = {
@@ -23,8 +23,6 @@ SIGNALS = {
 
 logger = logging.getLogger("uvicorn.error")
 
-WORKER_BOOT_ERROR = 3
-
 
 class Process:
     def __init__(
@@ -34,7 +32,6 @@ class Process:
         sockets: list[socket],
     ) -> None:
         self.real_target = target
-        self.config = config
 
         self.parent_conn, self.child_conn = Pipe()
         self.process = get_subprocess(config, self.target, sockets)
@@ -65,18 +62,6 @@ class Process:
             )
 
         threading.Thread(target=self.always_pong, daemon=True).start()
-
-        # Load before the event loop starts (#941), but after the pong thread is up so
-        # a slow app import doesn't trip the parent's healthcheck.
-        try:
-            if not self.config.loaded:
-                self.config.load()
-        except SystemExit:
-            sys.exit(WORKER_BOOT_ERROR)
-        except Exception:
-            logger.exception("Error loading ASGI app.")
-            sys.exit(WORKER_BOOT_ERROR)
-
         return self.real_target(sockets)
 
     def is_alive(self, timeout: float = 5) -> bool:
@@ -114,10 +99,6 @@ class Process:
     @property
     def pid(self) -> int | None:
         return self.process.pid
-
-    @property
-    def exitcode(self) -> int | None:
-        return self.process.exitcode
 
 
 class Multiprocess:
@@ -198,7 +179,7 @@ class Multiprocess:
             if self.should_exit.is_set():
                 return  # pragma: full coverage
 
-            if process.exitcode == WORKER_BOOT_ERROR:
+            if process.process.exitcode == WORKER_BOOT_ERROR:
                 logger.error(f"Child process [{process.pid}] failed to boot, shutting down.")
                 self.worker_boot_error = True
                 self.should_exit.set()

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import sys
 import threading
 from collections.abc import Callable
 from multiprocessing import Pipe
@@ -22,6 +23,8 @@ SIGNALS = {
 
 logger = logging.getLogger("uvicorn.error")
 
+WORKER_BOOT_ERROR = 3
+
 
 class Process:
     def __init__(
@@ -31,6 +34,7 @@ class Process:
         sockets: list[socket],
     ) -> None:
         self.real_target = target
+        self.config = config
 
         self.parent_conn, self.child_conn = Pipe()
         self.process = get_subprocess(config, self.target, sockets)
@@ -61,6 +65,18 @@ class Process:
             )
 
         threading.Thread(target=self.always_pong, daemon=True).start()
+
+        # Load before the event loop starts (#941), but after the pong thread is up so
+        # a slow app import doesn't trip the parent's healthcheck.
+        try:
+            if not self.config.loaded:
+                self.config.load()
+        except SystemExit:
+            sys.exit(WORKER_BOOT_ERROR)
+        except Exception:
+            logger.exception("Error loading ASGI app.")
+            sys.exit(WORKER_BOOT_ERROR)
+
         return self.real_target(sockets)
 
     def is_alive(self, timeout: float = 5) -> bool:
@@ -99,6 +115,10 @@ class Process:
     def pid(self) -> int | None:
         return self.process.pid
 
+    @property
+    def exitcode(self) -> int | None:
+        return self.process.exitcode
+
 
 class Multiprocess:
     def __init__(
@@ -115,6 +135,7 @@ class Multiprocess:
         self.processes: list[Process] = []
 
         self.should_exit = threading.Event()
+        self.worker_boot_error = False
 
         self.signal_queue: list[int] = []
         for sig in SIGNALS:
@@ -160,6 +181,9 @@ class Multiprocess:
         color_message = "Stopping parent process [{}]".format(click.style(str(os.getpid()), fg="cyan", bold=True))
         logger.info(message, extra={"color_message": color_message})
 
+        if self.worker_boot_error:
+            sys.exit(WORKER_BOOT_ERROR)
+
     def keep_subprocess_alive(self) -> None:
         if self.should_exit.is_set():
             return  # parent process is exiting, no need to keep subprocess alive
@@ -173,6 +197,12 @@ class Multiprocess:
 
             if self.should_exit.is_set():
                 return  # pragma: full coverage
+
+            if process.exitcode == WORKER_BOOT_ERROR:
+                logger.error(f"Child process [{process.pid}] failed to boot, shutting down.")
+                self.worker_boot_error = True
+                self.should_exit.set()
+                return
 
             logger.info(f"Child process [{process.pid}] died")
             process = Process(self.config, self.target, self.sockets)


### PR DESCRIPTION
## Summary

Closes the regression reported in #2980: since #2919, `uvicorn.run()` eagerly imports the app in the parent process, but spawn workers re-import it themselves - so with `--workers` or `--reload` the supervisor holds a full copy of the app for nothing (244 MB supervisor for a 200 MB app in the repro, now 45 MB).

- `run()` only loads the app in the parent when the parent serves it (`workers == 1`, no reload). Thread workers (#2900) are unaffected: they are not subprocesses, so they keep the eager parent load.
- A worker whose startup fails (bad import string, attribute error, exception in the app module body) now exits with code 3 (`WORKER_BOOT_ERROR`, same as gunicorn). The supervisor detects it, shuts everything down, and exits 3 - keeping #2440 fixed and extending fail-fast to module-body crashes, which the parent-side import never caught for spawn workers.

Behavior changes:
- A bad import string with `--workers` exits via the supervisor (~0.7s, exit code 3) instead of instantly in the parent (exit code 1).
- Under `--reload`, a broken app logs the error and waits for a file change instead of killing the reloader - the pre-#2919 behavior.
- An exception that escapes `Server.run` in a worker now shuts the whole server down instead of restarting the worker. In practice only startup failures escape it, and restarting was an infinite crash loop anyway.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.