### PR TITLE
Check directory excludes before the explicit-include shortcut in `FileFilter`

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -409,3 +409,38 @@ def test_base_reloader_closes_sockets_on_shutdown():
     assert sock.fileno() != -1
     reloader.shutdown()
     assert sock.fileno() == -1
+
+
+@pytest.mark.skipif(WatchFilesReload is None, reason="watchfiles not available")
+def test_file_filter_explicit_include_respects_exclude_dirs(tmp_path: Path):
+    """Exact-name entries in --reload-include must still be blocked by --reload-exclude dirs.
+
+    When the include pattern has no wildcards (e.g. ".dotted" or "ext/ext.jpg"),
+    FileFilter used to return True immediately after the endswith check, skipping
+    the exclude_dirs guard entirely.  A file inside an excluded directory should
+    be rejected even when its name matches an explicit include pattern.
+    """
+    from uvicorn.supervisors.watchfilesreload import FileFilter
+
+    excluded_dir = tmp_path / "vendor"
+    excluded_dir.mkdir()
+
+    config = Config(
+        app="tests.test_config:asgi_app",
+        reload=True,
+        reload_includes=[".dotted"],
+        reload_excludes=[str(excluded_dir)],
+    )
+    file_filter = FileFilter(config)
+
+    # Explicit include outside the excluded dir: must be watched.
+    assert file_filter(tmp_path / "src" / ".dotted") is True
+
+    # Explicit include inside the excluded dir: must NOT be watched.
+    assert file_filter(excluded_dir / ".dotted") is False
+
+    # Regular *.py outside excluded dir: must be watched.
+    assert file_filter(tmp_path / "app.py") is True
+
+    # Regular *.py inside excluded dir: must NOT be watched.
+    assert file_filter(excluded_dir / "app.py") is False

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -37,12 +37,16 @@ class FileFilter:
     def __call__(self, path: Path) -> bool:
         for include_pattern in self.includes:
             if path.match(include_pattern):
-                if str(path).endswith(include_pattern):
-                    return True  # pragma: full coverage
-
                 for exclude_dir in self.exclude_dirs:
                     if exclude_dir in path.parents:
                         return False  # pragma: no cover
+
+                # Exact-path includes (e.g. ".dotted" or "ext/ext.jpg") must
+                # bypass the pattern-level excludes so that hidden files and
+                # other non-glob entries listed in --reload-include are watched,
+                # but they still respect directory-level excludes above.
+                if str(path).endswith(include_pattern):
+                    return True  # pragma: full coverage
 
                 for exclude_pattern in self.excludes:
                     if path.match(exclude_pattern):


### PR DESCRIPTION
When an explicit path (e.g. `.dotted` or `ext/ext.jpg`) is listed in
`--reload-include`, `FileFilter.__call__` matched via `path.match()`
and then hit the `str(path).endswith(include_pattern)` shortcut, which
returned `True` immediately.  The early return skipped the loop that
checks `exclude_dirs`, so any file whose name exactly matched an include
pattern was watched even when it lived inside a directory listed in
`--reload-exclude`.

The `endswith` shortcut was added in c55af77 to let hidden/dotted files
and other non-glob entries bypass the *pattern-level* excludes (e.g.
`.*`).  That intent is correct; the mistake is that it also bypassed
*directory-level* excludes, which is a stronger signal from the user.

The fix moves the `exclude_dirs` loop above the `endswith` shortcut so
that directory exclusions are always evaluated first.  Files that match
an exact include pattern but reside under an excluded directory are now
rejected, while files outside excluded directories continue to bypass
the pattern excludes as before.

A new unit test (pure `FileFilter` instantiation, no file-system
watcher) reproduces the bug and confirms the fix: it asserts that
`vendor/.dotted` is not watched when `.dotted` is in `--reload-include`
and `vendor/` is in `--reload-exclude`.