### PR TITLE
Validate --header format and raise BadParameter on missing colon

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,11 +60,21 @@ def test_cli_headers() -> None:
     assert result.exit_code == 0
     mock_run.assert_called_once()
     assert mock_run.call_args[1]["headers"] == [
-        [
+        (
             "Content-Security-Policy",
             "default-src 'self'; script-src https://example.com",
-        ]
+        )
     ]
+
+
+def test_cli_headers_missing_colon() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["tests.test_cli:App", "--header", "X-Bad-Header"])
+
+    assert result.exit_code == 2
+    assert "Expected 'Name:Value' format" in result.output
+    assert "X-Bad-Header" in result.output
 
 
 def test_cli_call_server_run() -> None:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -59,6 +59,20 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     ctx.exit()
 
 
+def _parse_header(header: str) -> tuple[str, str]:
+    """Parse a ``Name:Value`` CLI header string into a ``(name, value)`` pair.
+
+    Raises :class:`click.BadParameter` when the required colon separator is absent.
+    """
+    if ":" not in header:
+        raise click.BadParameter(
+            f"Expected 'Name:Value' format, got '{header}'.",
+            param_hint="'--header'",
+        )
+    name, _, value = header.partition(":")
+    return name, value
+
+
 @click.command(context_settings={"auto_envvar_prefix": "UVICORN"})
 @click.argument("app", envvar="UVICORN_APP")
 @click.option(
@@ -483,7 +497,7 @@ def main(
         ssl_cert_reqs=ssl_cert_reqs,
         ssl_ca_certs=ssl_ca_certs,
         ssl_ciphers=ssl_ciphers,
-        headers=[header.split(":", 1) for header in headers],  # type: ignore[misc]
+        headers=[_parse_header(header) for header in headers],
         use_colors=use_colors,
         factory=factory,
         app_dir=app_dir,


### PR DESCRIPTION
# Summary

Passing `--header` without a colon separator (e.g. `--header X-Foo`) crashes
with an opaque `ValueError` deep inside `Config.load()`:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

This happens because `header.split(':', 1)` returns a 1-element list when no
colon is present, and the unpacking in `Config.load()` silently expects 2 items.

**Fix:** introduce `_parse_header()` which raises `click.BadParameter` at the
CLI boundary, giving the user a clear, actionable error:

```
Error: Invalid value for '--header': Expected 'Name:Value' format, got 'X-Foo'.
```

Also switches from `str.split()` (returns a `list`) to `str.partition()`
(returns a 3-tuple) so the type matches `list[tuple[str, str]]` expected by
`Config`, removing the `# type: ignore[misc]` comment.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.

---

> This fix was developed with AI assistance (Claude).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/2992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

