### PR TITLE
StatReload: exclude hidden / cache directories when scanning for .py files

### DIFF
--- a/tests/supervisors/test_statreload_filter.py
+++ b/tests/supervisors/test_statreload_filter.py
@@ -1,0 +1,69 @@
+"""Test that StatReload excludes hidden / cache / venv .py files by default.
+
+Without a fix, StatReload.iter_py_files() recursively lists every .py file
+under reload_dirs, including those inside .venv/, .mypy_cache/, .git/, and
+.pyc/.pyd/.pyo siblings. This causes spurious reloads on unrelated changes
+(virtualenv installs, type-checker cache, git checkout operations).
+
+WatchFilesReload has the same default exclude list (FileFilter); StatReload
+should match.
+"""
+
+from pathlib import Path
+
+from uvicorn.config import Config
+from uvicorn.supervisors.statreload import StatReload
+
+
+class _FakeStatReload(StatReload):
+    """StatReload requires sockets/target — we just want iter_py_files()."""
+
+    def __init__(self, config):
+        self.config = config
+        self.mtimes = {}
+        self.reloader_name = "test"
+        from threading import Event
+
+        self.should_exit = Event()
+        self.pid = 0
+        self.is_restarting = False
+        self.sockets = []
+        self.target = lambda **kw: None
+
+
+def _make_project(root: Path) -> Config:
+    (root / "app.py").write_text("# app\n")
+    (root / ".venv" / "lib").mkdir(parents=True)
+    (root / ".venv" / "lib" / "somelib.py").write_text("# venv lib\n")
+    (root / ".mypy_cache").mkdir()
+    (root / ".mypy_cache" / "x.py").write_text("# cache\n")
+    (root / ".git").mkdir()
+    (root / ".git" / "hooks").mkdir(parents=True)
+    (root / ".git" / "hooks" / "y.py").write_text("# git hook\n")
+    (root / "module.pyc").write_text("not python")  # extension is .pyc, not .py
+    (root / "x.pyo").write_text("not python")
+    return Config(app="app", reload=True, reload_dirs=[str(root)])
+
+
+def test_statreload_excludes_hidden_dirs(tmp_path):
+    config = _make_project(tmp_path)
+    r = _FakeStatReload(config)
+    watched = {p.name for p in r.iter_py_files()}
+    assert "app.py" in watched, "real app.py should still be watched"
+    assert "somelib.py" not in watched, ".venv/*.py should be excluded (regression: spurious venv reloads)"
+    assert "x.py" not in watched, ".mypy_cache/*.py should be excluded (regression: spurious cache reloads)"
+    # y.py is inside .git — should also be excluded
+    assert all(".git" not in str(p) for p in r.iter_py_files()), ".git/*.py should be excluded"
+
+
+def test_statreload_includes_app_in_subdir(tmp_path):
+    """Sanity: a real .py in a non-excluded subdir should be watched."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "real.py").write_text("# real\n")
+    (tmp_path / ".venv" / "lib").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".venv" / "lib" / "fake.py").write_text("# fake\n")
+    config = Config(app="app", reload=True, reload_dirs=[str(tmp_path)])
+    r = _FakeStatReload(config)
+    paths = [str(p) for p in r.iter_py_files()]
+    assert any("pkg/real.py" in p for p in paths), "real .py in a subdir should still be watched"
+    assert not any(".venv" in p for p in paths), "no .venv files should be watched"

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -46,7 +46,16 @@ class StatReload(BaseReload):
         self.mtimes = {}
         return super().restart()
 
+    # Default exclude patterns mirroring WatchFilesReload's FileFilter so
+    # that the two reloader implementations behave consistently. Without
+    # this, StatReload would pick up .py files inside .venv/, .mypy_cache/,
+    # .git/ and other hidden / cache directories, causing spurious reloads.
+    _DEFAULT_EXCLUDE_DIRS = (".venv", ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache")
+
     def iter_py_files(self) -> Iterator[Path]:
         for reload_dir in self.config.reload_dirs:
             for path in list(reload_dir.rglob("*.py")):
+                # Skip files inside well-known hidden / cache directories.
+                if any(part in self._DEFAULT_EXCLUDE_DIRS for part in path.parts):
+                    continue
                 yield path.resolve()


### PR DESCRIPTION
## Summary

`StatReload.iter_py_files()` does a recursive `rglob("*.py")` and yields **every** match, including `.py` files inside `.venv/`, `.mypy_cache/`, `.pytest_cache/`, `.ruff_cache/`, and `.git/`. `WatchFilesReload`'s `FileFilter` already excludes these (via watch_filter), but the stat-based reloader does not — so users running with `watchfiles` not installed see spurious reloads on venv installs, type-checker cache writes, linter cache writes, and git operations that touch `.git/hooks/*.py`.

## Fix

Add a small static `_DEFAULT_EXCLUDE_DIRS` tuple to `StatReload` and skip any path whose parts intersect it. Mirrors the spirit of `WatchFilesReload.FileFilter` defaults without taking a runtime dependency on watchfiles.

## Reproducer

```python
from pathlib import Path
from uvicorn.config import Config
from uvicorn.supervisors.statreload import StatReload

root = Path("/tmp/project")
(root / "app.py").write_text("# app")
(root / ".venv" / "lib").mkdir(parents=True)
(root / ".venv" / "lib" / "somelib.py").write_text("# venv lib")
(root / ".mypy_cache").mkdir()
(root / ".mypy_cache" / "x.py").write_text("# cache")

config = Config(app="app", reload=True, reload_dirs=[str(root)])
r = StatReload(config, target=lambda **kw: None, sockets=[])
for p in r.iter_py_files():
    print(p)
```

Before the fix: prints `app.py`, `.venv/lib/somelib.py`, `.mypy_cache/x.py` — the latter two cause spurious reloads.
After the fix: prints only `app.py`.

## Tests

`tests/supervisors/test_statreload_filter.py` — 2 cases:

- `test_statreload_excludes_hidden_dirs` — fails before, passes after
- `test_statreload_includes_app_in_subdir` — sanity check that real `.py` in a non-excluded subdir is still watched

Test run:
- New tests: 2/2 passing
- `tests/supervisors/`: 28 passed (full supervisors suite)
- `tests/test_config.py`: 122 passed
- No regressions

Refs: AI-2138 (bug-hunter Strategy B, source-code audit)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/2995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

