### PR TITLE
Automatic reap orphan child processes

### DIFF
--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import functools
+import logging
 import os
 import signal
 import socket
+import sys
 import threading
 import time
 from collections.abc import Callable
@@ -173,3 +175,62 @@ def test_multiprocess_sigttou() -> None:
     assert len(supervisor.processes) == 1
     supervisor.signal_queue.append(signal.SIGINT)
     supervisor.join_all()
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Orphan reaping is only supported on Linux.")
+def test_multiprocess_reap_orphans(caplog: pytest.LogCaptureFixture) -> None:  # pragma: py-not-linux
+    config = Config(app=app, workers=2)
+    supervisor = Multiprocess(config, target=run, sockets=[])
+
+    read_fd, write_fd = os.pipe()
+    child_pid = os.fork()
+    if child_pid == 0:  # pragma: no cover
+        os.close(write_fd)
+        os.read(read_fd, 1)
+        os._exit(0)
+    os.close(read_fd)
+
+    supervisor.reap_orphans()
+    assert os.waitpid(child_pid, os.WNOHANG) == (0, 0)
+
+    os.close(write_fd)
+
+    with caplog.at_level(logging.DEBUG, logger="uvicorn.error"):
+        deadline = time.monotonic() + 10
+        while f"Reaped orphaned child process [{child_pid}]" not in caplog.text:
+            supervisor.reap_orphans()
+            assert time.monotonic() < deadline, "Timed out waiting for the orphan to be reaped"
+            time.sleep(0.05)
+
+    with pytest.raises(ChildProcessError):
+        os.waitpid(child_pid, os.WNOHANG)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Orphan reaping is only supported on Linux.")
+def test_multiprocess_reap_orphans_no_children(monkeypatch: pytest.MonkeyPatch) -> None:  # pragma: py-not-linux
+    config = Config(app=app, workers=2)
+    supervisor = Multiprocess(config, target=run, sockets=[])
+
+    def no_children(pid: int, options: int) -> tuple[int, int]:
+        raise ChildProcessError
+
+    monkeypatch.setattr(os, "waitpid", no_children)
+    supervisor.reap_orphans()  # must not raise
+
+
+def test_multiprocess_reap_orphans_when_init_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = Config(app=app, workers=2)
+    supervisor = Multiprocess(config, target=run, sockets=[])
+
+    reaped = threading.Event()
+    monkeypatch.setattr(supervisor, "init_processes", lambda: None)
+    monkeypatch.setattr(supervisor, "keep_subprocess_alive", lambda: None)
+    monkeypatch.setattr(supervisor, "reap_orphans", reaped.set)
+    monkeypatch.setattr(os, "getpid", lambda: 1)
+
+    thread = threading.Thread(target=supervisor.run, daemon=True)
+    thread.start()
+    assert reaped.wait(10), "reap_orphans was not called while running as the init process"
+    supervisor.should_exit.set()
+    thread.join(10)
+    assert not thread.is_alive()

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import signal
+import sys
 import threading
 from collections.abc import Callable
 from multiprocessing import Pipe
@@ -148,9 +149,14 @@ class Multiprocess:
 
         self.init_processes()
 
+        is_init_process = os.getpid() == 1
+
         while not self.should_exit.wait(0.5):
             self.handle_signals()
             self.keep_subprocess_alive()
+
+            if is_init_process:
+                self.reap_orphans()
 
         self.terminate_all()
         self.join_all()
@@ -177,6 +183,20 @@ class Multiprocess:
             process = Process(self.config, self.target, self.sockets)
             process.start()
             self.processes[idx] = process
+
+    def reap_orphans(self) -> None:  # pragma: py-not-linux
+        if sys.platform != "linux":
+            return  # pragma: py-linux
+
+        while True:
+            try:
+                pid, _ = os.waitpid(-1, os.WNOHANG)
+            except ChildProcessError:
+                return
+            if pid == 0:
+                return
+
+            logger.debug(f"Reaped orphaned child process [{pid}]")
 
     def handle_signals(self) -> None:
         for sig in tuple(self.signal_queue):


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

If Uvicorn is running inside a Docker container and is configured as the container's entrypoint, it will run as PID 1. In this case, it is also responsible for reaping orphaned child processes.

This merge request introduces functionality to automatically clean up orphaned child processes when Uvicorn is running as PID 1, preventing process ID leaks and ensuring proper process management.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/2997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

