### PR TITLE
fix: add grace-period timeout to process.join() in BaseReload to prevent indefinite hang

### DIFF
--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -21,6 +21,8 @@ HANDLED_SIGNALS = (
 
 logger = logging.getLogger("uvicorn.error")
 
+_DEFAULT_GRACEFUL_TIMEOUT = 5
+
 
 class BaseReload:
     def __init__(
@@ -83,6 +85,25 @@ class BaseReload:
         self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
         self.process.start()
 
+    def _join_with_timeout(self) -> None:
+        """Join the worker process with a grace-period timeout.
+
+        If the worker has not exited after ``timeout_graceful_shutdown`` seconds
+        (defaulting to 5 s), it is force-killed with SIGKILL so the supervisor
+        is never blocked indefinitely by long-lived connections (SSE, WebSocket,
+        chunked streaming, etc.).
+        """
+        timeout = self.config.timeout_graceful_shutdown or _DEFAULT_GRACEFUL_TIMEOUT
+        self.process.join(timeout=timeout)
+        if self.process.is_alive():
+            logger.warning(
+                "Worker process [%s] did not exit after %ss; sending SIGKILL.",
+                self.process.pid,
+                timeout,
+            )
+            self.process.kill()
+            self.process.join()
+
     def restart(self) -> None:
         if sys.platform == "win32":  # pragma: py-not-win32
             self.is_restarting = True
@@ -94,7 +115,7 @@ class BaseReload:
             sys.stdout.flush()
         else:  # pragma: py-win32
             self.process.terminate()
-        self.process.join()
+        self._join_with_timeout()
 
         self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
         self.process.start()
@@ -104,7 +125,7 @@ class BaseReload:
             self.should_exit.set()  # pragma: py-not-win32
         else:
             self.process.terminate()  # pragma: py-win32
-        self.process.join()
+        self._join_with_timeout()
 
         for sock in self.sockets:
             sock.close()


### PR DESCRIPTION
## Summary

Fixes the bug reported in #2943.

`BaseReload.restart()` and `BaseReload.shutdown()` both called `self.process.join()` without a timeout. If a worker holds any long-lived connection (SSE, WebSocket, chunked streaming), it will not exit after receiving `SIGTERM` — the OS keeps the socket alive. `process.join()` then blocks indefinitely, hot-reload silently hangs, and no new worker is ever spawned.

## Changes

- Extracted a `_join_with_timeout()` helper on `BaseReload`.
- It calls `process.join(timeout=...)` using `config.timeout_graceful_shutdown` (falling back to 5 s if unset — the same default uvicorn uses elsewhere).
- If the process is still alive after the grace period, a warning is logged and `process.kill()` (SIGKILL) is sent, followed by a final blocking `process.join()` to reap the zombie.
- `restart()` and `shutdown()` now call `_join_with_timeout()` instead of the bare `process.join()`.

## Before / After

**Before:**
```python
def restart(self) -> None:
    ...
    self.process.terminate()
    self.process.join()          # blocks forever if worker has open connections
    ...

def shutdown(self) -> None:
    ...
    self.process.terminate()
    self.process.join()          # same problem
    ...
```

**After:**
```python
def _join_with_timeout(self) -> None:
    timeout = self.config.timeout_graceful_shutdown or 5
    self.process.join(timeout=timeout)
    if self.process.is_alive():
        logger.warning('Worker process [%s] did not exit after %ss; sending SIGKILL.', ...)
        self.process.kill()
        self.process.join()

def restart(self) -> None:
    ...
    self.process.terminate()
    self._join_with_timeout()    # never blocks indefinitely
    ...

def shutdown(self) -> None:
    ...
    self.process.terminate()
    self._join_with_timeout()    # never blocks indefinitely
    ...
```

## Testing

Reproduce with any app that has an SSE or WebSocket endpoint with a live client:

1. Connect a client so the connection stays open.
2. Edit any watched file to trigger a reload.
3. **Before this fix:** `WatchFiles detected changes` is logged, the worker receives SIGTERM but the supervisor hangs — no new worker appears.
4. **After this fix:** the worker is given a grace period; if it hasn't exited it is force-killed and the new worker starts immediately.

Closes #2943

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

