### PR TITLE
Stringify SERVER_PORT in the WSGI environ

### DIFF
--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -136,3 +136,32 @@ def test_build_environ_encoding() -> None:
     assert environ["SCRIPT_NAME"] == "/文".encode().decode("latin-1")
     assert environ["PATH_INFO"] == b"/all".decode("latin-1")
     assert environ["HTTP_KEY"] == "value1,value2"
+    # WSGI requires SERVER_PORT to be a native string (PEP 3333).
+    assert environ["SERVER_PORT"] == "80"
+
+
+def test_build_environ_server_port_is_str() -> None:
+    scope: HTTPScope = {
+        "asgi": {"version": "3.0", "spec_version": "2.0"},
+        "scheme": "http",
+        "raw_path": b"/",
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "path": "/",
+        "root_path": "",
+        "client": None,
+        "server": ("example.org", 8000),
+        "query_string": b"",
+        "headers": [],
+        "extensions": {},
+    }
+    message: HTTPRequestEvent = {
+        "type": "http.request",
+        "body": b"",
+        "more_body": False,
+    }
+    environ = wsgi.build_environ(scope, message, io.BytesIO(b""))
+    assert environ["SERVER_NAME"] == "example.org"
+    assert environ["SERVER_PORT"] == "8000"
+    assert isinstance(environ["SERVER_PORT"], str)

--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -52,7 +52,7 @@ def build_environ(scope: HTTPScope, message: ASGIReceiveEvent, body: io.BytesIO)
     if server is None:
         server = ("localhost", 80)
     environ["SERVER_NAME"] = server[0]
-    environ["SERVER_PORT"] = server[1]
+    environ["SERVER_PORT"] = str(server[1] or 80)
 
     # Get client IP address
     client = scope.get("client")


### PR DESCRIPTION
# Summary

`build_environ` assigns the scope's server port straight into the WSGI environ:

```python
environ["SERVER_PORT"] = server[1]
```

`server[1]` is an `int` (and can be `None` for a Unix domain socket, per the `server: tuple[str, int | None] | None` type in `uvicorn/_types.py`). PEP 3333 requires every value in the WSGI environ, including the CGI variables like `SERVER_PORT`, to be a native string. Every other CGI variable here (`SERVER_NAME`, `PATH_INFO`, `QUERY_STRING`, ...) is already a string, so `SERVER_PORT` is the odd one out, and a downstream WSGI app that does string work on it gets the wrong type.

The fix casts it, falling back to 80 when the port is `None`, which mirrors what asgiref's WSGI adapter does:

```python
environ["SERVER_PORT"] = str(server[1] or 80)
```

Added a test asserting `SERVER_PORT` is the string `"8000"` for an explicit server, and that the no-server default stays `"80"`.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

