### PR TITLE
fix: no downtime for multiple workers while restarting

### DIFF
--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -142,6 +142,73 @@ def test_multiprocess_sighup() -> None:
     supervisor.join_all()
 
 
+@pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="platform unsupports SIGHUP")
+def test_multiprocess_sighup_keeps_worker_count_during_restart() -> None:
+    """
+    Ensure that a SIGHUP-triggered restart never drops below the configured
+    number of live workers, i.e. each replacement process is started (and
+    confirmed healthy) before its predecessor is terminated.
+    """
+    config = Config(app=app, workers=2)
+    supervisor = Multiprocess(config, target=run, sockets=[])
+    threading.Thread(target=supervisor.run, daemon=True).start()
+    time.sleep(1)
+
+    pids = [p.pid for p in supervisor.processes]
+    counts: list[int] = []
+    stop = threading.Event()
+
+    def poll_alive_count() -> None:
+        while not stop.is_set():
+            counts.append(sum(1 for p in supervisor.processes if p.process.is_alive()))
+            time.sleep(0.01)
+
+    poller = threading.Thread(target=poll_alive_count, daemon=True)
+    poller.start()
+
+    supervisor.signal_queue.append(signal.SIGHUP)
+
+    # Poll instead of a fixed sleep, the supervisor loop runs on a 0.5s interval and `restart_all()`
+    # confirms each replacement worker's health before terminating the one it replaces, so the total
+    # time is non-deterministic.
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if [p.pid for p in supervisor.processes] != pids:
+            break
+        time.sleep(0.1)
+    assert pids != [p.pid for p in supervisor.processes]
+
+    stop.set()
+    poller.join()
+
+    assert counts, "poller did not sample any process counts"
+    assert min(counts) >= config.workers
+
+    supervisor.signal_queue.append(signal.SIGINT)
+    supervisor.join_all()
+
+
+def test_multiprocess_restart_keeps_old_process_if_new_one_unhealthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    If a replacement worker fails its health check during a restart, the
+    original worker should be left running instead of being terminated.
+    """
+    config = Config(app=app, workers=1)
+    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor.init_processes()
+    old_process = supervisor.processes[0]
+
+    monkeypatch.setattr(Process, "is_alive", lambda self, timeout=5: False)
+
+    supervisor.restart_all()
+
+    assert supervisor.processes[0] is old_process
+    assert old_process.process.is_alive()
+
+    old_process.terminate()
+    old_process.join()
+
+
 @pytest.mark.skipif(not hasattr(signal, "SIGTTIN"), reason="platform unsupports SIGTTIN")
 def test_multiprocess_sigttin() -> None:
     """

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -188,25 +188,29 @@ def test_multiprocess_sighup_keeps_worker_count_during_restart() -> None:
     supervisor.join_all()
 
 
-def test_multiprocess_restart_keeps_old_process_if_new_one_unhealthy(monkeypatch: pytest.MonkeyPatch) -> None:
+@new_console_in_windows
+def test_multiprocess_restart_keeps_old_process_if_new_one_unhealthy() -> None:
     """
     If a replacement worker fails its health check during a restart, the
     original worker should be left running instead of being terminated.
     """
-    config = Config(app=app, workers=1)
-    supervisor = Multiprocess(config, target=run, sockets=[])
-    supervisor.init_processes()
-    old_process = supervisor.processes[0]
+    original_is_alive = Process.is_alive
+    Process.is_alive = lambda self, timeout=5: False  # type: ignore[method-assign]
+    try:
+        config = Config(app=app, workers=1)
+        supervisor = Multiprocess(config, target=run, sockets=[])
+        supervisor.init_processes()
+        old_process = supervisor.processes[0]
 
-    monkeypatch.setattr(Process, "is_alive", lambda self, timeout=5: False)
+        supervisor.restart_all()
 
-    supervisor.restart_all()
+        assert supervisor.processes[0] is old_process
+        assert old_process.process.is_alive()
 
-    assert supervisor.processes[0] is old_process
-    assert old_process.process.is_alive()
-
-    old_process.terminate()
-    old_process.join()
+        old_process.terminate()
+        old_process.join()
+    finally:
+        Process.is_alive = original_is_alive  # type: ignore[method-assign]
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGTTIN"), reason="platform unsupports SIGTTIN")

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -134,12 +134,22 @@ class Multiprocess:
             process.join()
 
     def restart_all(self) -> None:
-        for idx, process in enumerate(self.processes):
-            process.terminate()
-            process.join()
+        for idx, old_process in enumerate(self.processes):
             new_process = Process(self.config, self.target, self.sockets)
             new_process.start()
+
+            if not new_process.is_alive(timeout=self.config.timeout_worker_healthcheck):
+                logger.error(
+                    "New worker failed to start during restart. Keeping existing worker [%s] running.",
+                    old_process.pid,
+                )
+                new_process.kill()
+                new_process.join()
+                continue
+
             self.processes[idx] = new_process
+            old_process.terminate()
+            old_process.join()
 
     def run(self) -> None:
         message = f"Started parent process [{os.getpid()}]"


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

