### PR TITLE
Add opt-in dual-stack IPv6 socket support

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -47,6 +47,7 @@ uvicorn itself.
 * `--port <int>` - Bind to a socket with this port. If set to 0, an available port will be picked. **Default:** *8000*.
 * `--uds <path>` - Bind to a UNIX domain socket, for example `--uds /tmp/uvicorn.sock`. Useful if you want to run Uvicorn behind a reverse proxy.
 * `--fd <int>` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.
+* `--dual-stack` - When binding an IPv6 socket, also accept IPv4 connections using IPv4-mapped IPv6 addresses on platforms that support dual-stack sockets. This changes network exposure for `--host '::'`, so it is opt-in. **Default:** *False*.
 
 ## Development
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ from pytest_mock import MockerFixture
 from tests.custom_loop_utils import CustomLoop
 from tests.utils import as_cwd, get_asyncio_default_loop_per_os
 from uvicorn._types import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Environ, Scope, StartResponse
-from uvicorn.config import Config, LoopFactoryType, UvicornDeprecationWarning
+from uvicorn.config import STARTUP_FAILURE, Config, LoopFactoryType, UvicornDeprecationWarning
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
@@ -260,6 +260,30 @@ def test_socket_bind() -> None:
     sock = config.bind_socket()
     assert isinstance(sock, socket.socket)
     sock.close()
+
+
+@pytest.mark.skipif(not socket.has_dualstack_ipv6(), reason="Platform does not support dual-stack IPv6 sockets")
+def test_dual_stack_socket_bind() -> None:
+    config = Config(app=asgi_app, host="::", port=0, dual_stack=True)
+    config.load()
+    sock = config.bind_socket()
+    try:
+        assert isinstance(sock, socket.socket)
+        assert sock.family == socket.AF_INET6
+        assert sock.getsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY) == 0
+    finally:
+        sock.close()
+
+
+def test_dual_stack_socket_bind_exits_with_startup_failure_when_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(socket, "has_dualstack_ipv6", lambda: False)
+    config = Config(app=asgi_app, host="::", port=0, dual_stack=True)
+
+    with pytest.raises(SystemExit) as exc_info:
+        config.bind_socket()
+    assert exc_info.value.code == STARTUP_FAILURE
 
 
 def test_ssl_config(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ import contextvars
 import json
 import logging
 import signal
+import socket
 import sys
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager
@@ -148,6 +149,18 @@ async def test_request_than_limit_max_requests_warn_log(
             responses = await asyncio.gather(*tasks)
             assert len(responses) == 2
     assert "Maximum request limit of 1 exceeded. Terminating process." in caplog.text
+
+
+@pytest.mark.skipif(not socket.has_dualstack_ipv6(), reason="Platform does not support dual-stack IPv6 sockets")
+async def test_dual_stack_server_accepts_ipv4_on_ipv6_socket(unused_tcp_port: int):
+    config = Config(app=app, host="::", port=unused_tcp_port, loop="asyncio", dual_stack=True)
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            ipv4_response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+            ipv6_response = await client.get(f"http://[::1]:{unused_tcp_port}")
+
+    assert ipv4_response.status_code == 200
+    assert ipv6_response.status_code == 200
 
 
 async def test_limit_max_requests_jitter(

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -242,12 +242,14 @@ class Config:
         factory: bool = False,
         h11_max_incomplete_event_size: int | None = None,
         reset_contextvars: bool = False,
+        dual_stack: bool = False,
     ):
         self.app = app
         self.host = host
         self.port = port
         self.uds = uds
         self.fd = fd
+        self.dual_stack = dual_stack
         self.loop = loop
         self.http = http
         self.ws = ws
@@ -579,8 +581,14 @@ class Config:
                 family = socket.AF_INET6
                 addr_format = "%s://[%s]:%d"
 
+            if family == socket.AF_INET6 and self.dual_stack and not socket.has_dualstack_ipv6():
+                logger.error("Dual-stack IPv6 sockets are not supported on this platform.")
+                sys.exit(STARTUP_FAILURE)
+
             sock = socket.socket(family=family)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if family == socket.AF_INET6 and self.dual_stack:
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
             try:
                 sock.bind((self.host, self.port))
             except OSError as exc:  # pragma: full coverage

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -76,6 +76,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
 )
 @click.option("--uds", type=str, default=None, help="Bind to a UNIX domain socket.")
 @click.option("--fd", type=int, default=None, help="Bind to socket from this file descriptor.")
+@click.option(
+    "--dual-stack",
+    is_flag=True,
+    default=False,
+    help="Allow IPv6 sockets to also accept IPv4 connections.",
+    show_default=True,
+)
 @click.option("--reload", is_flag=True, default=False, help="Enable auto-reload.")
 @click.option(
     "--reload-dir",
@@ -391,6 +398,7 @@ def main(
     port: int,
     uds: str,
     fd: int,
+    dual_stack: bool,
     loop: LoopFactoryType | str,
     http: HTTPProtocolType | str,
     ws: WSProtocolType | str,
@@ -443,6 +451,7 @@ def main(
         port=port,
         uds=uds,
         fd=fd,
+        dual_stack=dual_stack,
         loop=loop,
         http=http,
         ws=ws,
@@ -498,6 +507,7 @@ def run(
     port: int = 8000,
     uds: str | None = None,
     fd: int | None = None,
+    dual_stack: bool = False,
     loop: LoopFactoryType | str = "auto",
     http: type[asyncio.Protocol] | HTTPProtocolType | str = "auto",
     ws: type[asyncio.Protocol] | WSProtocolType | str = "auto",
@@ -554,6 +564,7 @@ def run(
         port=port,
         uds=uds,
         fd=fd,
+        dual_stack=dual_stack,
         loop=loop,
         http=http,
         ws=ws,

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -118,6 +118,7 @@ class Server:
             )
 
         loop = asyncio.get_running_loop()
+        has_logged_socket = False
 
         listeners: Sequence[socket.SocketType]
         if sockets is not None:  # pragma: full coverage
@@ -167,13 +168,23 @@ class Server:
         else:
             # Standard case. Create a socket from a host/port pair.
             try:
-                server = await loop.create_server(
-                    create_protocol,
-                    host=config.host,
-                    port=config.port,
-                    ssl=config.ssl,
-                    backlog=config.backlog,
-                )
+                if config.dual_stack and config.host and ":" in config.host:
+                    sock = config.bind_socket()
+                    server = await loop.create_server(
+                        create_protocol,
+                        sock=sock,
+                        ssl=config.ssl,
+                        backlog=config.backlog,
+                    )
+                    has_logged_socket = True
+                else:
+                    server = await loop.create_server(
+                        create_protocol,
+                        host=config.host,
+                        port=config.port,
+                        ssl=config.ssl,
+                        backlog=config.backlog,
+                    )
             except OSError as exc:
                 logger.error(exc)
                 await self.lifespan.shutdown()
@@ -183,7 +194,7 @@ class Server:
             listeners = server.sockets
             self.servers = [server]
 
-        if sockets is None:
+        if sockets is None and not has_logged_socket:
             self._log_started_message(listeners)
         else:
             # We're most likely running multiple workers, so a message has already been


### PR DESCRIPTION
## Summary

Adds an opt-in `--dual-stack` setting for IPv6 socket binding. When enabled with an IPv6 host such as `--host ::`, Uvicorn pre-binds an IPv6 socket with `IPV6_V6ONLY=0` on platforms that support dual-stack sockets, then serves that socket.

The default remains unchanged, so existing deployments that rely on `--host ::` being IPv6-only keep the current behavior.

## Motivation

The current single-worker path delegates host/port binding to `asyncio.create_server()`, which creates an IPv6-only socket. The reload / multi-worker path uses `Config.bind_socket()`, so behavior can differ depending on process mode. This option gives operators an explicit, documented way to request dual-stack behavior without changing default network exposure.

Related: #2945 and discussion #1529.

## Tests

```text
python -m pytest -o addopts="" tests/test_config.py::test_dual_stack_socket_bind tests/test_server.py::test_dual_stack_server_accepts_ipv4_on_ipv6_socket -q
..                                                                       [100%]
2 passed in 0.20s
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `--dual-stack` option, allowing IPv6 sockets to accept IPv4 connections.
  * Dual-stack connections now work over both IPv4 and IPv6 when supported by the platform.
  * Startup fails clearly on platforms without dual-stack IPv6 support.

* **Documentation**
  * Documented the option’s behavior and disabled-by-default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->