### PR TITLE
Skip the eager app import in the parent when spawning workers

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -91,22 +91,39 @@ def test_run_invalid_app_config_combination(caplog: pytest.LogCaptureFixture) ->
 def test_run_fails_fast_in_parent_on_bad_app_path(
     caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Bad app path with `--workers > 1` exits in the parent.
+    """A bad app path exits in the parent for the single-process case.
 
-    Regression for https://github.com/encode/uvicorn/discussions/2440: without
-    parent-side validation the supervisor restarts dying workers forever.
+    Regression for https://github.com/encode/uvicorn/issues/941: the app is
+    imported eagerly before the event loop starts.
     """
 
-    def fail(*args: object, **kwargs: object) -> None:  # pragma: no cover
-        pytest.fail("parent reached supervisor; should have exited on bad app path")
+    def fail(self: Server, sockets: object = None) -> None:  # pragma: no cover
+        pytest.fail("parent reached Server.run; should have exited on bad app path")
 
-    monkeypatch.setattr(Config, "bind_socket", fail)
-    monkeypatch.setattr(Multiprocess, "run", fail)
+    monkeypatch.setattr(Server, "run", fail)
 
     with pytest.raises(SystemExit) as exit_exception:
-        run("tests.test_main:nonexistent_attr", workers=2)
+        run("tests.test_main:nonexistent_attr")
     assert exit_exception.value.code == 1
     assert any("Error loading ASGI app" in record.message for record in caplog.records)
+
+
+def test_run_skips_eager_app_import_with_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With `--workers > 1` the parent does not import the app.
+
+    Spawn-based workers re-import everything, so loading it in the supervisor
+    only wastes memory. See https://github.com/Kludex/uvicorn/discussions/2980.
+    """
+
+    def fail(self: Config) -> object:  # pragma: no cover
+        pytest.fail("parent loaded the app; spawn workers re-import it themselves")
+
+    with socket.socket() as sock:
+        monkeypatch.setattr(Config, "load_app", fail)
+        monkeypatch.setattr(Multiprocess, "run", lambda self: None)
+        monkeypatch.setattr(Config, "bind_socket", lambda self: sock)
+
+        run("tests.test_main:app", workers=2)
 
 
 def test_run_imports_app_before_starting_event_loop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -601,12 +601,14 @@ def run(
         h11_max_incomplete_event_size=h11_max_incomplete_event_size,
         reset_contextvars=reset_contextvars,
     )
-    if (config.reload or config.workers > 1) and not isinstance(app, str):
-        logger = logging.getLogger("uvicorn.error")
-        logger.warning("You must pass the application as an import string to enable 'reload' or 'workers'.")
-        sys.exit(1)
+    if config.reload or config.workers > 1:
+        if not isinstance(app, str):
+            logger = logging.getLogger("uvicorn.error")
+            logger.warning("You must pass the application as an import string to enable 'reload' or 'workers'.")
+            sys.exit(1)
+    else:
+        config.load_app()
 
-    config.load_app()
     server = Server(config=config)
 
     try:


### PR DESCRIPTION
## What this does

Fixes the supervisor memory regression in #2980. #2919 added an eager `config.load_app()` in the parent process. With `reload` or `workers > 1`, the workers are spawned and re-import everything themselves, so the parent's import is pure overhead - roughly 500MB of resident memory in the supervisor for nothing. The eager import is now kept only for the single-process path, where it still guards against an app whose module body opens an event loop (#941).

Split out of #3001, which now only carries the startup-failure exit code work for #2440. #3001 is merged, so a worker that fails to import the app exits with `STARTUP_FAILURE` and the supervisor stops instead of restart-looping.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



