### PR TITLE
Cover the excluded-directory branch in `FileFilter` with a direct test

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -17,7 +17,7 @@ from uvicorn.supervisors.basereload import BaseReload, _display_path
 from uvicorn.supervisors.statreload import StatReload
 
 try:
-    from uvicorn.supervisors.watchfilesreload import WatchFilesReload
+    from uvicorn.supervisors.watchfilesreload import FileFilter, WatchFilesReload
 except ImportError:  # pragma: no cover
     WatchFilesReload = None  # type: ignore[misc,assignment]
 
@@ -409,3 +409,25 @@ def test_base_reloader_closes_sockets_on_shutdown():
     assert sock.fileno() != -1
     reloader.shutdown()
     assert sock.fileno() == -1
+
+
+@pytest.mark.skipif(WatchFilesReload is None, reason="watchfiles not available")
+def test_file_filter_excluded_directory(tmp_path: Path) -> None:
+    """A glob include inside an excluded directory is not watched.
+
+    Pins the branch directly: the reload tests that exercise it through real
+    file watching are skipped on Windows and macOS, which left it uncovered
+    on some CI runs (see #2974).
+    """
+    excluded_dir = tmp_path / "vendor"
+    excluded_dir.mkdir()
+
+    config = Config(
+        app="tests.test_config:asgi_app",
+        reload=True,
+        reload_excludes=[str(excluded_dir)],
+    )
+    file_filter = FileFilter(config)
+
+    assert file_filter(tmp_path / "app.py")
+    assert not file_filter(excluded_dir / "app.py")

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -42,7 +42,7 @@ class FileFilter:
 
                 for exclude_dir in self.exclude_dirs:
                     if exclude_dir in path.parents:
-                        return False  # pragma: no cover
+                        return False
 
                 for exclude_pattern in self.excludes:
                     if path.match(exclude_pattern):


### PR DESCRIPTION
## What this does

Adds a direct unit test for `FileFilter`'s excluded-directory branch and removes the `pragma: no cover` workaround from #2974.

The reload tests that exercise this branch through real file watching are skipped on Windows and macOS, so per-job coverage intermittently missed the line on 3.14t runs and failed `fail_under = 100` (the pragma from #2974 only moved the miss to the adjacent line). The unit test pins the current behavior deterministically on every platform: a glob include inside an excluded directory is not watched.

No behavior change.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

