### PR TITLE
Skip the shutdown wait when there are no connections or tasks

### DIFF
--- a/tests/supervisors/test_signal.py
+++ b/tests/supervisors/test_signal.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import signal
 from asyncio import Event
 
@@ -8,6 +9,45 @@ import pytest
 from tests.utils import assert_signal, run_server
 from uvicorn import Server
 from uvicorn.config import Config
+
+
+async def hanging_stream_app(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"start", "more_body": True})
+    # never finish the response, so the connection stays open
+    await Event().wait()
+
+
+@pytest.mark.anyio
+async def test_reload_worker_aborts_connections_on_shutdown(unused_tcp_port: int, caplog):
+    """A reload worker does not wait for long-lived connections on shutdown.
+
+    Without an explicit `timeout_graceful_shutdown`, a worker being replaced by
+    the reloader waited forever for open connections (SSE, WebSockets, streaming),
+    hanging the restart. Regression for https://github.com/Kludex/uvicorn/issues/2943.
+    """
+    config = Config(app="tests.supervisors.test_signal:hanging_stream_app", reload=True, port=unused_tcp_port)
+    server = Server(config=config)
+    with assert_signal(signal.SIGINT):
+        task = asyncio.create_task(server.serve())
+        try:
+            while not server.started:
+                await asyncio.sleep(0.01)
+            async with httpx.AsyncClient() as client:
+                req = asyncio.create_task(client.get(f"http://127.0.0.1:{unused_tcp_port}"))
+                await asyncio.sleep(0.1)  # next tick
+                server.handle_exit(sig=signal.SIGINT, frame=None)
+                with pytest.raises(httpx.RemoteProtocolError):
+                    await asyncio.wait_for(req, timeout=5)
+            # The worker must exit promptly instead of waiting for the connection.
+            await asyncio.wait_for(task, timeout=5)
+        finally:
+            if not task.done():  # pragma: no cover
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+    assert "Cancel 1 running task(s), timeout graceful shutdown exceeded" in caplog.messages
 
 
 @pytest.mark.anyio

--- a/tests/supervisors/test_signal.py
+++ b/tests/supervisors/test_signal.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import signal
 from asyncio import Event
 
@@ -11,43 +10,22 @@ from uvicorn import Server
 from uvicorn.config import Config
 
 
-async def hanging_stream_app(scope, receive, send):
-    await send({"type": "http.response.start", "status": 200, "headers": []})
-    await send({"type": "http.response.body", "body": b"start", "more_body": True})
-    # never finish the response, so the connection stays open
-    await Event().wait()
-
-
 @pytest.mark.anyio
-async def test_reload_worker_aborts_connections_on_shutdown(unused_tcp_port: int, caplog):
-    """A reload worker does not wait for long-lived connections on shutdown.
+async def test_zero_graceful_timeout_idle_shutdown_logs_no_error(unused_tcp_port: int, caplog):
+    """`timeout_graceful_shutdown=0` does not log a cancel error on an idle shutdown.
 
-    Without an explicit `timeout_graceful_shutdown`, a worker being replaced by
-    the reloader waited forever for open connections (SSE, WebSockets, streaming),
-    hanging the restart. Regression for https://github.com/Kludex/uvicorn/issues/2943.
+    On Python <= 3.11, `asyncio.wait_for` with `timeout=0` raises `TimeoutError`
+    before the awaited coroutine runs, so an idle server previously logged
+    "Cancel 0 running task(s)" on every shutdown when the timeout was set to 0.
     """
-    config = Config(app="tests.supervisors.test_signal:hanging_stream_app", reload=True, port=unused_tcp_port)
-    server = Server(config=config)
+    config = Config(app="tests.test_config:asgi_app", port=unused_tcp_port, timeout_graceful_shutdown=0)
+    server: Server
     with assert_signal(signal.SIGINT):
-        task = asyncio.create_task(server.serve())
-        try:
-            while not server.started:
-                await asyncio.sleep(0.01)
-            async with httpx.AsyncClient() as client:
-                req = asyncio.create_task(client.get(f"http://127.0.0.1:{unused_tcp_port}"))
-                await asyncio.sleep(0.1)  # next tick
-                server.handle_exit(sig=signal.SIGINT, frame=None)
-                with pytest.raises(httpx.RemoteProtocolError):
-                    await asyncio.wait_for(req, timeout=5)
-            # The worker must exit promptly instead of waiting for the connection.
-            await asyncio.wait_for(task, timeout=5)
-        finally:
-            if not task.done():  # pragma: no cover
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
+        async with run_server(config) as server:
+            server.handle_exit(sig=signal.SIGINT, frame=None)
+            await asyncio.sleep(0.1)  # ensure shutdown is complete
 
-    assert "Cancel 1 running task(s), timeout graceful shutdown exceeded" in caplog.messages
+    assert not any("Cancel" in message for message in caplog.messages)
 
 
 @pytest.mark.anyio

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -287,19 +287,22 @@ class Server:
             # See https://github.com/Kludex/uvicorn/issues/2943.
             timeout_graceful_shutdown = 0
 
+        # On Python <= 3.11 `asyncio.wait_for` with `timeout=0` raises `TimeoutError`
+        # before the coroutine runs, so only wait when there is something to wait for.
         # When 3.10 is not supported anymore, use `async with asyncio.timeout(...):`.
-        try:
-            await asyncio.wait_for(
-                self._wait_tasks_to_complete(),
-                timeout=timeout_graceful_shutdown,
-            )
-        except asyncio.TimeoutError:
-            logger.error(
-                "Cancel %s running task(s), timeout graceful shutdown exceeded",
-                len(self.server_state.tasks),
-            )
-            for t in self.server_state.tasks:
-                t.cancel(msg="Task cancelled, timeout graceful shutdown exceeded")
+        if self.server_state.connections or self.server_state.tasks:
+            try:
+                await asyncio.wait_for(
+                    self._wait_tasks_to_complete(),
+                    timeout=timeout_graceful_shutdown,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Cancel %s running task(s), timeout graceful shutdown exceeded",
+                    len(self.server_state.tasks),
+                )
+                for t in self.server_state.tasks:
+                    t.cancel(msg="Task cancelled, timeout graceful shutdown exceeded")
 
         # Send the lifespan shutdown event, and wait for application shutdown.
         if not self.force_exit:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -280,11 +280,18 @@ class Server:
             connection.shutdown()
         await asyncio.sleep(0.1)
 
+        timeout_graceful_shutdown = self.config.timeout_graceful_shutdown
+        if timeout_graceful_shutdown is None and self.config.should_reload:
+            # A reload worker is being replaced, so there is no point holding the
+            # restart hostage to long-lived connections (SSE, WebSockets, streaming).
+            # See https://github.com/Kludex/uvicorn/issues/2943.
+            timeout_graceful_shutdown = 0
+
         # When 3.10 is not supported anymore, use `async with asyncio.timeout(...):`.
         try:
             await asyncio.wait_for(
                 self._wait_tasks_to_complete(),
-                timeout=self.config.timeout_graceful_shutdown,
+                timeout=timeout_graceful_shutdown,
             )
         except asyncio.TimeoutError:
             logger.error(

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -280,13 +280,6 @@ class Server:
             connection.shutdown()
         await asyncio.sleep(0.1)
 
-        timeout_graceful_shutdown = self.config.timeout_graceful_shutdown
-        if timeout_graceful_shutdown is None and self.config.should_reload:
-            # A reload worker is being replaced, so there is no point holding the
-            # restart hostage to long-lived connections (SSE, WebSockets, streaming).
-            # See https://github.com/Kludex/uvicorn/issues/2943.
-            timeout_graceful_shutdown = 0
-
         # On Python <= 3.11 `asyncio.wait_for` with `timeout=0` raises `TimeoutError`
         # before the coroutine runs, so only wait when there is something to wait for.
         # When 3.10 is not supported anymore, use `async with asyncio.timeout(...):`.
@@ -294,7 +287,7 @@ class Server:
             try:
                 await asyncio.wait_for(
                     self._wait_tasks_to_complete(),
-                    timeout=timeout_graceful_shutdown,
+                    timeout=self.config.timeout_graceful_shutdown,
                 )
             except asyncio.TimeoutError:
                 logger.error(


### PR DESCRIPTION
## What this does

Makes an explicit `timeout_graceful_shutdown=0` work cleanly: on Python <= 3.11, `asyncio.wait_for` with `timeout=0` raises `TimeoutError` before the awaited coroutine runs, so an idle server logged a spurious `Cancel 0 running task(s), timeout graceful shutdown exceeded` error on every shutdown. The wait is now skipped when there are no connections or tasks.

Context: #2943 is addressed by setting `--timeout-graceful-shutdown` (e.g. `0` for instant reloads); this makes that answer clean on all supported Pythons. No behavior change otherwise.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.