### PR TITLE
Rename `uvicorn.error` logger to `uvicorn.server` and move WebSocket handshake lines to the access log

### DIFF
--- a/docs/concepts/logging.md
+++ b/docs/concepts/logging.md
@@ -1,17 +1,21 @@
 Uvicorn uses Python's built-in [`logging`](https://docs.python.org/3/library/logging.html)
 module, and provides three loggers out of the box:
 
-| Logger name      | Purpose                                            |
-|------------------|----------------------------------------------------|
-| `uvicorn`        | Parent logger (rarely used directly)               |
-| `uvicorn.error`  | Server-level messages (startup, shutdown, errors)   |
-| `uvicorn.access` | Per-request access log lines                        |
+| Logger name      | Purpose                                                              |
+|------------------|----------------------------------------------------------------------|
+| `uvicorn`        | Parent logger (rarely used directly)                                 |
+| `uvicorn.server` | Server messages: startup, shutdown, protocol errors                  |
+| `uvicorn.access` | Per-request access log lines, including WebSocket handshake outcomes |
 
-!!! note
-    Despite its name, `uvicorn.error` is **not** limited to error messages.
-    It is the general-purpose server logger, similar to how Gunicorn names its
-    main logger. See [#562](https://github.com/encode/uvicorn/issues/562) for
-    background.
+!!! note "Renamed from `uvicorn.error`"
+    The `uvicorn.server` logger was previously named `uvicorn.error`, even though
+    it carried messages of every level (a convention inherited from Gunicorn).
+    See [#562](https://github.com/encode/uvicorn/issues/562) for background.
+
+    For now, a log config that references `uvicorn.error` is also applied to
+    `uvicorn.server`, and a deprecation warning is emitted. Update your config
+    to use `uvicorn.server` - the compatibility behavior will be removed in a
+    future release.
 
 ## Default Configuration
 
@@ -48,7 +52,7 @@ LOGGING_CONFIG = {
     },
     "loggers": {
         "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.server": {"level": "INFO"},
         "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
     },
 }
@@ -99,7 +103,7 @@ loggers:
       - default
     level: INFO
     propagate: false
-  uvicorn.error:
+  uvicorn.server:
     level: INFO
   uvicorn.access:
     handlers:
@@ -161,7 +165,7 @@ Create a file named `log_config.json`:
       "level": "INFO",
       "propagate": false
     },
-    "uvicorn.error": {
+    "uvicorn.server": {
       "level": "INFO"
     },
     "uvicorn.access": {
@@ -209,7 +213,7 @@ log_config = {
     },
     "loggers": {
         "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.server": {"level": "INFO"},
         "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
     },
 }
@@ -256,7 +260,7 @@ loggers:
       - file
     level: INFO
     propagate: false
-  uvicorn.error:
+  uvicorn.server:
     level: INFO
   uvicorn.access:
     handlers:
@@ -272,7 +276,9 @@ logs to the file as well, add `file` to the `uvicorn.access.handlers` list.
 
 Use the `--no-access-log` CLI flag, or set `access_log=False` programmatically.
 This removes all handlers from `uvicorn.access` without affecting the
-`uvicorn.error` logger.
+`uvicorn.server` logger. WebSocket handshake lines (e.g.
+`"WebSocket /path HTTP/1.1" 101`) are part of the access log, so this disables
+them as well.
 
 ### Disabling Colors
 
@@ -303,7 +309,7 @@ loggers:
       - default
     level: INFO
     propagate: false
-  uvicorn.error:
+  uvicorn.server:
     level: INFO
   uvicorn.access:
     handlers:

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -75,12 +75,12 @@ async def test_trace_logging_on_http_protocol(http_protocol_cls, caplog, logging
         log_config=logging_config,
         port=unused_tcp_port,
     )
-    with caplog_for_logger(caplog, "uvicorn.error"):
+    with caplog_for_logger(caplog, "uvicorn.server"):
         async with run_server(config):
             async with httpx.AsyncClient() as client:
                 response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
         assert response.status_code == 204
-        messages = [record.message for record in caplog.records if record.name == "uvicorn.error"]
+        messages = [record.message for record in caplog.records if record.name == "uvicorn.server"]
         assert any(" - HTTP connection made" in message for message in messages)
         assert any(" - HTTP connection lost" in message for message in messages)
 
@@ -111,14 +111,47 @@ async def test_trace_logging_on_ws_protocol(
         ws=ws_protocol_cls,
         port=unused_tcp_port,
     )
-    with caplog_for_logger(caplog, "uvicorn.error"):
+    with caplog_for_logger(caplog, "uvicorn.server"):
         async with run_server(config):
             is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert is_open
-        messages = [record.message for record in caplog.records if record.name == "uvicorn.error"]
+        messages = [record.message for record in caplog.records if record.name == "uvicorn.server"]
         assert any(" - Upgrading to WebSocket" in message for message in messages)
         assert any(" - WebSocket connection made" in message for message in messages)
         assert any(" - WebSocket connection lost" in message for message in messages)
+
+
+async def test_access_logging_on_ws_protocol(
+    ws_protocol_cls: WSProtocol,
+    caplog: pytest.LogCaptureFixture,
+    logging_config: dict[str, Any],
+    unused_tcp_port: int,
+):
+    async def websocket_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "websocket"
+        while True:
+            message = await receive()
+            if message["type"] == "websocket.connect":
+                await send({"type": "websocket.accept"})
+            elif message["type"] == "websocket.disconnect":
+                break
+
+    async def open_connection(url: str):
+        async with connect(url) as websocket:
+            return websocket.state is State.OPEN
+
+    config = Config(
+        app=websocket_app,
+        log_config=logging_config,
+        ws=ws_protocol_cls,
+        port=unused_tcp_port,
+    )
+    with caplog_for_logger(caplog, "uvicorn.access"):
+        async with run_server(config):
+            is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
+        assert is_open
+        messages = [record.message for record in caplog.records if record.name == "uvicorn.access"]
+        assert any('"WebSocket / HTTP/1.1" 101' in message for message in messages)
 
 
 @pytest.mark.parametrize("use_colors", [(True), (False), (None)])

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -919,8 +919,8 @@ async def test_invalid_http_request(
     app = Response("Hello, world", media_type="text/plain")
     request = INVALID_REQUEST_TEMPLATE % request_line
 
-    caplog.set_level(logging.INFO, logger="uvicorn.error")
-    logging.getLogger("uvicorn.error").propagate = True
+    caplog.set_level(logging.INFO, logger="uvicorn.server")
+    logging.getLogger("uvicorn.server").propagate = True
 
     protocol = get_connected_protocol(app, http_protocol_cls)
     protocol.data_received(request)
@@ -1127,7 +1127,7 @@ async def test_lifespan_state(http_protocol_cls: type[HTTPProtocol]):
 async def test_header_upgrade_is_not_websocket_depend_installed(
     caplog: pytest.LogCaptureFixture, http_protocol_cls: type[HTTPProtocol]
 ):
-    caplog.set_level(logging.WARNING, logger="uvicorn.error")
+    caplog.set_level(logging.WARNING, logger="uvicorn.server")
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, http_protocol_cls)
@@ -1143,7 +1143,7 @@ async def test_header_upgrade_is_not_websocket_depend_installed(
 async def test_header_upgrade_is_websocket_depend_not_installed(
     caplog: pytest.LogCaptureFixture, http_protocol_cls: type[HTTPProtocol]
 ):
-    caplog.set_level(logging.WARNING, logger="uvicorn.error")
+    caplog.set_level(logging.WARNING, logger="uvicorn.server")
     app = Response("Hello, world", media_type="text/plain")
 
     protocol = get_connected_protocol(app, http_protocol_cls, ws="none")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -216,7 +216,7 @@ def test_app_unimportable_other(caplog: pytest.LogCaptureFixture) -> None:
     with pytest.raises(SystemExit):
         config.load()
     error_messages = [
-        record.message for record in caplog.records if record.name == "uvicorn.error" and record.levelname == "ERROR"
+        record.message for record in caplog.records if record.name == "uvicorn.server" and record.levelname == "ERROR"
     ]
     assert (
         'Error loading ASGI app. Attribute "app" not found in module "tests.test_config".'  # noqa: E501
@@ -465,7 +465,7 @@ def test_config_log_level(log_level: int) -> None:
     config = Config(app=asgi_app, log_level=log_level)
     config.load()
 
-    assert logging.getLogger("uvicorn.error").level == log_level
+    assert logging.getLogger("uvicorn.server").level == log_level
     assert logging.getLogger("uvicorn.access").level == log_level
     assert logging.getLogger("uvicorn.asgi").level == log_level
     assert config.log_level == log_level
@@ -486,7 +486,7 @@ def test_config_log_effective_level(log_level: int, uvicorn_logger_level: int) -
     config.load()
 
     effective_level = log_level or uvicorn_logger_level or default_level
-    assert logging.getLogger("uvicorn.error").getEffectiveLevel() == effective_level
+    assert logging.getLogger("uvicorn.server").getEffectiveLevel() == effective_level
     assert logging.getLogger("uvicorn.access").getEffectiveLevel() == effective_level
     assert logging.getLogger("uvicorn.asgi").getEffectiveLevel() == effective_level
 
@@ -495,7 +495,67 @@ def test_config_log_effective_level(log_level: int, uvicorn_logger_level: int) -
 def test_config_log_level_case_insensitive(log_level: str) -> None:
     config = Config(app=asgi_app, log_level=log_level)
     config.load()
-    assert logging.getLogger("uvicorn.error").level == logging.INFO
+    assert logging.getLogger("uvicorn.server").level == logging.INFO
+
+
+@pytest.fixture
+def isolated_server_logger() -> Iterator[logging.Logger]:
+    server_logger = logging.getLogger("uvicorn.server")
+    state = (server_logger.level, server_logger.handlers[:], server_logger.propagate)
+    server_logger.handlers = []
+    server_logger.setLevel(logging.NOTSET)
+    server_logger.propagate = True
+    yield server_logger
+    server_logger.level, server_logger.handlers, server_logger.propagate = state
+
+
+def test_config_log_config_legacy_error_logger_dict(isolated_server_logger: logging.Logger) -> None:
+    log_config: dict[str, Any] = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "loggers": {"uvicorn.error": {"level": "WARNING"}},
+    }
+    with pytest.warns(UvicornDeprecationWarning, match="renamed to `uvicorn.server`"):
+        Config(app=asgi_app, log_config=log_config)
+
+    assert isolated_server_logger.level == logging.WARNING
+
+
+def test_config_log_config_legacy_error_logger_fileconfig(
+    tmp_path: Path, isolated_server_logger: logging.Logger
+) -> None:
+    server_logger = isolated_server_logger
+
+    log_config = tmp_path / "log_config.ini"
+    log_config.write_text(
+        "[loggers]\n"
+        "keys=root,uvicorn.error\n"
+        "[handlers]\n"
+        "keys=console\n"
+        "[formatters]\n"
+        "keys=default\n"
+        "[logger_root]\n"
+        "level=INFO\n"
+        "handlers=console\n"
+        "[logger_uvicorn.error]\n"
+        "level=WARNING\n"
+        "handlers=console\n"
+        "qualname=uvicorn.error\n"
+        "propagate=0\n"
+        "[handler_console]\n"
+        "class=StreamHandler\n"
+        "level=NOTSET\n"
+        "formatter=default\n"
+        "args=(sys.stderr,)\n"
+        "[formatter_default]\n"
+        "format=%(message)s\n"
+    )
+    with pytest.warns(UvicornDeprecationWarning, match="renamed to `uvicorn.server`"):
+        Config(app=asgi_app, log_config=str(log_config))
+
+    assert server_logger.level == logging.WARNING
+    assert server_logger.handlers == logging.getLogger("uvicorn.error").handlers
+    assert not server_logger.propagate
 
 
 @pytest.mark.filterwarnings("ignore: websockets.legacy is deprecated.*:DeprecationWarning")
@@ -654,7 +714,7 @@ def test_custom_loop__not_importable_custom_loop_setup_function(caplog: pytest.L
     with pytest.raises(SystemExit):
         config.get_loop_factory()
     error_messages = [
-        record.message for record in caplog.records if record.name == "uvicorn.error" and record.levelname == "ERROR"
+        record.message for record in caplog.records if record.name == "uvicorn.server" and record.levelname == "ERROR"
     ]
     assert (
         'Error loading custom loop setup function. Attribute "non_existing_setup_function" not found in module "tests.test_config".'  # noqa: E501

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -151,7 +151,7 @@ def test_lifespan_with_failed_startup(mode, raise_exception, caplog):
     loop.run_until_complete(test())
     loop.close()
     error_messages = [
-        record.message for record in caplog.records if record.name == "uvicorn.error" and record.levelname == "ERROR"
+        record.message for record in caplog.records if record.name == "uvicorn.server" and record.levelname == "ERROR"
     ]
     assert "the lifespan event failed" in error_messages.pop(0)
     assert "Application startup failed. Exiting." in error_messages.pop(0)
@@ -234,7 +234,7 @@ def test_lifespan_with_failed_shutdown(mode, raise_exception, caplog):
     loop = asyncio.new_event_loop()
     loop.run_until_complete(test())
     error_messages = [
-        record.message for record in caplog.records if record.name == "uvicorn.error" and record.levelname == "ERROR"
+        record.message for record in caplog.records if record.name == "uvicorn.server" and record.levelname == "ERROR"
     ]
     assert "the lifespan event failed" in error_messages.pop(0)
     assert "Application shutdown failed. Exiting." in error_messages.pop(0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,7 +81,7 @@ def test_run_invalid_app_config_combination(caplog: pytest.LogCaptureFixture) ->
     with pytest.raises(SystemExit) as exit_exception:
         run(app, reload=True)
     assert exit_exception.value.code == STARTUP_FAILURE
-    assert caplog.records[-1].name == "uvicorn.error"
+    assert caplog.records[-1].name == "uvicorn.server"
     assert caplog.records[-1].levelno == WARNING
     assert caplog.records[-1].message == (
         "You must pass the application as an import string to enable 'reload' or 'workers'."

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -140,7 +140,7 @@ def test_run_exits_with_startup_failure_on_unloadable_app() -> None:
 async def test_request_than_limit_max_requests_warn_log(
     unused_tcp_port: int, http_protocol_cls: type[H11Protocol | HttpToolsProtocol], caplog: pytest.LogCaptureFixture
 ):
-    caplog.set_level(logging.INFO, logger="uvicorn.error")
+    caplog.set_level(logging.INFO, logger="uvicorn.server")
     config = Config(app=app, limit_max_requests=1, port=unused_tcp_port, http=http_protocol_cls)
     async with run_server(config):
         async with httpx.AsyncClient() as client:
@@ -153,7 +153,7 @@ async def test_request_than_limit_max_requests_warn_log(
 async def test_limit_max_requests_jitter(
     unused_tcp_port: int, http_protocol_cls: type[H11Protocol | HttpToolsProtocol], caplog: pytest.LogCaptureFixture
 ):
-    caplog.set_level(logging.INFO, logger="uvicorn.error")
+    caplog.set_level(logging.INFO, logger="uvicorn.server")
     config = Config(
         app=app, limit_max_requests=1, limit_max_requests_jitter=2, port=unused_tcp_port, http=http_protocol_cls
     )

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -9,6 +9,7 @@ import os
 import socket
 import ssl
 import sys
+import warnings
 from collections.abc import Awaitable, Callable
 from configparser import RawConfigParser
 from pathlib import Path
@@ -106,12 +107,27 @@ LOGGING_CONFIG: dict[str, Any] = {
     },
     "loggers": {
         "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.server": {"level": "INFO"},
         "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
     },
 }
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
+
+
+def _bridge_legacy_error_logger(log_config: dict[str, Any]) -> None:
+    loggers = log_config.get("loggers") or {}
+    if "uvicorn.error" not in loggers:
+        return
+    warnings.warn(
+        "The `uvicorn.error` logger was renamed to `uvicorn.server`. The provided log config was applied to "
+        "`uvicorn.server` as well, but this compatibility behavior will be removed in a future release. "
+        "Update the logger name in your log config.",
+        UvicornDeprecationWarning,
+        stacklevel=2,
+    )
+    loggers.setdefault("uvicorn.server", loggers["uvicorn.error"])
+    log_config["loggers"] = loggers
 
 
 def create_ssl_context(
@@ -388,10 +404,12 @@ class Config:
                 if self.use_colors in (True, False):
                     self.log_config["formatters"]["default"]["use_colors"] = self.use_colors
                     self.log_config["formatters"]["access"]["use_colors"] = self.use_colors
+                _bridge_legacy_error_logger(self.log_config)
                 logging.config.dictConfig(self.log_config)
             elif isinstance(self.log_config, str) and self.log_config.endswith(".json"):
                 with open(self.log_config) as file:
                     loaded_config = json.load(file)
+                    _bridge_legacy_error_logger(loaded_config)
                     logging.config.dictConfig(loaded_config)
             elif isinstance(self.log_config, str) and self.log_config.endswith((".yaml", ".yml")):
                 try:
@@ -403,18 +421,34 @@ class Config:
 
                 with open(self.log_config) as file:
                     loaded_config = yaml.safe_load(file)
+                    _bridge_legacy_error_logger(loaded_config)
                     logging.config.dictConfig(loaded_config)
             else:
                 # See the note about fileConfig() here:
                 # https://docs.python.org/3/library/logging.config.html#configuration-file-format
                 logging.config.fileConfig(self.log_config, disable_existing_loggers=False)
+                legacy_logger = logging.getLogger("uvicorn.error")
+                if legacy_logger.handlers or legacy_logger.level != logging.NOTSET:
+                    warnings.warn(
+                        "The `uvicorn.error` logger was renamed to `uvicorn.server`. Its configuration was applied "
+                        "to `uvicorn.server` as well, but this compatibility behavior will be removed in a future "
+                        "release. Update the logger name in your log config.",
+                        UvicornDeprecationWarning,
+                        stacklevel=1,
+                    )
+                    server_logger = logging.getLogger("uvicorn.server")
+                    if not server_logger.handlers and server_logger.level == logging.NOTSET:
+                        server_logger.setLevel(legacy_logger.level)
+                        server_logger.propagate = legacy_logger.propagate
+                        for handler in legacy_logger.handlers:
+                            server_logger.addHandler(handler)
 
         if self.log_level is not None:
             if isinstance(self.log_level, str):
                 log_level = LOG_LEVELS[self.log_level.lower()]
             else:
                 log_level = self.log_level
-            logging.getLogger("uvicorn.error").setLevel(log_level)
+            logging.getLogger("uvicorn.server").setLevel(log_level)
             logging.getLogger("uvicorn.access").setLevel(log_level)
             logging.getLogger("uvicorn.asgi").setLevel(log_level)
         if self.access_log is False:

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -34,7 +34,7 @@ class LifespanOn:
             config.load()
 
         self.config = config
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.server")
         self.startup_event = asyncio.Event()
         self.shutdown_event = asyncio.Event()
         self.receive_queue: Queue[LifespanReceiveMessage] = asyncio.Queue()

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -41,7 +41,7 @@ def _metavar_from_type(_type: Any) -> str:
     return f"[{'|'.join(key for key in get_args(_type) if key != 'none')}]"
 
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> None:
@@ -602,7 +602,7 @@ def run(
     )
     if config.reload or config.workers > 1:
         if not isinstance(app, str):
-            logger = logging.getLogger("uvicorn.error")
+            logger = logging.getLogger("uvicorn.server")
             logger.warning("You must pass the application as an import string to enable 'reload' or 'workers'.")
             sys.exit(STARTUP_FAILURE)
     else:

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -52,7 +52,7 @@ class H11Protocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.server")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
         self.conn = h11.Connection(

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -56,7 +56,7 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.server")
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
         self.parser = httptools.HttpRequestParser(self)

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -75,6 +75,8 @@ class WebSocketProtocol(WebSocketServerProtocol):
         self.config = config
         self.app = cast(ASGI3Application, config.loaded_app)
         self.loop = _loop or asyncio.get_event_loop()
+        self.access_logger = logging.getLogger("uvicorn.access")
+        self.access_log = self.access_logger.hasHandlers()
         self.root_path = config.root_path
         self.asgi_version = config.asgi_version
         self.app_state = app_state
@@ -113,7 +115,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             ping_interval=self.config.ws_ping_interval,
             ping_timeout=self.config.ws_ping_timeout,
             extensions=extensions,
-            logger=logging.getLogger("uvicorn.error"),
+            logger=logging.getLogger("uvicorn.server"),
         )
         self.server_header = None
         self.extra_headers = [
@@ -267,11 +269,15 @@ class WebSocketProtocol(WebSocketServerProtocol):
     async def asgi_send(self, message: ASGISendEvent) -> None:
         if not self.handshake_started_event.is_set():
             if message["type"] == "websocket.accept":
-                self.logger.info(
-                    '%s - "WebSocket %s" [accepted]',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        101,
+                    )
                 self.initial_response = None
                 self.accepted_subprotocol = cast(Subprotocol | None, message.get("subprotocol"))
                 if "headers" in message:
@@ -284,22 +290,29 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 self.handshake_started_event.set()
 
             elif message["type"] == "websocket.close":
-                self.logger.info(
-                    '%s - "WebSocket %s" 403',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        403,
+                    )
                 self.initial_response = (http.HTTPStatus.FORBIDDEN, [], b"")
                 self.handshake_started_event.set()
                 self.closed_event.set()
 
             elif message["type"] == "websocket.http.response.start":
-                self.logger.info(
-                    '%s - "WebSocket %s" %d',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                    message["status"],
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        message["status"],
+                    )
                 # websockets requires the status to be an enum. look it up.
                 status = http.HTTPStatus(message["status"])
                 headers = [

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -54,7 +54,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.config = config
         self.app = config.loaded_app
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.server")
+        self.access_logger = logging.getLogger("uvicorn.access")
+        self.access_log = self.access_logger.hasHandlers()
         self.root_path = config.root_path
         self.asgi_version = config.asgi_version
         self.app_state = app_state
@@ -89,7 +91,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.conn = ServerProtocol(
             extensions=extensions,
             max_size=self.config.ws_max_size,
-            logger=logging.getLogger("uvicorn.error"),
+            logger=logging.getLogger("uvicorn.server"),
         )
 
         self.read_paused = False
@@ -371,11 +373,15 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
         if not self.handshake_complete and self.initial_response is None:
             if message["type"] == "websocket.accept":
-                self.logger.info(
-                    '%s - "WebSocket %s" [accepted]',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        101,
+                    )
                 headers = [
                     (name.decode("latin-1").lower(), value.decode("latin-1"))
                     for name, value in (self.default_headers + list(message.get("headers", [])))
@@ -394,11 +400,15 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
             elif message["type"] == "websocket.close":
                 self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
-                self.logger.info(
-                    '%s - "WebSocket %s" 403',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        403,
+                    )
                 response = self.conn.reject(HTTPStatus.FORBIDDEN, "")
                 self.conn.send_response(response)
                 output = self.conn.data_to_send()
@@ -409,12 +419,15 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             elif message["type"] == "websocket.http.response.start" and self.initial_response is None:
                 if not (100 <= message["status"] < 600):
                     raise RuntimeError("Invalid HTTP status code '%d' in response." % message["status"])
-                self.logger.info(
-                    '%s - "WebSocket %s" %d',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                    message["status"],
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        message["status"],
+                    )
                 headers = [
                     (name.decode("latin-1"), value.decode("latin-1"))
                     for name, value in list(message.get("headers", []))

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -79,7 +79,9 @@ class WSProtocol(asyncio.Protocol):
         self.config = config
         self.app = cast(ASGI3Application, config.loaded_app)
         self.loop = _loop or asyncio.get_event_loop()
-        self.logger = logging.getLogger("uvicorn.error")
+        self.logger = logging.getLogger("uvicorn.server")
+        self.access_logger = logging.getLogger("uvicorn.access")
+        self.access_log = self.access_logger.hasHandlers()
         self.root_path = config.root_path
         self.asgi_version = config.asgi_version
         self.app_state = app_state
@@ -354,11 +356,15 @@ class WSProtocol(asyncio.Protocol):
 
         if not self.handshake_complete:
             if message["type"] == "websocket.accept":
-                self.logger.info(
-                    '%s - "WebSocket %s" [accepted]',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        101,
+                    )
                 subprotocol = message.get("subprotocol")
                 extra_headers = self.default_headers + list(message.get("headers", []))
                 extensions: list[Extension] = []
@@ -378,11 +384,15 @@ class WSProtocol(asyncio.Protocol):
 
             elif message["type"] == "websocket.close":
                 self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
-                self.logger.info(
-                    '%s - "WebSocket %s" 403',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        403,
+                    )
                 self.handshake_complete = True
                 self.close_sent = True
                 event = events.RejectConnection(status_code=403, headers=[])
@@ -395,12 +405,15 @@ class WSProtocol(asyncio.Protocol):
                 if not (100 <= message["status"] < 600):
                     msg = "Invalid HTTP status code '%d' in response."
                     raise RuntimeError(msg % message["status"])
-                self.logger.info(
-                    '%s - "WebSocket %s" %d',
-                    get_client_addr(self.scope),
-                    get_path_with_query_string(self.scope),
-                    message["status"],
-                )
+                if self.access_log:
+                    self.access_logger.info(
+                        '%s - "%s %s HTTP/%s" %d',
+                        get_client_addr(self.scope),
+                        "WebSocket",
+                        get_path_with_query_string(self.scope),
+                        self.scope["http_version"],
+                        message["status"],
+                    )
                 self.handshake_complete = True
                 event = events.RejectConnection(
                     status_code=message["status"],

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -37,7 +37,7 @@ HANDLED_SIGNALS = (
 if sys.platform == "win32":  # pragma: py-not-win32
     HANDLED_SIGNALS += (signal.SIGBREAK,)  # Windows signal 21. Sent by Ctrl+Break.
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class ServerState:

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -19,7 +19,7 @@ HANDLED_SIGNALS = (
     signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
 )
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class BaseReload:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -20,7 +20,7 @@ SIGNALS = {
     if hasattr(signal, f"SIG{x}")
 }
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class Process:

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -8,7 +8,7 @@ from socket import socket
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
 
-logger = logging.getLogger("uvicorn.error")
+logger = logging.getLogger("uvicorn.server")
 
 
 class StatReload(BaseReload):

--- a/uvicorn/workers.py
+++ b/uvicorn/workers.py
@@ -32,7 +32,7 @@ class UvicornWorker(Worker):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        logger = logging.getLogger("uvicorn.error")
+        logger = logging.getLogger("uvicorn.server")
         logger.handlers = self.log.error_log.handlers
         logger.setLevel(self.log.error_log.level)
         logger.propagate = False


### PR DESCRIPTION
Closes #562

- Rename `uvicorn.error` to `uvicorn.server`: the old name carried messages of every severity, which misleads anyone formatting with `%(name)s` or alerting on "error" in log output. The new purpose-based name matches aiohttp, tornado, and granian.
- Log configs that still reference `uvicorn.error` are applied to `uvicorn.server` as well (dict, JSON, YAML, and INI paths), with a visible-by-default deprecation warning, so existing configs keep working during a transition period.
- WebSocket handshake outcomes (101/403/custom rejection status) are traffic records, not diagnostics, so they now log on `uvicorn.access` in the standard access-line format and are disabled by `--no-access-log`.

Behavior changes worth noting: with access logs disabled the WS handshake lines disappear entirely (previously they always logged), and the line format changed from `"WebSocket /path" [accepted]` to `"WebSocket /path HTTP/1.1" 101`, which affects anyone grepping for the old text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

