### PR TITLE
Add experimental HTTP/2 support via rh2 (Rust h2 crate)

### DIFF
--- a/docs/concepts/http2.md
+++ b/docs/concepts/http2.md
@@ -10,7 +10,7 @@ Uvicorn can serve HTTP/2 using a Rust-backed codec provided by the
 `hyper`). Install it with the `http2` extra:
 
 ```bash
-pip install "uvicorn[http2]"
+pip install "uvicorn[http2-rh2]"
 ```
 
 Enable it with the `--http2` flag (or `Config(http2=True)`):

--- a/docs/concepts/http2.md
+++ b/docs/concepts/http2.md
@@ -1,0 +1,39 @@
+# HTTP/2
+
+!!! warning
+    HTTP/2 support is **experimental**. The API and behavior may change. Please
+    try it out and report back.
+
+Uvicorn can serve HTTP/2 using a Rust-backed codec provided by the
+[`rh2`](https://pypi.org/project/rh2/) package, which wraps the
+[`h2`](https://crates.io/crates/h2) crate (the HTTP/2 implementation behind
+`hyper`). Install it with the `http2` extra:
+
+```bash
+pip install "uvicorn[http2]"
+```
+
+Enable it with the `--http2` flag (or `Config(http2=True)`):
+
+```bash
+uvicorn main:app --http2 --ssl-keyfile key.pem --ssl-certfile cert.pem
+```
+
+When TLS is configured, `h2` is offered over ALPN alongside `http/1.1`, so
+clients that support HTTP/2 negotiate it automatically and everyone else falls
+back to HTTP/1.1. Cleartext prior-knowledge HTTP/2 (`h2c`, e.g.
+`curl --http2-prior-knowledge`) is also detected.
+
+## How it works
+
+- The codec is *sans-IO*: uvicorn feeds it bytes from the socket and writes back
+  whatever it produces, while the `h2` crate owns the connection state machine
+  (flow control, `SETTINGS`/`PING` acknowledgement, `GOAWAY`, `RST_STREAM`).
+- Each HTTP/2 stream maps to one ASGI request/response cycle, so requests are
+  multiplexed over a single connection.
+
+## Limitations
+
+- Server push is not supported (deprecated in practice; not planned).
+- Upgrade-based `h2c` (RFC 7540 section 3.2) is served as HTTP/1.1, which the
+  RFC permits.

--- a/docs/concepts/http2.md
+++ b/docs/concepts/http2.md
@@ -10,7 +10,7 @@ Uvicorn can serve HTTP/2 using a Rust-backed codec provided by the
 `hyper`). Install it with the `http2` extra:
 
 ```bash
-pip install "uvicorn[http2-rh2]"
+pip install "uvicorn[rh2]"
 ```
 
 Enable it with the `--http2` flag (or `Config(http2=True)`):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Lifespan: concepts/lifespan.md
       - Logging: concepts/logging.md
       - WebSockets: concepts/websockets.md
+      - HTTP/2: concepts/http2.md
       - Event Loop: concepts/event-loop.md
   - Deployment:
       - Deployment: deployment/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ standard = [
     "watchfiles>=0.20",
     "websockets>=11.0",
 ]
-http2 = [
+http2-rh2 = [
     "rh2>=0.0.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ standard = [
     "watchfiles>=0.20",
     "websockets>=11.0",
 ]
+http2 = [
+    "rh2>=0.0.1",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ standard = [
     "watchfiles>=0.20",
     "websockets>=11.0",
 ]
-http2-rh2 = [
+rh2 = [
     "rh2>=0.0.1",
 ]
 

--- a/tests/protocols/test_rust_http2.py
+++ b/tests/protocols/test_rust_http2.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
+from uvicorn.config import Config
+from uvicorn.lifespan.off import LifespanOff
+from uvicorn.server import ServerState
+
+try:
+    import h2.config
+    import h2.connection
+    import h2.events
+
+    # Importing the protocol pulls in `rh2`; ModuleNotFoundError means it is absent.
+    from uvicorn.protocols.http.rust_h2_impl import RustH2Protocol
+
+    skip_if_no_rh2 = pytest.mark.skipif(False, reason="")
+except ModuleNotFoundError:  # pragma: no cover
+    skip_if_no_rh2 = pytest.mark.skipif(True, reason="rh2 or h2 is not installed")
+
+pytestmark = [pytest.mark.anyio, skip_if_no_rh2]
+
+
+class MockSSLObject:
+    def __init__(self, alpn_protocol: str | None) -> None:
+        self._alpn_protocol = alpn_protocol
+
+    def selected_alpn_protocol(self) -> str | None:
+        return self._alpn_protocol
+
+
+class MockTransport:
+    def __init__(self, sslcontext: bool = True, alpn_protocol: str | None = "h2") -> None:
+        self.buffer = b""
+        self.closed = False
+        self.read_paused = False
+        self.sslcontext = sslcontext
+        self.alpn_protocol = alpn_protocol
+        self.protocol: asyncio.Protocol | None = None
+
+    def get_extra_info(self, key: str) -> Any:
+        return {
+            "sockname": ("127.0.0.1", 8000),
+            "peername": ("127.0.0.1", 8001),
+            "sslcontext": self.sslcontext,
+            "ssl_object": MockSSLObject(self.alpn_protocol) if self.sslcontext else None,
+        }.get(key)
+
+    def set_protocol(self, protocol: asyncio.Protocol) -> None:
+        self.protocol = protocol
+
+    def get_protocol(self) -> asyncio.Protocol | None:
+        return self.protocol
+
+    def write(self, data: bytes) -> None:
+        assert not self.closed
+        self.buffer += data
+
+    def drain(self) -> None:
+        self.buffer = b""
+
+    def close(self) -> None:
+        self.closed = True
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+    def pause_reading(self) -> None:
+        self.read_paused = True
+
+    def resume_reading(self) -> None:
+        self.read_paused = False
+
+
+def get_connected_protocol(app: Callable[..., Any], **kwargs: Any) -> tuple[RustH2Protocol, MockTransport]:
+    loop = asyncio.get_event_loop()
+    transport = MockTransport()
+    config = Config(app=app, http2=True, **kwargs)
+    server_state = ServerState()
+    lifespan = LifespanOff(config)
+    protocol = RustH2Protocol(config=config, server_state=server_state, app_state=lifespan.state, _loop=loop)
+    protocol.connection_made(transport)  # type: ignore[arg-type]
+    return protocol, transport
+
+
+class H2Client:
+    def __init__(self) -> None:
+        self.conn = h2.connection.H2Connection(config=h2.config.H2Configuration(client_side=True))
+        self.conn.initiate_connection()
+
+    def preface(self) -> bytes:
+        return self.conn.data_to_send()
+
+    def request(
+        self,
+        method: bytes = b"GET",
+        path: bytes = b"/",
+        body: bytes = b"",
+        extra_headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> tuple[int, bytes]:
+        stream_id = self.conn.get_next_available_stream_id()
+        headers = [
+            (b":method", method),
+            (b":scheme", b"https"),
+            (b":authority", b"example.org"),
+            (b":path", path),
+        ] + (extra_headers or [])
+        self.conn.send_headers(stream_id, headers, end_stream=not body)
+        if body:
+            self.conn.send_data(stream_id, body, end_stream=True)
+        return stream_id, self.conn.data_to_send()
+
+    def receive(self, data: bytes) -> list[Any]:
+        return self.conn.receive_data(data)
+
+
+async def drain_tasks() -> None:
+    # Let the ASGI task(s) created by the protocol run to completion.
+    for _ in range(50):
+        await asyncio.sleep(0)
+
+
+async def _collect_response(client: H2Client, protocol: RustH2Protocol, transport: MockTransport) -> dict[str, Any]:
+    await drain_tasks()
+    events = client.receive(transport.buffer)
+    transport.buffer = b""
+    status = None
+    headers: list[tuple[bytes, bytes]] = []
+    body = b""
+    ended = False
+    for event in events:
+        if isinstance(event, h2.events.ResponseReceived):
+            for name, value in event.headers:
+                if name == b":status":
+                    status = int(value)
+                else:
+                    headers.append((name, value))
+        elif isinstance(event, h2.events.DataReceived):
+            body += event.data
+        elif isinstance(event, h2.events.StreamEnded):
+            ended = True
+    return {"status": status, "headers": headers, "body": body, "ended": ended}
+
+
+async def test_get_request() -> None:
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        assert scope["http_version"] == "2"
+        assert scope["method"] == "GET"
+        assert scope["path"] == "/hello"
+        await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"text/plain")]})
+        await send({"type": "http.response.body", "body": b"hello world"})
+
+    client = H2Client()
+    protocol, transport = get_connected_protocol(app)
+    protocol.data_received(client.preface())
+    _, data = client.request(path=b"/hello")
+    protocol.data_received(data)
+
+    response = await _collect_response(client, protocol, transport)
+    assert response["status"] == 200
+    assert response["body"] == b"hello world"
+    assert response["ended"] is True
+
+
+async def test_post_request_with_body() -> None:
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        body = b""
+        while True:
+            message = await receive()
+            body += message.get("body", b"")
+            if not message.get("more_body", False):
+                break
+        await send({"type": "http.response.start", "status": 201, "headers": []})
+        await send({"type": "http.response.body", "body": b"got:" + body})
+
+    client = H2Client()
+    protocol, transport = get_connected_protocol(app)
+    protocol.data_received(client.preface())
+    _, data = client.request(method=b"POST", path=b"/upload", body=b"payload")
+    protocol.data_received(data)
+
+    response = await _collect_response(client, protocol, transport)
+    assert response["status"] == 201
+    assert response["body"] == b"got:payload"
+
+
+async def test_h2c_prior_knowledge_upgrade_from_h11() -> None:
+    from uvicorn.protocols.http.h11_impl import H11Protocol
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["http_version"] == "2"
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"h2c ok"})
+
+    loop = asyncio.get_event_loop()
+    transport = MockTransport(sslcontext=False)  # cleartext -> prior-knowledge sniffing
+    config = Config(app=app, http2=True)
+    server_state = ServerState()
+    lifespan = LifespanOff(config)
+    h11 = H11Protocol(config=config, server_state=server_state, app_state=lifespan.state, _loop=loop)
+    h11.connection_made(transport)  # type: ignore[arg-type]
+
+    client = H2Client()
+    _, data = client.request(path=b"/")
+    # The client's preface + first frames arrive on the h11 protocol, which sniffs
+    # the HTTP/2 preface and hands the connection to RustH2Protocol.
+    h11.data_received(client.preface() + data)
+
+    assert isinstance(transport.get_protocol(), RustH2Protocol)
+    await drain_tasks()
+    events = client.receive(transport.buffer)
+    body = b"".join(e.data for e in events if isinstance(e, h2.events.DataReceived))
+    assert body == b"h2c ok"
+
+
+async def test_concurrent_streams() -> None:
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        path = scope["path"].encode("ascii")
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"path=" + path})
+
+    client = H2Client()
+    protocol, transport = get_connected_protocol(app)
+    protocol.data_received(client.preface())
+    _, d1 = client.request(path=b"/a")
+    _, d2 = client.request(path=b"/b")
+    protocol.data_received(d1)
+    protocol.data_received(d2)
+
+    await drain_tasks()
+    events = client.receive(transport.buffer)
+    bodies = b"".join(e.data for e in events if isinstance(e, h2.events.DataReceived))
+    assert b"path=/a" in bodies
+    assert b"path=/b" in bodies

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -54,6 +54,7 @@ HTTP_PROTOCOLS: dict[str, str] = {
     "h11": "uvicorn.protocols.http.h11_impl:H11Protocol",
     "httptools": "uvicorn.protocols.http.httptools_impl:HttpToolsProtocol",
 }
+HTTP2_PROTOCOL = "uvicorn.protocols.http.rust_h2_impl:RustH2Protocol"
 WS_PROTOCOLS: dict[str, str | None] = {
     "auto": "uvicorn.protocols.websockets.auto:AutoWebSocketsProtocol",
     "none": None,
@@ -122,6 +123,7 @@ def create_ssl_context(
     cert_reqs: int,
     ca_certs: str | os.PathLike[str] | None,
     ciphers: str | None,
+    alpn_protocols: list[str] | None = None,
 ) -> ssl.SSLContext:
     ctx = ssl.SSLContext(ssl_version)
     get_password = (lambda: password) if password else None
@@ -131,6 +133,8 @@ def create_ssl_context(
         ctx.load_verify_locations(ca_certs)
     if ciphers:
         ctx.set_ciphers(ciphers)
+    if alpn_protocols:
+        ctx.set_alpn_protocols(alpn_protocols)
     return ctx
 
 
@@ -197,6 +201,7 @@ class Config:
         fd: int | None = None,
         loop: LoopFactoryType | str = "auto",
         http: type[asyncio.Protocol] | HTTPProtocolType | str = "auto",
+        http2: bool | type[asyncio.Protocol] | str = False,
         ws: type[asyncio.Protocol] | WSProtocolType | str = "auto",
         ws_max_size: int = 16 * 1024 * 1024,
         ws_max_queue: int = 32,
@@ -250,6 +255,7 @@ class Config:
         self.fd = fd
         self.loop = loop
         self.http = http
+        self.http2 = http2
         self.ws = ws
         self.ws_max_size = ws_max_size
         self.ws_max_queue = ws_max_queue
@@ -465,6 +471,7 @@ class Config:
                 cert_reqs=self.ssl_cert_reqs,
                 ca_certs=self.ssl_ca_certs,
                 ciphers=self.ssl_ciphers,
+                alpn_protocols=["h2", "http/1.1"] if self.http2 else None,
             )
         else:
             self.ssl = None
@@ -481,6 +488,16 @@ class Config:
             self.http_protocol_class: type[asyncio.Protocol] = http_protocol_class
         else:
             self.http_protocol_class = self.http
+
+        self.http2_protocol_class: type[asyncio.Protocol] | None
+        if self.http2 is False:
+            self.http2_protocol_class = None
+        elif self.http2 is True:
+            self.http2_protocol_class = import_from_string(HTTP2_PROTOCOL)
+        elif isinstance(self.http2, str):
+            self.http2_protocol_class = import_from_string(self.http2)
+        else:
+            self.http2_protocol_class = self.http2
 
         if isinstance(self.ws, str):
             ws_protocol_class = import_from_string(WS_PROTOCOLS.get(self.ws, self.ws))

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -132,6 +132,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     show_default=True,
 )
 @click.option(
+    "--http2",
+    is_flag=True,
+    default=False,
+    help="Enable experimental HTTP/2 support (requires the `rh2` package).",
+)
+@click.option(
     "--ws",
     type=str,
     metavar=_metavar_from_type(WSProtocolType),
@@ -393,6 +399,7 @@ def main(
     fd: int,
     loop: LoopFactoryType | str,
     http: HTTPProtocolType | str,
+    http2: bool,
     ws: WSProtocolType | str,
     ws_max_size: int,
     ws_max_queue: int,
@@ -445,6 +452,7 @@ def main(
         fd=fd,
         loop=loop,
         http=http,
+        http2=http2,
         ws=ws,
         ws_max_size=ws_max_size,
         ws_max_queue=ws_max_queue,
@@ -500,6 +508,7 @@ def run(
     fd: int | None = None,
     loop: LoopFactoryType | str = "auto",
     http: type[asyncio.Protocol] | HTTPProtocolType | str = "auto",
+    http2: bool | type[asyncio.Protocol] | str = False,
     ws: type[asyncio.Protocol] | WSProtocolType | str = "auto",
     ws_max_size: int = 16777216,
     ws_max_queue: int = 32,
@@ -556,6 +565,7 @@ def run(
         fd=fd,
         loop=loop,
         http=http,
+        http2=http2,
         ws=ws,
         ws_max_size=ws_max_size,
         ws_max_queue=ws_max_queue,

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -27,6 +27,8 @@ from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, 
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
+HTTP2_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
 
 def _get_status_phrase(status_code: int) -> bytes:
     try:
@@ -62,6 +64,7 @@ class H11Protocol(asyncio.Protocol):
             else DEFAULT_MAX_INCOMPLETE_EVENT_SIZE,
         )
         self.ws_protocol_class = config.ws_protocol_class
+        self.http2_protocol_class = config.http2_protocol_class
         self.root_path = config.root_path
         self.asgi_version = config.asgi_version
         self.limit_concurrency = config.limit_concurrency
@@ -88,6 +91,11 @@ class H11Protocol(asyncio.Protocol):
         self.headers: list[tuple[bytes, bytes]] = None  # type: ignore[assignment]
         self.cycle: RequestResponseCycle = None  # type: ignore[assignment]
 
+        # HTTP/2 prior-knowledge detection state, active until the first bytes
+        # of a cleartext connection rule the HTTP/2 preface out.
+        self._h2_sniff = False
+        self._h2_buffer = b""
+
     # Protocol interface
     def connection_made(  # type: ignore[override]
         self, transport: asyncio.Transport
@@ -99,6 +107,15 @@ class H11Protocol(asyncio.Protocol):
         self.server = get_local_addr(transport)
         self.client = get_remote_addr(transport)
         self.scheme = "https" if is_ssl(transport) else "http"
+
+        if self.http2_protocol_class is not None:  # pragma: no-rh2
+            if self.scheme == "https":
+                ssl_object = transport.get_extra_info("ssl_object")
+                if ssl_object is not None and ssl_object.selected_alpn_protocol() == "h2":
+                    self._upgrade_to_h2(transport)
+                    return
+            else:
+                self._h2_sniff = True
 
         if self.logger.level <= TRACE_LOG_LEVEL:
             prefix = "%s:%d - " % self.client if self.client else ""
@@ -169,8 +186,33 @@ class H11Protocol(asyncio.Protocol):
             self._unsupported_upgrade_warning()
         return False
 
+    def _upgrade_to_h2(self, transport: asyncio.Transport, initial_data: bytes = b"") -> None:  # pragma: no-rh2
+        assert self.http2_protocol_class is not None
+        self.connections.discard(self)
+        protocol = self.http2_protocol_class(  # type: ignore[call-arg]
+            config=self.config,
+            server_state=self.server_state,
+            app_state=self.app_state,
+            _loop=self.loop,
+        )
+        transport.set_protocol(protocol)
+        protocol.connection_made(transport)
+        if initial_data:
+            protocol.data_received(initial_data)
+
     def data_received(self, data: bytes) -> None:
         self._unset_keepalive_if_required()
+
+        if self._h2_sniff:  # pragma: no-rh2
+            data = self._h2_buffer + data
+            if len(data) < len(HTTP2_PREFACE) and HTTP2_PREFACE.startswith(data):
+                self._h2_buffer = data
+                return
+            self._h2_sniff = False
+            self._h2_buffer = b""
+            if data.startswith(HTTP2_PREFACE):
+                self._upgrade_to_h2(self.transport, initial_data=data)
+                return
 
         self.conn.receive_data(data)
         self.handle_events()

--- a/uvicorn/protocols/http/rust_h2_impl.py
+++ b/uvicorn/protocols/http/rust_h2_impl.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import logging
+import sys
+import warnings
+from collections.abc import Callable
+from typing import Any, Literal
+
+import rh2
+
+from uvicorn._types import (
+    ASGI3Application,
+    ASGIReceiveEvent,
+    ASGISendEvent,
+    HTTPResponseBodyEvent,
+    HTTPResponseStartEvent,
+    HTTPScope,
+)
+from uvicorn.config import Config
+from uvicorn.logging import TRACE_LOG_LEVEL
+from uvicorn.protocols.http.flow_control import FlowControl, service_unavailable
+from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
+from uvicorn.server import ServerState
+
+_EXPERIMENTAL_WARNING_EMITTED = False
+
+
+def _warn_experimental_once() -> None:
+    global _EXPERIMENTAL_WARNING_EMITTED
+    if _EXPERIMENTAL_WARNING_EMITTED:
+        return
+    _EXPERIMENTAL_WARNING_EMITTED = True
+    warnings.warn(
+        "Uvicorn's HTTP/2 support is experimental. I'd really appreciate if you try it out and report back! "
+        "See the docs at https://uvicorn.dev/concepts/http2/.",
+        UserWarning,
+        stacklevel=2,
+    )
+
+
+# RFC 9113 section 8.2.2: connection-specific headers MUST NOT appear in HTTP/2.
+# An ASGI app or middleware tuned for HTTP/1.1 may still emit them, so strip
+# them on the way out rather than letting the codec reject the response.
+FORBIDDEN_HEADERS = frozenset({b"connection", b"keep-alive", b"proxy-connection", b"transfer-encoding", b"upgrade"})
+
+PSEUDO_HEADERS = frozenset({b":method", b":scheme", b":authority", b":path"})
+
+
+class RustH2Protocol(asyncio.Protocol):
+    def __init__(
+        self,
+        config: Config,
+        server_state: ServerState,
+        app_state: dict[str, Any],
+        _loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        if not config.loaded:
+            config.load()
+
+        _warn_experimental_once()
+        self.config = config
+        self.app = config.loaded_app
+        self.loop = _loop or asyncio.get_event_loop()
+        self.logger = logging.getLogger("uvicorn.error")
+        self.access_logger = logging.getLogger("uvicorn.access")
+        self.access_log = self.access_logger.hasHandlers()
+        self.conn = rh2.H2Connection()
+        self.root_path = config.root_path
+        self.asgi_version = config.asgi_version
+        self.limit_concurrency = config.limit_concurrency
+        self.app_state = app_state
+
+        # Timeouts
+        self.timeout_keep_alive_task: asyncio.TimerHandle | None = None
+        self.timeout_keep_alive = config.timeout_keep_alive
+
+        # Shared server state
+        self.server_state = server_state
+        self.connections = server_state.connections
+        self.tasks = server_state.tasks
+
+        # Per-connection state
+        self.transport: asyncio.Transport = None  # type: ignore[assignment]
+        self.flow: FlowControl = None  # type: ignore[assignment]
+        self.server: tuple[str, int | None] | None = None
+        self.client: tuple[str, int] | None = None
+        self.scheme: Literal["http", "https"] | None = None
+        self.shutdown_requested = False
+
+        # Per-stream state, keyed by HTTP/2 stream id.
+        self.cycles: dict[int, RequestResponseCycle] = {}
+
+    # asyncio.Protocol interface
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:  # type: ignore[override]
+        self.connections.add(self)
+        self.transport = transport  # type: ignore[assignment]
+        self.flow = FlowControl(transport)  # type: ignore[arg-type]
+        self.server = get_local_addr(transport)
+        self.client = get_remote_addr(transport)
+        self.scheme = "https" if is_ssl(transport) else "http"
+
+        if self.logger.level <= TRACE_LOG_LEVEL:
+            prefix = "%s:%d - " % self.client if self.client else ""
+            self.logger.log(TRACE_LOG_LEVEL, "%sHTTP/2 connection made", prefix)
+
+        # Emit the connection preface / initial SETTINGS immediately.
+        self.transport.write(self.conn.data_to_send())
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        self.connections.discard(self)
+
+        if self.logger.level <= TRACE_LOG_LEVEL:
+            prefix = "%s:%d - " % self.client if self.client else ""
+            self.logger.log(TRACE_LOG_LEVEL, "%sHTTP/2 connection lost", prefix)
+
+        for cycle in self.cycles.values():
+            if not cycle.response_complete:
+                cycle.disconnected = True
+            cycle.message_event.set()
+        if self.flow is not None:
+            self.flow.resume_writing()
+        self._unset_keepalive_if_required()
+
+    def eof_received(self) -> None:
+        pass
+
+    def _unset_keepalive_if_required(self) -> None:
+        if self.timeout_keep_alive_task is not None:
+            self.timeout_keep_alive_task.cancel()
+            self.timeout_keep_alive_task = None
+
+    def data_received(self, data: bytes) -> None:
+        self._unset_keepalive_if_required()
+
+        try:
+            events = self.conn.receive_data(data)
+        except ValueError as exc:
+            self.logger.warning("Invalid HTTP/2 frame received: %s", exc)
+            self.transport.close()
+            return
+
+        self.handle_events(events)
+        self.flush()
+
+        # Frames that carry no stream-level event (SETTINGS, PING, WINDOW_UPDATE)
+        # cancelled the keep-alive timer above but never re-arm it, so re-arm now
+        # if the connection is idle.
+        if not self.cycles and self.timeout_keep_alive_task is None and not self.transport.is_closing():
+            self.timeout_keep_alive_task = self.loop.call_later(
+                self.timeout_keep_alive, self.timeout_keep_alive_handler
+            )
+
+    def flush(self) -> None:
+        """Write out bytes the codec queued outside a cycle's send path - the
+        connection preface and DATA released by an inbound WINDOW_UPDATE."""
+        data = self.conn.data_to_send()
+        if data:
+            self.transport.write(data)
+
+    def handle_events(self, events: list[Any]) -> None:
+        for event in events:
+            if isinstance(event, rh2.RequestReceived):
+                self.handle_request(event)
+            elif isinstance(event, rh2.DataReceived):
+                cycle = self.cycles.get(event.stream_id)
+                if cycle is None or cycle.response_complete:
+                    continue
+                cycle.body += event.data
+                if event.stream_ended:
+                    cycle.more_body = False
+                cycle.message_event.set()
+            elif isinstance(event, rh2.StreamEnded):
+                cycle = self.cycles.get(event.stream_id)
+                if cycle is None or cycle.response_complete:
+                    continue
+                cycle.more_body = False
+                cycle.message_event.set()
+            elif isinstance(event, rh2.StreamReset):
+                self.handle_rst_stream(event)
+            elif isinstance(event, rh2.ConnectionTerminated):
+                self.shutdown_requested = True
+                if not self.cycles:
+                    self.transport.close()
+
+    def handle_request(self, event: rh2.RequestReceived) -> None:
+        pseudo: dict[bytes, bytes] = {}
+        headers: list[tuple[bytes, bytes]] = []
+        for raw_name, raw_value in event.headers:
+            name, value = bytes(raw_name), bytes(raw_value)
+            if name in PSEUDO_HEADERS:
+                pseudo[name] = value
+            else:
+                headers.append((name, value))
+
+        method = pseudo.get(b":method", b"GET")
+        raw_path = pseudo.get(b":path", b"/")
+        path, _, query = raw_path.partition(b"?")
+        full_raw_path = self.root_path.encode("ascii") + raw_path.split(b"?")[0]
+
+        scope: HTTPScope = {
+            "type": "http",
+            "asgi": {"version": self.asgi_version, "spec_version": "2.3"},
+            "http_version": "2",
+            "server": self.server,
+            "client": self.client,
+            "scheme": self.scheme,  # type: ignore[typeddict-item]
+            "method": method.decode("ascii"),
+            "root_path": self.root_path,
+            "path": self.root_path + path.decode("ascii"),
+            "raw_path": full_raw_path,
+            "query_string": query,
+            "headers": headers,
+            "state": self.app_state.copy(),
+        }
+
+        # Refuse new streams once a shutdown began, and answer 503 when the
+        # concurrency limit is exceeded.
+        if self.shutdown_requested:
+            app = service_unavailable
+        elif self.limit_concurrency is not None and (
+            len(self.connections) >= self.limit_concurrency or len(self.tasks) >= self.limit_concurrency
+        ):
+            app = service_unavailable
+            self.logger.warning("Exceeded concurrency limit.")
+        else:
+            app = self.app
+
+        cycle = RequestResponseCycle(
+            scope=scope,
+            conn=self.conn,
+            stream_id=event.stream_id,
+            transport=self.transport,
+            flow=self.flow,
+            logger=self.logger,
+            access_logger=self.access_logger,
+            access_log=self.access_log,
+            default_headers=self.server_state.default_headers,
+            message_event=asyncio.Event(),
+            on_response=self.on_response_complete,
+        )
+        self.cycles[event.stream_id] = cycle
+        if event.stream_ended:
+            cycle.more_body = False
+            cycle.message_event.set()
+
+        if self.config.reset_contextvars:
+            if sys.version_info >= (3, 11):  # pragma: py-lt-311
+                task = self.loop.create_task(cycle.run_asgi(app), context=contextvars.Context())
+            else:  # pragma: py-gte-311
+                task = contextvars.Context().run(self.loop.create_task, cycle.run_asgi(app))
+        else:
+            task = self.loop.create_task(cycle.run_asgi(app))
+        task.add_done_callback(self.tasks.discard)
+        self.tasks.add(task)
+
+    def handle_rst_stream(self, event: rh2.StreamReset) -> None:
+        cycle = self.cycles.pop(event.stream_id, None)
+        if cycle is None:
+            return
+        if not cycle.response_complete:
+            cycle.disconnected = True
+            cycle.message_event.set()
+        self.on_stream_closed()
+
+    def on_response_complete(self, stream_id: int) -> None:
+        self.server_state.total_requests += 1
+        self.cycles.pop(stream_id, None)
+        self.flush()
+        self.on_stream_closed()
+
+    def on_stream_closed(self) -> None:
+        if self.transport.is_closing():
+            return
+
+        self._unset_keepalive_if_required()
+
+        if not self.cycles:
+            if self.shutdown_requested:
+                self.transport.close()
+                return
+            self.timeout_keep_alive_task = self.loop.call_later(
+                self.timeout_keep_alive, self.timeout_keep_alive_handler
+            )
+
+    def shutdown(self) -> None:
+        """Called by the server to commence a graceful shutdown."""
+        self.shutdown_requested = True
+        if not self.cycles:
+            self.conn.close_connection()
+            self.flush()
+            self.transport.close()
+
+    def pause_writing(self) -> None:
+        self.flow.pause_writing()  # pragma: no cover
+
+    def resume_writing(self) -> None:
+        self.flow.resume_writing()  # pragma: no cover
+
+    def timeout_keep_alive_handler(self) -> None:
+        if not self.transport.is_closing():
+            self.conn.close_connection()
+            self.flush()
+            self.transport.close()
+
+
+class RequestResponseCycle:
+    def __init__(
+        self,
+        scope: HTTPScope,
+        conn: rh2.H2Connection,
+        stream_id: int,
+        transport: asyncio.Transport,
+        flow: FlowControl,
+        logger: logging.Logger,
+        access_logger: logging.Logger,
+        access_log: bool,
+        default_headers: list[tuple[bytes, bytes]],
+        message_event: asyncio.Event,
+        on_response: Callable[[int], None],
+    ) -> None:
+        self.scope = scope
+        self.conn = conn
+        self.stream_id = stream_id
+        self.transport = transport
+        self.flow = flow
+        self.logger = logger
+        self.access_logger = access_logger
+        self.access_log = access_log
+        self.default_headers = default_headers
+        self.message_event = message_event
+        self.on_response = on_response
+
+        # Connection state
+        self.disconnected = False
+
+        # Request state
+        self.body = bytearray()
+        self.more_body = True
+
+        # Response state
+        self.response_started = False
+        self.response_complete = False
+
+    # ASGI exception wrapper
+    async def run_asgi(self, app: ASGI3Application) -> None:
+        try:
+            result = await app(self.scope, self.receive, self.send)  # type: ignore[func-returns-value]
+        except BaseException as exc:
+            self.logger.error("Exception in ASGI application\n", exc_info=exc)
+            if not self.response_started:
+                await self.send_500_response()
+            else:
+                self.transport.close()
+        else:
+            if result is not None:
+                self.logger.error("ASGI callable should return None, but returned '%s'.", result)
+                self.transport.close()
+            elif not self.response_started and not self.disconnected:
+                self.logger.error("ASGI callable returned without starting response.")
+                await self.send_500_response()
+            elif not self.response_complete and not self.disconnected:
+                self.logger.error("ASGI callable returned without completing response.")
+                self.transport.close()
+        finally:
+            self.on_response(self.stream_id)
+            self.on_response = lambda stream_id: None
+
+    async def send_500_response(self) -> None:
+        await self.send(
+            {
+                "type": "http.response.start",
+                "status": 500,
+                "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+            }
+        )
+        await self.send({"type": "http.response.body", "body": b"Internal Server Error"})
+
+    async def send(self, message: ASGISendEvent) -> None:
+        message_type = message["type"]
+
+        if self.flow.write_paused and not self.disconnected:
+            await self.flow.drain()
+
+        if self.disconnected:
+            return
+
+        if not self.response_started:
+            if message_type != "http.response.start":
+                raise RuntimeError(
+                    f"Expected ASGI message 'http.response.start', but got '{message_type}'."
+                )
+            message = cast_response_start(message)
+            self.response_started = True
+
+            status = message["status"]
+            out_headers: list[tuple[bytes, bytes]] = []
+            for name, value in self.default_headers + list(message.get("headers", [])):
+                if name.lower() in FORBIDDEN_HEADERS:
+                    continue
+                out_headers.append((name, value))
+
+            if self.access_log:
+                self.access_logger.info(
+                    '%s - "%s %s HTTP/%s" %d',
+                    get_client_addr(self.scope),
+                    self.scope["method"],
+                    get_path_with_query_string(self.scope),
+                    self.scope["http_version"],
+                    status,
+                )
+
+            self.conn.send_headers(self.stream_id, status, out_headers, end_stream=False)
+            self.transport.write(self.conn.data_to_send())
+
+        elif not self.response_complete:
+            if message_type != "http.response.body":
+                raise RuntimeError(f"Expected ASGI message 'http.response.body', but got '{message_type}'.")
+            body = message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+            self.conn.send_data(self.stream_id, bytes(body), end_stream=not more_body)
+            self.transport.write(self.conn.data_to_send())
+
+            if not more_body:
+                self.response_complete = True
+                self.message_event.set()
+        else:
+            raise RuntimeError(f"Unexpected ASGI message '{message_type}' sent, after response already completed.")
+
+    async def receive(self) -> ASGIReceiveEvent:
+        if not self.disconnected and not self.response_complete:
+            await self.message_event.wait()
+            self.message_event.clear()
+
+        if self.disconnected:
+            return {"type": "http.disconnect"}
+
+        body = bytes(self.body)
+        if body:
+            self.conn.acknowledge_data(self.stream_id, len(body))
+            self.transport.write(self.conn.data_to_send())
+        self.body = bytearray()
+        return {
+            "type": "http.request",
+            "body": body,
+            "more_body": self.more_body,
+        }
+
+
+def cast_response_start(message: ASGISendEvent) -> HTTPResponseStartEvent:
+    return message  # type: ignore[return-value]
+
+
+def cast_response_body(message: ASGISendEvent) -> HTTPResponseBodyEvent:
+    return message  # type: ignore[return-value]


### PR DESCRIPTION
Adds an experimental \`--http2\` flag, with the HTTP/2 protocol implemented on top of [\`rh2\`](https://github.com/Kludex/rh2) - a new Rust-backed sans-IO codec that wraps the [\`h2\`](https://crates.io/crates/h2) crate (the HTTP/2 implementation behind \`hyper\`) via PyO3. This is a third HTTP/2 approach alongside the zttp/Zig one (#2982) and the hyper-h2 one (#2793), reusing the same protocol-layer integration shape.

## How it works

- \`--http2\` / \`Config(http2=True)\` loads \`RustH2Protocol\` and offers \`["h2", "http/1.1"]\` via ALPN on TLS.
- The \`h11\` protocol hands the transport over to the HTTP/2 protocol when ALPN negotiated \`h2\`, or when a cleartext connection opens with the HTTP/2 preface (prior-knowledge h2c, e.g. \`curl --http2-prior-knowledge\`).
- One \`RequestResponseCycle\` per stream. The \`h2\` crate owns the connection state machine - flow control, SETTINGS/PING acknowledgement, GOAWAY, RST_STREAM - so the Python layer stays a thin sans-IO driver, mirroring the hyper-h2 / zttp integrations.

## The rh2 binding

\`rh2\` is a standalone PyO3/maturin package. The \`h2\` crate drives a connection over an async \`tokio\` transport; rh2 runs it *sans-IO* by backing that transport with in-memory buffers and pumping the futures by hand with a no-op waker. It exposes a hyper-h2-style \`H2Connection\` (\`receive_data\` -> events, \`data_to_send\`, \`send_headers\`/\`send_data\`/\`reset_stream\`, flow-control ack). Install with \`pip install uvicorn[rh2]\`.

## Verified

End-to-end against hyper-h2 as the client (in \`tests/protocols/test_rust_http2.py\`): GET, POST with a request body, multiplexed concurrent streams, and the cleartext h2c prior-knowledge upgrade through the h11 protocol. The rh2 package itself is separately tested against hyper-h2, including a 100 KiB body that exceeds the initial flow-control window.

## Known limitations

- ALPN-over-TLS handoff mirrors the tested h2c path but is not exercised in CI here (no TLS in the unit harness).
- Upgrade-based h2c (RFC 7540 3.2) is served as HTTP/1.1 rather than upgraded (allowed by the RFC).
- No server push (deprecated in practice; not planned).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



