### PR TITLE
Split comma-separated `Sec-WebSocket-Protocol` values in the websockets-sansio implementation

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -658,8 +658,13 @@ async def test_subprotocols(
     subprotocol: str,
     unused_tcp_port: int,
 ):
+    advertised_subprotocols: list[str] | None = None
+
     class App(WebSocketResponse):
         async def websocket_connect(self, message: WebSocketConnectEvent):
+            nonlocal advertised_subprotocols
+            assert self.scope["type"] == "websocket"
+            advertised_subprotocols = list(self.scope["subprotocols"])
             await self.send({"type": "websocket.accept", "subprotocol": subprotocol})
 
     async def get_subprotocol(url: str):
@@ -670,6 +675,7 @@ async def test_subprotocols(
     async with run_server(config):
         accepted_subprotocol = await get_subprotocol(f"ws://127.0.0.1:{unused_tcp_port}")
         assert accepted_subprotocol == subprotocol
+        assert advertised_subprotocols == ["proto1", "proto2"]
 
 
 MAX_WS_BYTES = 1024 * 1024 * 16

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -197,6 +197,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             for key, value in event.headers.raw_items()
         ]
         raw_path, _, query_string = event.path.partition("?")
+        subprotocols: list[str] = []
+        for header in event.headers.get_all("Sec-WebSocket-Protocol"):
+            subprotocols.extend([token.strip() for token in header.split(",")])
         self.scope: WebSocketScope = {
             "type": "websocket",
             "asgi": {"version": self.asgi_version, "spec_version": "2.4"},
@@ -209,7 +212,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             "raw_path": self.root_path.encode("ascii") + raw_path.encode("ascii"),
             "query_string": query_string.encode("ascii"),
             "headers": headers,
-            "subprotocols": event.headers.get_all("Sec-WebSocket-Protocol"),
+            "subprotocols": subprotocols,
             "state": self.app_state.copy(),
             "extensions": {"websocket.http.response": {}},
         }


### PR DESCRIPTION
# Summary

Fixes #3018 (discussion), discovered downstream in falconry/falcon#2678.

Since 0.50.0 the `websockets-sansio` implementation builds the ASGI scope with:

```python
"subprotocols": event.headers.get_all("Sec-WebSocket-Protocol"),
```

`get_all()` returns one string per header *line*, so a client advertising multiple subprotocols in a single comma-separated header (what the `websockets` client library sends) yields `scope["subprotocols"] == ["amqp, wamp"]` instead of `["amqp", "wamp"]`. An app that then accepts `scope["subprotocols"][0]` echoes the malformed value back, and spec-compliant clients reject the handshake with `InvalidHeader: invalid Sec-WebSocket-Protocol header: multiple values: amqp, wamp`.

This PR splits header values on commas, mirroring the legacy `websockets` implementation ([`websockets_impl.py`](https://github.com/Kludex/uvicorn/blob/main/uvicorn/protocols/websockets/websockets_impl.py#L175-L177)). `wsproto` already parses subprotocols natively, so only the sansio implementation needed the change.

The existing `test_subprotocols` test now also asserts the scope contents; it fails on `main` for the sansio implementation (`['proto1, proto2']`) and passes with this fix. Root cause analysis credit: @Deep070203 in falconry/falcon#2678.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. (No docs change needed — behavior now matches the documented ASGI spec and the other implementations.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

