### PR TITLE
Require websockets>=13.0 for the default sansio implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ standard = [
     "PyYAML>=5.1",
     "uvloop>=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
     "watchfiles>=0.20",
-    "websockets>=11.0",
+    "websockets>=13.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

Since 0.50.0, `--ws auto` selects the `websockets-sansio` implementation whenever `websockets` is importable (#2985). That implementation imports `from websockets.server import ServerProtocol`, which only exists in `websockets>=13.0`. The `[standard]` extra, however, still allows `websockets>=11.0`.

So a user with `websockets` 11.x or 12.x installed and the default `--ws auto` now crashes at startup with:

```
ImportError: cannot import name 'ServerProtocol' from 'websockets.server'
```

where 0.49 fell back to the legacy implementation and worked. This bumps the floor to match what the default implementation actually requires.

## Notes

- `websockets.server.ServerProtocol` (the sans-I/O API) was introduced in websockets 13.0.
- This only pins the `[standard]` extra. A follow-up could also add a version guard in `uvicorn/protocols/websockets/auto.py` so `auto` degrades to `wsproto`/legacy instead of importing a sansio module that will fail, but the pin is the minimal fix.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

