### PR TITLE
Version 0.50.2

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,12 @@
 toc_depth: 2
 ---
 
+## 0.50.2 (July 6, 2026)
+
+### Fixed
+
+* Require `websockets>=13.0`, which the default `websockets-sansio` implementation needs (#3021)
+
 ## 0.50.1 (July 6, 2026)
 
 ### Fixed

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.50.1"
+__version__ = "0.50.2"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Patch release.

### Fixed

* Require `websockets>=13.0`, which the default `websockets-sansio` implementation needs (#3021)

> [!NOTE]
> Depends on #3021 - merge that first so the release actually contains the pin bump.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

