### PR TITLE
Report worker readiness through the healthcheck pong

### DIFF
--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import os
 import signal
-import socket
 import threading
 import time
 from collections.abc import Callable
@@ -42,27 +41,37 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     pass  # pragma: no cover
 
 
-def run(sockets: list[socket.socket] | None) -> None:
-    while True:  # pragma: no cover
-        time.sleep(1)
-
-
 def test_process_ping_pong() -> None:
-    process = Process(Config(app=app), target=lambda x: None, sockets=[])
+    process = Process(Config(app=app), sockets=[])
     threading.Thread(target=process.always_pong, daemon=True).start()
     assert process.ping()
 
 
 def test_process_ping_pong_timeout() -> None:
-    process = Process(Config(app=app), target=lambda x: None, sockets=[])
+    process = Process(Config(app=app), sockets=[])
     assert not process.ping(0.1)
 
 
 def test_process_ping_broken_pipe() -> None:
-    process = Process(Config(app=app), target=lambda x: None, sockets=[])
+    process = Process(Config(app=app), sockets=[])
     process.parent_conn.close()
     process.child_conn.close()
     assert not process.ping(0.1)
+
+
+def test_process_ready() -> None:
+    """`ping()` latches `ready` once the worker's server reports it has finished startup."""
+    process = Process(Config(app=app), sockets=[])
+    threading.Thread(target=process.always_pong, daemon=True).start()
+
+    # The server hasn't started yet, so the worker is alive but not ready.
+    assert process.ping()
+    assert not process.ready
+
+    process.server = Server(process.config)
+    process.server.started = True
+    assert process.ping()
+    assert process.ready
 
 
 @new_console_in_windows
@@ -74,7 +83,7 @@ def test_multiprocess_run() -> None:
     quit immediately.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     supervisor.signal_queue.append(signal.SIGINT)
     supervisor.join_all()
@@ -86,7 +95,7 @@ def test_multiprocess_health_check() -> None:
     Ensure that the health check works as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     process = supervisor.processes[0]
@@ -107,8 +116,7 @@ def test_multiprocess_worker_dies_on_startup() -> None:
     Regression for https://github.com/encode/uvicorn/discussions/2440.
     """
     config = Config(app="tests.supervisors.test_multiprocess:does_not_exist", workers=2)
-    server = Server(config)
-    supervisor = Multiprocess(config, target=server.run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     thread = threading.Thread(target=supervisor.run, daemon=True)
     thread.start()
     deadline = time.monotonic() + 10
@@ -124,7 +132,7 @@ def test_multiprocess_sigterm() -> None:
     Ensure that the SIGTERM signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     supervisor.signal_queue.append(signal.SIGTERM)
@@ -138,7 +146,7 @@ def test_multiprocess_sigbreak() -> None:  # pragma: py-not-win32
     Ensure that the SIGBREAK signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     supervisor.signal_queue.append(getattr(signal, "SIGBREAK"))
@@ -151,7 +159,7 @@ def test_multiprocess_sighup() -> None:
     Ensure that the SIGHUP signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     pids = [p.pid for p in supervisor.processes]
@@ -174,7 +182,7 @@ def test_multiprocess_sigttin() -> None:
     Ensure that the SIGTTIN signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     supervisor.signal_queue.append(signal.SIGTTIN)
     time.sleep(1)
@@ -189,7 +197,7 @@ def test_multiprocess_sigttou() -> None:
     Ensure that the SIGTTOU signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     supervisor.signal_queue.append(signal.SIGTTOU)
     time.sleep(1)

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -68,7 +68,8 @@ def test_process_ready() -> None:
     assert process.ping()
     assert not process.ready
 
-    process.server = Server(process.config)
+    process._server = Server(process.config)
+    assert process.server is process._server
     process.server.started = True
     assert process.ping()
     assert process.ready

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -63,7 +63,6 @@ def test_process_ready() -> None:
     process = Process(Config(app=app), sockets=[])
     threading.Thread(target=process.always_pong, daemon=True).start()
 
-    # The server exists but hasn't finished startup yet, so the worker is alive but not ready.
     assert process.ping()
     assert not process.ready
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -12,7 +12,6 @@ import pytest
 
 from uvicorn import Config
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
-from uvicorn.server import Server
 from uvicorn.supervisors import Multiprocess
 from uvicorn.supervisors.multiprocess import Process
 
@@ -43,7 +42,6 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 
 def test_process_ping_pong() -> None:
     process = Process(Config(app=app), sockets=[])
-    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
     assert process.ping()
 
@@ -63,7 +61,6 @@ def test_process_ping_broken_pipe() -> None:
 def test_process_ready() -> None:
     """`ping()` latches `ready` once the worker's server reports it has finished startup."""
     process = Process(Config(app=app), sockets=[])
-    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
 
     # The server exists but hasn't finished startup yet, so the worker is alive but not ready.

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -43,6 +43,7 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 
 def test_process_ping_pong() -> None:
     process = Process(Config(app=app), sockets=[])
+    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
     assert process.ping()
 
@@ -62,14 +63,13 @@ def test_process_ping_broken_pipe() -> None:
 def test_process_ready() -> None:
     """`ping()` latches `ready` once the worker's server reports it has finished startup."""
     process = Process(Config(app=app), sockets=[])
+    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
 
-    # The server hasn't started yet, so the worker is alive but not ready.
+    # The server exists but hasn't finished startup yet, so the worker is alive but not ready.
     assert process.ping()
     assert not process.ready
 
-    process._server = Server(process.config)
-    assert process.server is process._server
     process.server.started = True
     assert process.ping()
     assert process.ready

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -59,16 +59,15 @@ def test_process_ping_broken_pipe() -> None:
 
 
 def test_process_ready() -> None:
-    """`ping()` latches `ready` once the worker's server reports it has finished startup."""
+    """`is_ready()` reflects whether the worker's server has finished startup."""
     process = Process(Config(app=app), sockets=[])
     threading.Thread(target=process.always_pong, daemon=True).start()
 
     assert process.ping()
-    assert not process.ready
+    assert not process.is_ready()
 
     process.server.started = True
-    assert process.ping()
-    assert process.ready
+    assert process.is_ready()
 
 
 @new_console_in_windows

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -616,7 +616,7 @@ def run(
             ChangeReload(config, target=server.run, sockets=[sock]).run()
         elif config.workers > 1:
             sock = config.bind_socket()
-            Multiprocess(config, target=server.run, sockets=[sock]).run()
+            Multiprocess(config, sockets=[sock]).run()
         else:
             server.run()
     except KeyboardInterrupt:  # pragma: full coverage

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -35,7 +35,7 @@ class Process:
         self.process = get_subprocess(config, self.target, sockets)
 
     def _healthcheck(self, timeout: float) -> bool | None:
-        """Ping the worker and return its server-started flag, or None if it never answered."""
+        """Return the worker's reported startup flag, or None if it does not answer within timeout seconds."""
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
@@ -46,15 +46,15 @@ class Process:
             return None
 
     def ping(self, timeout: float = 5) -> bool:
-        """Return whether the worker answered the healthcheck within the timeout."""
+        """Return True if the worker answers a healthcheck within timeout seconds."""
         return self._healthcheck(timeout) is not None
 
     def is_ready(self, timeout: float = 5) -> bool:
-        """Return whether the worker answered and its server has finished startup."""
+        """Return True if the worker answers and reports that its server has finished startup."""
         return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
-        """Answer a healthcheck ping with whether the server has finished startup."""
+        """Reply to one healthcheck ping with whether the server has finished startup."""
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -35,7 +35,7 @@ class Process:
         self.process = get_subprocess(config, self.target, sockets)
 
     def _healthcheck(self, timeout: float) -> bool | None:
-        """Return the worker's reported startup flag, or None if it does not answer within timeout seconds."""
+        """Receives a timeout and returns the worker's startup flag, or None if it does not answer in time."""
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
@@ -46,15 +46,15 @@ class Process:
             return None
 
     def ping(self, timeout: float = 5) -> bool:
-        """Return True if the worker answers a healthcheck within timeout seconds."""
+        """Receives a timeout and returns True if the worker answers a healthcheck in time."""
         return self._healthcheck(timeout) is not None
 
     def is_ready(self, timeout: float = 5) -> bool:
-        """Return True if the worker answers and reports that its server has finished startup."""
+        """Receives a timeout and returns True if the worker answers and its server has finished startup."""
         return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
-        """Reply to one healthcheck ping with whether the server has finished startup."""
+        """Receives one healthcheck ping and replies with whether the server has finished startup."""
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -68,7 +68,6 @@ class Process:
                 lambda sig, frame: signal.raise_signal(signal.SIGTERM),
             )
 
-        self._server = Server(config=self.config)
         threading.Thread(target=self.always_pong, daemon=True).start()
         self.server.run(sockets)
 
@@ -106,8 +105,9 @@ class Process:
 
     @property
     def server(self) -> Server:
-        # Only valid once the worker has entered `target()`; never `None` to callers.
-        assert self._server is not None
+        # Created lazily on first access, so the property is never `None` to callers.
+        if self._server is None:
+            self._server = Server(config=self.config)
         return self._server
 
     @property

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -30,22 +30,29 @@ class Process:
     ) -> None:
         self.config = config
         self._server: Server | None = None
-        self.ready = False
 
         self.parent_conn, self.child_conn = Pipe()
         self.process = get_subprocess(config, self.target, sockets)
 
-    def ping(self, timeout: float = 5) -> bool:
+    def _healthcheck(self, timeout: float) -> bool | None:
+        # Ping the worker; return its `Server.started` flag, or None if it never answered.
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
                 started: bool = self.parent_conn.recv()
-                self.ready = self.ready or started
-                return True
-            return False
+                return started
+            return None
         except (OSError, EOFError, pickle.UnpicklingError):
             # The worker died and closed its side of the pipe.
-            return False
+            return None
+
+    def ping(self, timeout: float = 5) -> bool:
+        # Liveness: the worker answered the healthcheck within `timeout`.
+        return self._healthcheck(timeout) is not None
+
+    def is_ready(self, timeout: float = 5) -> bool:
+        # Readiness: the worker answered and its server finished startup.
+        return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
         # Report whether the server finished startup, not merely that the process is alive.

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -29,7 +29,7 @@ class Process:
         sockets: list[socket],
     ) -> None:
         self.config = config
-        self.server: Server | None = None
+        self._server: Server | None = None
         self.ready = False
 
         self.parent_conn, self.child_conn = Pipe()
@@ -50,8 +50,9 @@ class Process:
     def pong(self) -> None:
         # The pong reports whether the worker's server has finished startup, so the supervisor
         # can tell a worker that has merely booted from one that is actually serving requests.
+        # `_server` is still `None` while the worker boots, before `target()` creates it.
         self.child_conn.recv()
-        self.child_conn.send(self.server is not None and self.server.started)
+        self.child_conn.send(self._server is not None and self._server.started)
 
     def always_pong(self) -> None:
         while True:
@@ -67,7 +68,7 @@ class Process:
                 lambda sig, frame: signal.raise_signal(signal.SIGTERM),
             )
 
-        self.server = Server(config=self.config)
+        self._server = Server(config=self.config)
         threading.Thread(target=self.always_pong, daemon=True).start()
         self.server.run(sockets)
 
@@ -102,6 +103,12 @@ class Process:
     def join(self) -> None:
         logger.info(f"Waiting for child process [{self.process.pid}]")
         self.process.join()
+
+    @property
+    def server(self) -> Server:
+        # Only valid once the worker has entered `target()`; never `None` to callers.
+        assert self._server is not None
+        return self._server
 
     @property
     def pid(self) -> int | None:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -48,9 +48,7 @@ class Process:
             return False
 
     def pong(self) -> None:
-        # The pong reports whether the worker's server has finished startup, so the supervisor
-        # can tell a worker that has merely booted from one that is actually serving requests.
-        # `target()` creates the server before starting this thread, so `server` is always set here.
+        # Report whether the server finished startup, not merely that the process is alive.
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 
@@ -105,7 +103,6 @@ class Process:
 
     @property
     def server(self) -> Server:
-        # Created lazily on first access, so the property is never `None` to callers.
         if self._server is None:
             self._server = Server(config=self.config)
         return self._server

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -5,14 +5,13 @@ import os
 import pickle
 import signal
 import threading
-from collections.abc import Callable
 from multiprocessing import Pipe
 from socket import socket
-from typing import Any
 
 from uvicorn._ansi import style
 from uvicorn._subprocess import get_subprocess
 from uvicorn.config import STARTUP_FAILURE, Config
+from uvicorn.server import Server
 
 SIGNALS = {
     getattr(signal, f"SIG{x}"): x
@@ -27,10 +26,11 @@ class Process:
     def __init__(
         self,
         config: Config,
-        target: Callable[[list[socket] | None], None],
         sockets: list[socket],
     ) -> None:
-        self.real_target = target
+        self.config = config
+        self.server: Server | None = None
+        self.ready = False
 
         self.parent_conn, self.child_conn = Pipe()
         self.process = get_subprocess(config, self.target, sockets)
@@ -39,7 +39,8 @@ class Process:
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
-                self.parent_conn.recv()
+                started: bool = self.parent_conn.recv()
+                self.ready = self.ready or started
                 return True
             return False
         except (OSError, EOFError, pickle.UnpicklingError):
@@ -47,14 +48,16 @@ class Process:
             return False
 
     def pong(self) -> None:
+        # The pong reports whether the worker's server has finished startup, so the supervisor
+        # can tell a worker that has merely booted from one that is actually serving requests.
         self.child_conn.recv()
-        self.child_conn.send(b"pong")
+        self.child_conn.send(self.server is not None and self.server.started)
 
     def always_pong(self) -> None:
         while True:
             self.pong()
 
-    def target(self, sockets: list[socket] | None = None) -> Any:  # pragma: no cover
+    def target(self, sockets: list[socket] | None = None) -> None:  # pragma: no cover
         if os.name == "nt":  # pragma: py-not-win32
             # Windows doesn't support SIGTERM, so we use SIGBREAK instead.
             # And then we raise SIGTERM when SIGBREAK is received.
@@ -64,8 +67,9 @@ class Process:
                 lambda sig, frame: signal.raise_signal(signal.SIGTERM),
             )
 
+        self.server = Server(config=self.config)
         threading.Thread(target=self.always_pong, daemon=True).start()
-        return self.real_target(sockets)
+        self.server.run(sockets)
 
     def is_alive(self, timeout: float = 5) -> bool:
         if not self.process.is_alive():
@@ -112,11 +116,9 @@ class Multiprocess:
     def __init__(
         self,
         config: Config,
-        target: Callable[[list[socket] | None], None],
         sockets: list[socket],
     ) -> None:
         self.config = config
-        self.target = target
         self.sockets = sockets
 
         self.processes_num = config.workers
@@ -130,7 +132,7 @@ class Multiprocess:
 
     def init_processes(self) -> None:
         for _ in range(self.processes_num):
-            process = Process(self.config, self.target, self.sockets)
+            process = Process(self.config, self.sockets)
             process.start()
             self.processes.append(process)
 
@@ -146,7 +148,7 @@ class Multiprocess:
         for idx, process in enumerate(self.processes):
             process.terminate()
             process.join()
-            new_process = Process(self.config, self.target, self.sockets)
+            new_process = Process(self.config, self.sockets)
             new_process.start()
             self.processes[idx] = new_process
 
@@ -191,7 +193,7 @@ class Multiprocess:
                 return  # pragma: full coverage
 
             logger.info(f"Child process [{process.pid}] died")
-            process = Process(self.config, self.target, self.sockets)
+            process = Process(self.config, self.sockets)
             process.start()
             self.processes[idx] = process
 
@@ -224,7 +226,7 @@ class Multiprocess:
     def handle_ttin(self) -> None:  # pragma: py-win32
         logger.info("Received SIGTTIN, increasing the number of processes.")
         self.processes_num += 1
-        process = Process(self.config, self.target, self.sockets)
+        process = Process(self.config, self.sockets)
         process.start()
         self.processes.append(process)
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -50,9 +50,9 @@ class Process:
     def pong(self) -> None:
         # The pong reports whether the worker's server has finished startup, so the supervisor
         # can tell a worker that has merely booted from one that is actually serving requests.
-        # `_server` is still `None` while the worker boots, before `target()` creates it.
+        # `target()` creates the server before starting this thread, so `server` is always set here.
         self.child_conn.recv()
-        self.child_conn.send(self._server is not None and self._server.started)
+        self.child_conn.send(self.server.started)
 
     def always_pong(self) -> None:
         while True:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -35,7 +35,7 @@ class Process:
         self.process = get_subprocess(config, self.target, sockets)
 
     def _healthcheck(self, timeout: float) -> bool | None:
-        # Ping the worker; return its `Server.started` flag, or None if it never answered.
+        """Ping the worker and return its server-started flag, or None if it never answered."""
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
@@ -43,19 +43,18 @@ class Process:
                 return started
             return None
         except (OSError, EOFError, pickle.UnpicklingError):
-            # The worker died and closed its side of the pipe.
             return None
 
     def ping(self, timeout: float = 5) -> bool:
-        # Liveness: the worker answered the healthcheck within `timeout`.
+        """Return whether the worker answered the healthcheck within the timeout."""
         return self._healthcheck(timeout) is not None
 
     def is_ready(self, timeout: float = 5) -> bool:
-        # Readiness: the worker answered and its server finished startup.
+        """Return whether the worker answered and its server has finished startup."""
         return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
-        # Report whether the server finished startup, not merely that the process is alive.
+        """Answer a healthcheck ping with whether the server has finished startup."""
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 


### PR DESCRIPTION
## Why

The healthcheck pong only proved a worker *booted*: the pong thread starts before `Server.run()`, so a worker answered `is_alive` before its app had imported or lifespan startup had finished. Zero-downtime restart (#3025) needs to know when a worker is actually *serving*, not merely alive.

## How

`Process` owns its `Server` (created lazily in the `server` property) and the pong now reports `Server.started`. The healthcheck splits into two pure queries over one round-trip:

- `ping()` - liveness: the worker answered.
- `is_ready()` - readiness: the worker answered *and* its server finished startup.

No stored `ready` flag; readiness is queried, not latched (keeps command/query separation).

## Is it backwards compatible?

Yes for the public API - the change is internal to `uvicorn.supervisors`. `Process`/`Multiprocess` drop the `target` parameter (each `Process` builds its own `Server` so the pong can read `started`); the documented entrypoints (`uvicorn.run`, the CLI) are unaffected.
