### PR TITLE
Restart workers with overlap on SIGHUP for near-zero-downtime reloads

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -78,7 +78,7 @@ The default process manager monitors the status of child processes and automatic
 
 You can also manage child processes by sending specific signals to the main process. (Not supported on Windows.)
 
-- `SIGHUP`: Work processes are graceful restarted one after another. If you update the code, the new worker process will use the new code.
+- `SIGHUP`: Gracefully restart the workers one at a time. Each replacement is brought up and confirmed serving before the worker it replaces is retired, so no requests are dropped during the restart. If a replacement never becomes ready within `--timeout-worker-healthcheck`, the old worker is kept and the restart is aborted. Fresh workers pick up the new code on disk.
 - `SIGTTIN`: Increase the number of worker processes by one.
 - `SIGTTOU`: Decrease the number of worker processes by one.
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -78,7 +78,7 @@ The default process manager monitors the status of child processes and automatic
 
 You can also manage child processes by sending specific signals to the main process. (Not supported on Windows.)
 
-- `SIGHUP`: Gracefully restart the workers one at a time. Each replacement is brought up and confirmed serving before the worker it replaces is retired, so no requests are dropped during the restart. If a replacement never becomes ready within `--timeout-worker-healthcheck`, the old worker is kept and the restart is aborted. Fresh workers pick up the new code on disk.
+- `SIGHUP`: Gracefully restart the workers one at a time with no dropped requests. Fresh workers pick up new code on disk.
 - `SIGTTIN`: Increase the number of worker processes by one.
 - `SIGTTOU`: Decrease the number of worker processes by one.
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -180,7 +180,6 @@ def test_multiprocess_restart_aborts_when_replacement_not_ready(monkeypatch: pyt
     supervisor.init_processes()
     original_pids = [p.pid for p in supervisor.processes]
 
-    # Force every freshly spawned replacement to never report ready, so `wait_until_ready` times out.
     monkeypatch.setattr(Process, "is_ready", lambda self, timeout=1: False)
     supervisor.restart_all()
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools
 import os
 import signal
-import socket
 import threading
 import time
 from collections.abc import Callable
@@ -42,27 +41,37 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     pass  # pragma: no cover
 
 
-def run(sockets: list[socket.socket] | None) -> None:
-    while True:  # pragma: no cover
-        time.sleep(1)
-
-
 def test_process_ping_pong() -> None:
-    process = Process(Config(app=app), target=lambda x: None, sockets=[])
+    process = Process(Config(app=app), sockets=[])
     threading.Thread(target=process.always_pong, daemon=True).start()
     assert process.ping()
 
 
 def test_process_ping_pong_timeout() -> None:
-    process = Process(Config(app=app), target=lambda x: None, sockets=[])
+    process = Process(Config(app=app), sockets=[])
     assert not process.ping(0.1)
 
 
 def test_process_ping_broken_pipe() -> None:
-    process = Process(Config(app=app), target=lambda x: None, sockets=[])
+    process = Process(Config(app=app), sockets=[])
     process.parent_conn.close()
     process.child_conn.close()
     assert not process.ping(0.1)
+
+
+def test_process_ready() -> None:
+    """`ping()` latches `ready` once the worker's server reports it has finished startup."""
+    process = Process(Config(app=app), sockets=[])
+    threading.Thread(target=process.always_pong, daemon=True).start()
+
+    # The server hasn't started yet, so the worker is alive but not ready.
+    assert process.ping()
+    assert not process.ready
+
+    process.server = Server(process.config)
+    process.server.started = True
+    assert process.ping()
+    assert process.ready
 
 
 @new_console_in_windows
@@ -74,7 +83,7 @@ def test_multiprocess_run() -> None:
     quit immediately.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     supervisor.signal_queue.append(signal.SIGINT)
     supervisor.join_all()
@@ -86,7 +95,7 @@ def test_multiprocess_health_check() -> None:
     Ensure that the health check works as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     process = supervisor.processes[0]
@@ -107,8 +116,7 @@ def test_multiprocess_worker_dies_on_startup() -> None:
     Regression for https://github.com/encode/uvicorn/discussions/2440.
     """
     config = Config(app="tests.supervisors.test_multiprocess:does_not_exist", workers=2)
-    server = Server(config)
-    supervisor = Multiprocess(config, target=server.run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     thread = threading.Thread(target=supervisor.run, daemon=True)
     thread.start()
     deadline = time.monotonic() + 10
@@ -124,7 +132,7 @@ def test_multiprocess_sigterm() -> None:
     Ensure that the SIGTERM signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     supervisor.signal_queue.append(signal.SIGTERM)
@@ -138,7 +146,7 @@ def test_multiprocess_sigbreak() -> None:  # pragma: py-not-win32
     Ensure that the SIGBREAK signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     supervisor.signal_queue.append(getattr(signal, "SIGBREAK"))
@@ -151,7 +159,7 @@ def test_multiprocess_sighup() -> None:
     Ensure that the SIGHUP signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     pids = [p.pid for p in supervisor.processes]
@@ -174,7 +182,7 @@ def test_multiprocess_sigttin() -> None:
     Ensure that the SIGTTIN signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     supervisor.signal_queue.append(signal.SIGTTIN)
     time.sleep(1)
@@ -189,7 +197,7 @@ def test_multiprocess_sigttou() -> None:
     Ensure that the SIGTTOU signal is handled as expected.
     """
     config = Config(app=app, workers=2)
-    supervisor = Multiprocess(config, target=run, sockets=[])
+    supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     supervisor.signal_queue.append(signal.SIGTTOU)
     time.sleep(1)

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -189,6 +189,25 @@ def test_multiprocess_restart_aborts_when_replacement_not_ready(monkeypatch: pyt
     supervisor.join_all()
 
 
+def test_wait_until_ready_bails_on_shutdown_or_dead_worker() -> None:
+    process = Process(Config(app=app), sockets=[])
+
+    should_exit = threading.Event()
+    should_exit.set()
+    assert process.wait_until_ready(timeout=1, should_exit=should_exit) is False
+    assert process.wait_until_ready(timeout=0.5) is False
+
+
+def test_multiprocess_restart_stops_when_shutting_down() -> None:
+    supervisor = Multiprocess(Config(app=app, workers=1), sockets=[])
+    supervisor.processes = [Process(supervisor.config, [])]
+    supervisor.should_exit.set()
+
+    supervisor.restart_all()
+
+    assert len(supervisor.processes) == 1
+
+
 @pytest.mark.skipif(not hasattr(signal, "SIGTTIN"), reason="platform unsupports SIGTTIN")
 def test_multiprocess_sigttin() -> None:
     """

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -68,7 +68,8 @@ def test_process_ready() -> None:
     assert process.ping()
     assert not process.ready
 
-    process.server = Server(process.config)
+    process._server = Server(process.config)
+    assert process.server is process._server
     process.server.started = True
     assert process.ping()
     assert process.ready

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -154,15 +154,13 @@ def test_multiprocess_sighup() -> None:
     """
     Ensure that the SIGHUP signal is handled as expected.
     """
-    config = Config(app=app, workers=2)
+    config = Config(app=app, workers=2, timeout_worker_healthcheck=30)
     supervisor = Multiprocess(config, sockets=[])
     threading.Thread(target=supervisor.run, daemon=True).start()
     time.sleep(1)
     pids = [p.pid for p in supervisor.processes]
     supervisor.signal_queue.append(signal.SIGHUP)
-    # Poll instead of a fixed sleep — `restart_all()` waits for each replacement to become ready
-    # before draining the worker it replaces, so the total time is non-deterministic.
-    deadline = time.monotonic() + 10
+    deadline = time.monotonic() + 30
     while time.monotonic() < deadline:
         if [p.pid for p in supervisor.processes] != pids:
             break

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -63,7 +63,6 @@ def test_process_ready() -> None:
     process = Process(Config(app=app), sockets=[])
     threading.Thread(target=process.always_pong, daemon=True).start()
 
-    # The server exists but hasn't finished startup yet, so the worker is alive but not ready.
     assert process.ping()
     assert not process.ready
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -161,8 +161,8 @@ def test_multiprocess_sighup() -> None:
     time.sleep(1)
     pids = [p.pid for p in supervisor.processes]
     supervisor.signal_queue.append(signal.SIGHUP)
-    # Poll instead of a fixed sleep — the supervisor loop runs on a 0.5s interval and `restart_all()` terminates/joins
-    # each worker sequentially, so the total time is non-deterministic.
+    # Poll instead of a fixed sleep — `restart_all()` waits for each replacement to become ready
+    # before draining the worker it replaces, so the total time is non-deterministic.
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline:
         if [p.pid for p in supervisor.processes] != pids:
@@ -170,6 +170,22 @@ def test_multiprocess_sighup() -> None:
         time.sleep(0.1)
     assert pids != [p.pid for p in supervisor.processes]
     supervisor.signal_queue.append(signal.SIGINT)
+    supervisor.join_all()
+
+
+def test_multiprocess_restart_aborts_when_replacement_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a replacement never becomes ready, the existing worker is kept and the restart is aborted."""
+    config = Config(app=app, workers=2, timeout_worker_healthcheck=1)
+    supervisor = Multiprocess(config, sockets=[])
+    supervisor.init_processes()
+    original_pids = [p.pid for p in supervisor.processes]
+
+    # Force every freshly spawned replacement to look unready, so `wait_until_ready` times out.
+    monkeypatch.setattr(Process, "is_alive", lambda self, timeout=1: False)
+    supervisor.restart_all()
+
+    assert [p.pid for p in supervisor.processes] == original_pids
+    supervisor.terminate_all()
     supervisor.join_all()
 
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -12,7 +12,6 @@ import pytest
 
 from uvicorn import Config
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
-from uvicorn.server import Server
 from uvicorn.supervisors import Multiprocess
 from uvicorn.supervisors.multiprocess import Process
 
@@ -43,7 +42,6 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 
 def test_process_ping_pong() -> None:
     process = Process(Config(app=app), sockets=[])
-    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
     assert process.ping()
 
@@ -63,7 +61,6 @@ def test_process_ping_broken_pipe() -> None:
 def test_process_ready() -> None:
     """`ping()` latches `ready` once the worker's server reports it has finished startup."""
     process = Process(Config(app=app), sockets=[])
-    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
 
     # The server exists but hasn't finished startup yet, so the worker is alive but not ready.

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -179,8 +179,8 @@ def test_multiprocess_restart_aborts_when_replacement_not_ready(monkeypatch: pyt
     supervisor.init_processes()
     original_pids = [p.pid for p in supervisor.processes]
 
-    # Force every freshly spawned replacement to look unready, so `wait_until_ready` times out.
-    monkeypatch.setattr(Process, "is_alive", lambda self, timeout=1: False)
+    # Force every freshly spawned replacement to never report ready, so `wait_until_ready` times out.
+    monkeypatch.setattr(Process, "is_ready", lambda self, timeout=1: False)
     supervisor.restart_all()
 
     assert [p.pid for p in supervisor.processes] == original_pids

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -43,6 +43,7 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 
 def test_process_ping_pong() -> None:
     process = Process(Config(app=app), sockets=[])
+    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
     assert process.ping()
 
@@ -62,14 +63,13 @@ def test_process_ping_broken_pipe() -> None:
 def test_process_ready() -> None:
     """`ping()` latches `ready` once the worker's server reports it has finished startup."""
     process = Process(Config(app=app), sockets=[])
+    process._server = Server(process.config)
     threading.Thread(target=process.always_pong, daemon=True).start()
 
-    # The server hasn't started yet, so the worker is alive but not ready.
+    # The server exists but hasn't finished startup yet, so the worker is alive but not ready.
     assert process.ping()
     assert not process.ready
 
-    process._server = Server(process.config)
-    assert process.server is process._server
     process.server.started = True
     assert process.ping()
     assert process.ready

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -59,16 +59,15 @@ def test_process_ping_broken_pipe() -> None:
 
 
 def test_process_ready() -> None:
-    """`ping()` latches `ready` once the worker's server reports it has finished startup."""
+    """`is_ready()` reflects whether the worker's server has finished startup."""
     process = Process(Config(app=app), sockets=[])
     threading.Thread(target=process.always_pong, daemon=True).start()
 
     assert process.ping()
-    assert not process.ready
+    assert not process.is_ready()
 
     process.server.started = True
-    assert process.ping()
-    assert process.ready
+    assert process.is_ready()
 
 
 @new_console_in_windows

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -172,6 +172,7 @@ def test_multiprocess_sighup() -> None:
     supervisor.join_all()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="test spawns real worker processes")
 def test_multiprocess_restart_aborts_when_replacement_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     """If a replacement never becomes ready, the existing worker is kept and the restart is aborted."""
     config = Config(app=app, workers=2, timeout_worker_healthcheck=1)
@@ -184,6 +185,7 @@ def test_multiprocess_restart_aborts_when_replacement_not_ready(monkeypatch: pyt
     supervisor.restart_all()
 
     assert [p.pid for p in supervisor.processes] == original_pids
+    assert all(process.is_alive() for process in supervisor.processes)
     supervisor.terminate_all()
     supervisor.join_all()
 

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -616,7 +616,7 @@ def run(
             ChangeReload(config, target=server.run, sockets=[sock]).run()
         elif config.workers > 1:
             sock = config.bind_socket()
-            Multiprocess(config, target=server.run, sockets=[sock]).run()
+            Multiprocess(config, sockets=[sock]).run()
         else:
             server.run()
     except KeyboardInterrupt:  # pragma: full coverage

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -35,7 +35,7 @@ class Process:
         self.process = get_subprocess(config, self.target, sockets)
 
     def _healthcheck(self, timeout: float) -> bool | None:
-        """Ping the worker and return its server-started flag, or None if it never answered."""
+        """Return the worker's reported startup flag, or None if it does not answer within timeout seconds."""
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
@@ -46,15 +46,15 @@ class Process:
             return None
 
     def ping(self, timeout: float = 5) -> bool:
-        """Return whether the worker answered the healthcheck within the timeout."""
+        """Return True if the worker answers a healthcheck within timeout seconds."""
         return self._healthcheck(timeout) is not None
 
     def is_ready(self, timeout: float = 5) -> bool:
-        """Return whether the worker answered and its server has finished startup."""
+        """Return True if the worker answers and reports that its server has finished startup."""
         return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
-        """Answer a healthcheck ping with whether the server has finished startup."""
+        """Reply to one healthcheck ping with whether the server has finished startup."""
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -35,7 +35,7 @@ class Process:
         self.process = get_subprocess(config, self.target, sockets)
 
     def _healthcheck(self, timeout: float) -> bool | None:
-        """Return the worker's reported startup flag, or None if it does not answer within timeout seconds."""
+        """Receives a timeout and returns the worker's startup flag, or None if it does not answer in time."""
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
@@ -46,15 +46,15 @@ class Process:
             return None
 
     def ping(self, timeout: float = 5) -> bool:
-        """Return True if the worker answers a healthcheck within timeout seconds."""
+        """Receives a timeout and returns True if the worker answers a healthcheck in time."""
         return self._healthcheck(timeout) is not None
 
     def is_ready(self, timeout: float = 5) -> bool:
-        """Return True if the worker answers and reports that its server has finished startup."""
+        """Receives a timeout and returns True if the worker answers and its server has finished startup."""
         return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
-        """Reply to one healthcheck ping with whether the server has finished startup."""
+        """Receives one healthcheck ping and replies with whether the server has finished startup."""
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -83,14 +83,13 @@ class Process:
         return self.ping(timeout)
 
     def wait_until_ready(self, timeout: float, should_exit: threading.Event | None = None) -> bool:
-        # Poll a freshly started worker until its server reports it finished startup. Returns False
-        # if the worker exits, a shutdown is requested, or it never becomes ready within the window.
+        """Poll until the worker is serving, returning False if it exits or a shutdown is requested first."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if should_exit is not None and should_exit.is_set():
                 return False
             if not self.process.is_alive():
-                return False  # the worker exited, e.g. a startup failure
+                return False
             if self.is_ready(timeout=1):
                 return True
             time.sleep(0.1)
@@ -117,9 +116,6 @@ class Process:
         # In Windows, the method will call `TerminateProcess` to kill the process.
         # In Unix, the method will send SIGKILL to the process.
         self.process.kill()
-
-        # Close the healthcheck pipe, like `terminate()`, so a repeatedly killed worker
-        # (e.g. SIGHUP reloads against a broken app) doesn't leak descriptors.
         self.parent_conn.close()
         self.child_conn.close()
 
@@ -175,21 +171,15 @@ class Multiprocess:
             process.join()
 
     def restart_all(self) -> None:
-        # Rolling restart with worker overlap. All workers share the same listening socket(s), bound
-        # once by the parent, so old and new workers can accept connections concurrently. For each
-        # slot we bring a replacement up and wait until it is serving before draining the worker it
-        # replaces, so a live worker is always serving the shared socket.
+        """Restart workers one at a time, draining each only after its replacement is serving."""
         for idx, old_process in enumerate(self.processes):
             if self.should_exit.is_set():
-                return  # a shutdown arrived mid-restart; stop rolling and let run() exit
+                return
 
             new_process = Process(self.config, self.sockets)
             new_process.start()
 
             if not new_process.wait_until_ready(self.config.timeout_worker_healthcheck, self.should_exit):
-                # The replacement never started serving (broken app, bad TLS or socket bind, or a
-                # startup slower than the healthcheck window), or a shutdown was requested. Keep the
-                # existing worker serving rather than tearing down a working service.
                 new_process.kill()
                 new_process.join()
                 if not self.should_exit.is_set():
@@ -199,7 +189,7 @@ class Multiprocess:
                     )
                 return
 
-            old_process.terminate()  # graceful SIGTERM: drains in-flight requests
+            old_process.terminate()
             old_process.join()
             self.processes[idx] = new_process
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -68,7 +68,6 @@ class Process:
                 lambda sig, frame: signal.raise_signal(signal.SIGTERM),
             )
 
-        self._server = Server(config=self.config)
         threading.Thread(target=self.always_pong, daemon=True).start()
         self.server.run(sockets)
 
@@ -106,8 +105,9 @@ class Process:
 
     @property
     def server(self) -> Server:
-        # Only valid once the worker has entered `target()`; never `None` to callers.
-        assert self._server is not None
+        # Created lazily on first access, so the property is never `None` to callers.
+        if self._server is None:
+            self._server = Server(config=self.config)
         return self._server
 
     @property

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -83,11 +83,13 @@ class Process:
 
         return self.ping(timeout)
 
-    def wait_until_ready(self, timeout: float) -> bool:
+    def wait_until_ready(self, timeout: float, should_exit: threading.Event | None = None) -> bool:
         # Poll a freshly started worker until its server reports it finished startup. Returns False
-        # if the worker exits or never becomes ready within the window (broken or slow startup).
+        # if the worker exits, a shutdown is requested, or it never becomes ready within the window.
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
+            if should_exit is not None and should_exit.is_set():
+                return False
             if not self.process.is_alive():
                 return False  # the worker exited, e.g. a startup failure
             if self.is_ready(timeout=1):
@@ -179,19 +181,23 @@ class Multiprocess:
         # slot we bring a replacement up and wait until it is serving before draining the worker it
         # replaces, so a live worker is always serving the shared socket.
         for idx, old_process in enumerate(self.processes):
+            if self.should_exit.is_set():
+                return  # a shutdown arrived mid-restart; stop rolling and let run() exit
+
             new_process = Process(self.config, self.sockets)
             new_process.start()
 
-            if not new_process.wait_until_ready(self.config.timeout_worker_healthcheck):
+            if not new_process.wait_until_ready(self.config.timeout_worker_healthcheck, self.should_exit):
                 # The replacement never started serving (broken app, bad TLS or socket bind, or a
-                # startup slower than the healthcheck window). Keep the existing worker serving
-                # rather than tearing down a working service, and abandon the restart.
-                logger.error(
-                    f"New child process [{new_process.pid}] was not ready in time; "
-                    f"keeping worker [{old_process.pid}] and aborting the restart."
-                )
+                # startup slower than the healthcheck window), or a shutdown was requested. Keep the
+                # existing worker serving rather than tearing down a working service.
                 new_process.kill()
                 new_process.join()
+                if not self.should_exit.is_set():
+                    logger.error(
+                        f"New child process [{new_process.pid}] was not ready in time; "
+                        f"keeping worker [{old_process.pid}] and aborting the restart."
+                    )
                 return
 
             old_process.terminate()  # graceful SIGTERM: drains in-flight requests

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -30,22 +30,29 @@ class Process:
     ) -> None:
         self.config = config
         self._server: Server | None = None
-        self.ready = False
 
         self.parent_conn, self.child_conn = Pipe()
         self.process = get_subprocess(config, self.target, sockets)
 
-    def ping(self, timeout: float = 5) -> bool:
+    def _healthcheck(self, timeout: float) -> bool | None:
+        # Ping the worker; return its `Server.started` flag, or None if it never answered.
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
                 started: bool = self.parent_conn.recv()
-                self.ready = self.ready or started
-                return True
-            return False
+                return started
+            return None
         except (OSError, EOFError, pickle.UnpicklingError):
             # The worker died and closed its side of the pipe.
-            return False
+            return None
+
+    def ping(self, timeout: float = 5) -> bool:
+        # Liveness: the worker answered the healthcheck within `timeout`.
+        return self._healthcheck(timeout) is not None
+
+    def is_ready(self, timeout: float = 5) -> bool:
+        # Readiness: the worker answered and its server finished startup.
+        return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
         # Report whether the server finished startup, not merely that the process is alive.

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -171,8 +171,8 @@ class Multiprocess:
             process.join()
 
     def restart_all(self) -> None:
-        """Replaces every worker by spawning a fresh one and retiring the oldest, one at a time."""
-        for _ in range(len(self.processes)):
+        """Replaces each worker, bringing its replacement into service before retiring the old worker."""
+        for idx, old_process in enumerate(self.processes):
             if self.should_exit.is_set():
                 return
 
@@ -185,14 +185,13 @@ class Multiprocess:
                 if not self.should_exit.is_set():
                     logger.error(
                         f"New child process [{new_process.pid}] was not ready in time; "
-                        "keeping the existing workers and aborting the restart."
+                        f"keeping worker [{old_process.pid}] and aborting the restart."
                     )
                 return
 
-            self.processes.append(new_process)
-            oldest = self.processes.pop(0)
-            oldest.terminate()
-            oldest.join()
+            old_process.terminate()
+            old_process.join()
+            self.processes[idx] = new_process
 
     def run(self) -> None:
         message = f"Started parent process [{os.getpid()}]"

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -83,7 +83,7 @@ class Process:
         return self.ping(timeout)
 
     def wait_until_ready(self, timeout: float, should_exit: threading.Event | None = None) -> bool:
-        """Return True once the worker is serving, or False on worker exit, shutdown, or timeout."""
+        """Receives a timeout and returns True if the worker starts serving, or False on exit, shutdown, or timeout."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if should_exit is not None and should_exit.is_set():
@@ -171,7 +171,7 @@ class Multiprocess:
             process.join()
 
     def restart_all(self) -> None:
-        """Replace each worker, bringing its replacement into service before retiring the old worker."""
+        """Replaces each worker, bringing its replacement into service before retiring the old worker."""
         for idx, old_process in enumerate(self.processes):
             if self.should_exit.is_set():
                 return

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -29,7 +29,7 @@ class Process:
         sockets: list[socket],
     ) -> None:
         self.config = config
-        self.server: Server | None = None
+        self._server: Server | None = None
         self.ready = False
 
         self.parent_conn, self.child_conn = Pipe()
@@ -50,8 +50,9 @@ class Process:
     def pong(self) -> None:
         # The pong reports whether the worker's server has finished startup, so the supervisor
         # can tell a worker that has merely booted from one that is actually serving requests.
+        # `_server` is still `None` while the worker boots, before `target()` creates it.
         self.child_conn.recv()
-        self.child_conn.send(self.server is not None and self.server.started)
+        self.child_conn.send(self._server is not None and self._server.started)
 
     def always_pong(self) -> None:
         while True:
@@ -67,7 +68,7 @@ class Process:
                 lambda sig, frame: signal.raise_signal(signal.SIGTERM),
             )
 
-        self.server = Server(config=self.config)
+        self._server = Server(config=self.config)
         threading.Thread(target=self.always_pong, daemon=True).start()
         self.server.run(sockets)
 
@@ -102,6 +103,12 @@ class Process:
     def join(self) -> None:
         logger.info(f"Waiting for child process [{self.process.pid}]")
         self.process.join()
+
+    @property
+    def server(self) -> Server:
+        # Only valid once the worker has entered `target()`; never `None` to callers.
+        assert self._server is not None
+        return self._server
 
     @property
     def pid(self) -> int | None:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import signal
 import threading
+import time
 from multiprocessing import Pipe
 from socket import socket
 
@@ -97,6 +98,11 @@ class Process:
         # In Unix, the method will send SIGKILL to the process.
         self.process.kill()
 
+        # Close the healthcheck pipe, like `terminate()`, so a repeatedly killed worker
+        # (e.g. SIGHUP reloads against a broken app) doesn't leak descriptors.
+        self.parent_conn.close()
+        self.child_conn.close()
+
     def join(self) -> None:
         logger.info(f"Waiting for child process [{self.process.pid}]")
         self.process.join()
@@ -148,12 +154,41 @@ class Multiprocess:
         for process in self.processes:
             process.join()
 
+    def wait_until_ready(self, process: Process) -> bool:
+        # Poll a freshly started worker until its server reports it finished startup. Returns False
+        # if the worker never becomes ready within the healthcheck window (broken or slow startup).
+        deadline = time.monotonic() + self.config.timeout_worker_healthcheck
+        while time.monotonic() < deadline:
+            if process.is_alive(timeout=1) and process.ready:
+                return True
+            time.sleep(0.1)
+        return False
+
     def restart_all(self) -> None:
-        for idx, process in enumerate(self.processes):
-            process.terminate()
-            process.join()
+        # Rolling restart with worker overlap. All workers share the same listening socket(s), bound
+        # once by the parent, so old and new workers can accept connections concurrently. For each
+        # slot we bring a replacement up and wait until it is serving before draining the worker it
+        # replaces, so a live worker is always serving the shared socket.
+        for idx in range(len(self.processes)):
+            old_process = self.processes[idx]
+
             new_process = Process(self.config, self.sockets)
             new_process.start()
+
+            if not self.wait_until_ready(new_process):
+                # The replacement never started serving (broken app, bad TLS or socket bind, or a
+                # startup slower than the healthcheck window). Keep the existing worker serving
+                # rather than tearing down a working service, and abandon the restart.
+                logger.error(
+                    f"New child process [{new_process.pid}] was not ready in time; "
+                    f"keeping worker [{old_process.pid}] and aborting the restart."
+                )
+                new_process.kill()
+                new_process.join()
+                return
+
+            old_process.terminate()  # graceful SIGTERM: drains in-flight requests
+            old_process.join()
             self.processes[idx] = new_process
 
     def run(self) -> None:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -48,9 +48,7 @@ class Process:
             return False
 
     def pong(self) -> None:
-        # The pong reports whether the worker's server has finished startup, so the supervisor
-        # can tell a worker that has merely booted from one that is actually serving requests.
-        # `target()` creates the server before starting this thread, so `server` is always set here.
+        # Report whether the server finished startup, not merely that the process is alive.
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 
@@ -105,7 +103,6 @@ class Process:
 
     @property
     def server(self) -> Server:
-        # Created lazily on first access, so the property is never `None` to callers.
         if self._server is None:
             self._server = Server(config=self.config)
         return self._server

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -159,14 +159,11 @@ class Multiprocess:
         for sig in SIGNALS:
             signal.signal(sig, lambda sig, frame: self.signal_queue.append(sig))
 
-    def _spawn(self) -> Process:
-        process = Process(self.config, self.sockets)
-        process.start()
-        return process
-
     def init_processes(self) -> None:
         for _ in range(self.processes_num):
-            self.processes.append(self._spawn())
+            process = Process(self.config, self.sockets)
+            process.start()
+            self.processes.append(process)
 
     def terminate_all(self) -> None:
         for process in self.processes:
@@ -182,7 +179,8 @@ class Multiprocess:
         # slot we bring a replacement up and wait until it is serving before draining the worker it
         # replaces, so a live worker is always serving the shared socket.
         for idx, old_process in enumerate(self.processes):
-            new_process = self._spawn()
+            new_process = Process(self.config, self.sockets)
+            new_process.start()
 
             if not new_process.wait_until_ready(self.config.timeout_worker_healthcheck):
                 # The replacement never started serving (broken app, bad TLS or socket bind, or a
@@ -241,7 +239,9 @@ class Multiprocess:
                 return  # pragma: full coverage
 
             logger.info(f"Child process [{process.pid}] died")
-            self.processes[idx] = self._spawn()
+            process = Process(self.config, self.sockets)
+            process.start()
+            self.processes[idx] = process
 
     def handle_signals(self) -> None:
         for sig in tuple(self.signal_queue):
@@ -272,7 +272,9 @@ class Multiprocess:
     def handle_ttin(self) -> None:  # pragma: py-win32
         logger.info("Received SIGTTIN, increasing the number of processes.")
         self.processes_num += 1
-        self.processes.append(self._spawn())
+        process = Process(self.config, self.sockets)
+        process.start()
+        self.processes.append(process)
 
     def handle_ttou(self) -> None:  # pragma: py-win32
         logger.info("Received SIGTTOU, decreasing number of processes.")

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -83,7 +83,7 @@ class Process:
         return self.ping(timeout)
 
     def wait_until_ready(self, timeout: float, should_exit: threading.Event | None = None) -> bool:
-        """Poll until the worker is serving, returning False if it exits or a shutdown is requested first."""
+        """Return True once the worker is serving, or False on worker exit, shutdown, or timeout."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if should_exit is not None and should_exit.is_set():
@@ -171,7 +171,7 @@ class Multiprocess:
             process.join()
 
     def restart_all(self) -> None:
-        """Restart workers one at a time, draining each only after its replacement is serving."""
+        """Replace each worker, bringing its replacement into service before retiring the old worker."""
         for idx, old_process in enumerate(self.processes):
             if self.should_exit.is_set():
                 return

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -171,8 +171,8 @@ class Multiprocess:
             process.join()
 
     def restart_all(self) -> None:
-        """Replaces each worker, bringing its replacement into service before retiring the old worker."""
-        for idx, old_process in enumerate(self.processes):
+        """Replaces every worker by spawning a fresh one and retiring the oldest, one at a time."""
+        for _ in range(len(self.processes)):
             if self.should_exit.is_set():
                 return
 
@@ -185,13 +185,14 @@ class Multiprocess:
                 if not self.should_exit.is_set():
                     logger.error(
                         f"New child process [{new_process.pid}] was not ready in time; "
-                        f"keeping worker [{old_process.pid}] and aborting the restart."
+                        "keeping the existing workers and aborting the restart."
                     )
                 return
 
-            old_process.terminate()
-            old_process.join()
-            self.processes[idx] = new_process
+            self.processes.append(new_process)
+            oldest = self.processes.pop(0)
+            oldest.terminate()
+            oldest.join()
 
     def run(self) -> None:
         message = f"Started parent process [{os.getpid()}]"

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -76,6 +76,16 @@ class Process:
 
         return self.ping(timeout)
 
+    def wait_until_ready(self, timeout: float) -> bool:
+        # Poll a freshly started worker until its server reports it finished startup. Returns False
+        # if the worker never becomes ready within the window (broken or slow startup).
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.is_alive(timeout=1) and self.ready:
+                return True
+            time.sleep(0.1)
+        return False
+
     def start(self) -> None:
         self.process.start()
 
@@ -140,11 +150,14 @@ class Multiprocess:
         for sig in SIGNALS:
             signal.signal(sig, lambda sig, frame: self.signal_queue.append(sig))
 
+    def _spawn(self) -> Process:
+        process = Process(self.config, self.sockets)
+        process.start()
+        return process
+
     def init_processes(self) -> None:
         for _ in range(self.processes_num):
-            process = Process(self.config, self.sockets)
-            process.start()
-            self.processes.append(process)
+            self.processes.append(self._spawn())
 
     def terminate_all(self) -> None:
         for process in self.processes:
@@ -154,28 +167,15 @@ class Multiprocess:
         for process in self.processes:
             process.join()
 
-    def wait_until_ready(self, process: Process) -> bool:
-        # Poll a freshly started worker until its server reports it finished startup. Returns False
-        # if the worker never becomes ready within the healthcheck window (broken or slow startup).
-        deadline = time.monotonic() + self.config.timeout_worker_healthcheck
-        while time.monotonic() < deadline:
-            if process.is_alive(timeout=1) and process.ready:
-                return True
-            time.sleep(0.1)
-        return False
-
     def restart_all(self) -> None:
         # Rolling restart with worker overlap. All workers share the same listening socket(s), bound
         # once by the parent, so old and new workers can accept connections concurrently. For each
         # slot we bring a replacement up and wait until it is serving before draining the worker it
         # replaces, so a live worker is always serving the shared socket.
-        for idx in range(len(self.processes)):
-            old_process = self.processes[idx]
+        for idx, old_process in enumerate(self.processes):
+            new_process = self._spawn()
 
-            new_process = Process(self.config, self.sockets)
-            new_process.start()
-
-            if not self.wait_until_ready(new_process):
+            if not new_process.wait_until_ready(self.config.timeout_worker_healthcheck):
                 # The replacement never started serving (broken app, bad TLS or socket bind, or a
                 # startup slower than the healthcheck window). Keep the existing worker serving
                 # rather than tearing down a working service, and abandon the restart.
@@ -232,9 +232,7 @@ class Multiprocess:
                 return  # pragma: full coverage
 
             logger.info(f"Child process [{process.pid}] died")
-            process = Process(self.config, self.sockets)
-            process.start()
-            self.processes[idx] = process
+            self.processes[idx] = self._spawn()
 
     def handle_signals(self) -> None:
         for sig in tuple(self.signal_queue):
@@ -265,9 +263,7 @@ class Multiprocess:
     def handle_ttin(self) -> None:  # pragma: py-win32
         logger.info("Received SIGTTIN, increasing the number of processes.")
         self.processes_num += 1
-        process = Process(self.config, self.sockets)
-        process.start()
-        self.processes.append(process)
+        self.processes.append(self._spawn())
 
     def handle_ttou(self) -> None:  # pragma: py-win32
         logger.info("Received SIGTTOU, decreasing number of processes.")

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -85,10 +85,12 @@ class Process:
 
     def wait_until_ready(self, timeout: float) -> bool:
         # Poll a freshly started worker until its server reports it finished startup. Returns False
-        # if the worker never becomes ready within the window (broken or slow startup).
+        # if the worker exits or never becomes ready within the window (broken or slow startup).
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if self.is_alive(timeout=1) and self.ready:
+            if not self.process.is_alive():
+                return False  # the worker exited, e.g. a startup failure
+            if self.is_ready(timeout=1):
                 return True
             time.sleep(0.1)
         return False

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -5,14 +5,13 @@ import os
 import pickle
 import signal
 import threading
-from collections.abc import Callable
 from multiprocessing import Pipe
 from socket import socket
-from typing import Any
 
 from uvicorn._ansi import style
 from uvicorn._subprocess import get_subprocess
 from uvicorn.config import STARTUP_FAILURE, Config
+from uvicorn.server import Server
 
 SIGNALS = {
     getattr(signal, f"SIG{x}"): x
@@ -27,10 +26,11 @@ class Process:
     def __init__(
         self,
         config: Config,
-        target: Callable[[list[socket] | None], None],
         sockets: list[socket],
     ) -> None:
-        self.real_target = target
+        self.config = config
+        self.server: Server | None = None
+        self.ready = False
 
         self.parent_conn, self.child_conn = Pipe()
         self.process = get_subprocess(config, self.target, sockets)
@@ -39,7 +39,8 @@ class Process:
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
-                self.parent_conn.recv()
+                started: bool = self.parent_conn.recv()
+                self.ready = self.ready or started
                 return True
             return False
         except (OSError, EOFError, pickle.UnpicklingError):
@@ -47,14 +48,16 @@ class Process:
             return False
 
     def pong(self) -> None:
+        # The pong reports whether the worker's server has finished startup, so the supervisor
+        # can tell a worker that has merely booted from one that is actually serving requests.
         self.child_conn.recv()
-        self.child_conn.send(b"pong")
+        self.child_conn.send(self.server is not None and self.server.started)
 
     def always_pong(self) -> None:
         while True:
             self.pong()
 
-    def target(self, sockets: list[socket] | None = None) -> Any:  # pragma: no cover
+    def target(self, sockets: list[socket] | None = None) -> None:  # pragma: no cover
         if os.name == "nt":  # pragma: py-not-win32
             # Windows doesn't support SIGTERM, so we use SIGBREAK instead.
             # And then we raise SIGTERM when SIGBREAK is received.
@@ -64,8 +67,9 @@ class Process:
                 lambda sig, frame: signal.raise_signal(signal.SIGTERM),
             )
 
+        self.server = Server(config=self.config)
         threading.Thread(target=self.always_pong, daemon=True).start()
-        return self.real_target(sockets)
+        self.server.run(sockets)
 
     def is_alive(self, timeout: float = 5) -> bool:
         if not self.process.is_alive():
@@ -112,11 +116,9 @@ class Multiprocess:
     def __init__(
         self,
         config: Config,
-        target: Callable[[list[socket] | None], None],
         sockets: list[socket],
     ) -> None:
         self.config = config
-        self.target = target
         self.sockets = sockets
 
         self.processes_num = config.workers
@@ -130,7 +132,7 @@ class Multiprocess:
 
     def init_processes(self) -> None:
         for _ in range(self.processes_num):
-            process = Process(self.config, self.target, self.sockets)
+            process = Process(self.config, self.sockets)
             process.start()
             self.processes.append(process)
 
@@ -146,7 +148,7 @@ class Multiprocess:
         for idx, process in enumerate(self.processes):
             process.terminate()
             process.join()
-            new_process = Process(self.config, self.target, self.sockets)
+            new_process = Process(self.config, self.sockets)
             new_process.start()
             self.processes[idx] = new_process
 
@@ -191,7 +193,7 @@ class Multiprocess:
                 return  # pragma: full coverage
 
             logger.info(f"Child process [{process.pid}] died")
-            process = Process(self.config, self.target, self.sockets)
+            process = Process(self.config, self.sockets)
             process.start()
             self.processes[idx] = process
 
@@ -224,7 +226,7 @@ class Multiprocess:
     def handle_ttin(self) -> None:  # pragma: py-win32
         logger.info("Received SIGTTIN, increasing the number of processes.")
         self.processes_num += 1
-        process = Process(self.config, self.target, self.sockets)
+        process = Process(self.config, self.sockets)
         process.start()
         self.processes.append(process)
 

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -50,9 +50,9 @@ class Process:
     def pong(self) -> None:
         # The pong reports whether the worker's server has finished startup, so the supervisor
         # can tell a worker that has merely booted from one that is actually serving requests.
-        # `_server` is still `None` while the worker boots, before `target()` creates it.
+        # `target()` creates the server before starting this thread, so `server` is always set here.
         self.child_conn.recv()
-        self.child_conn.send(self._server is not None and self._server.started)
+        self.child_conn.send(self.server.started)
 
     def always_pong(self) -> None:
         while True:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -35,7 +35,7 @@ class Process:
         self.process = get_subprocess(config, self.target, sockets)
 
     def _healthcheck(self, timeout: float) -> bool | None:
-        # Ping the worker; return its `Server.started` flag, or None if it never answered.
+        """Ping the worker and return its server-started flag, or None if it never answered."""
         try:
             self.parent_conn.send(b"ping")
             if self.parent_conn.poll(timeout):
@@ -43,19 +43,18 @@ class Process:
                 return started
             return None
         except (OSError, EOFError, pickle.UnpicklingError):
-            # The worker died and closed its side of the pipe.
             return None
 
     def ping(self, timeout: float = 5) -> bool:
-        # Liveness: the worker answered the healthcheck within `timeout`.
+        """Return whether the worker answered the healthcheck within the timeout."""
         return self._healthcheck(timeout) is not None
 
     def is_ready(self, timeout: float = 5) -> bool:
-        # Readiness: the worker answered and its server finished startup.
+        """Return whether the worker answered and its server has finished startup."""
         return self._healthcheck(timeout) is True
 
     def pong(self) -> None:
-        # Report whether the server finished startup, not merely that the process is alive.
+        """Answer a healthcheck ping with whether the server has finished startup."""
         self.child_conn.recv()
         self.child_conn.send(self.server.started)
 


### PR DESCRIPTION
Supersedes #3023 and folds in #3024. Addresses the multi-worker half of #2757 (single-worker restart needs #2931).

## Why

On `SIGHUP`, `restart_all()` was stop-then-start: terminate a worker, wait for it to exit, then start its replacement. Each slot has a window with no worker serving it - a total gap for a single-worker service - so requests arriving during the swap are dropped. Fixing that needs the parent to know when a replacement is actually *serving*, not just alive, so this PR has two parts: a readiness signal and the rolling restart that uses it.

## Readiness signal

The healthcheck pong only proved a worker *booted* - the pong thread starts before `Server.run()`, so it answered before startup finished. Now `Process` owns its `Server` and the pong reports `Server.started`. The healthcheck splits into two pure queries over one round-trip:

- `ping()` - liveness: the worker answered.
- `is_ready()` - readiness: the worker answered *and* its server finished startup.

## Rolling restart

Workers share the parent-bound socket, so old and new can serve concurrently. `restart_all()` now rolls each slot: start the replacement, wait until `is_ready`, then gracefully `SIGTERM` the old worker to drain in-flight requests.

If a replacement never becomes ready within `timeout_worker_healthcheck`, the old worker is kept and the restart is aborted rather than tearing down a working service - the same shape as a Kubernetes rollout stalling on a failed readiness probe. The wait is interruptible: a shutdown signal received mid-restart is honored within one healthcheck window.

## Verified live

Driven against a 2-worker server under ~8 concurrent clients:
- **Happy path:** SIGHUP rotated both workers to fresh PIDs; 13k requests, 0 dropped.
- **Abort path:** a replacement that hangs in startup was rejected after the healthcheck timeout; the original workers kept serving; 16k requests, 0 dropped.

## Is it backwards compatible?

Yes for the public API - all changes are internal to `uvicorn.supervisors`. `Process`/`Multiprocess` drop the `target` parameter (each `Process` builds its own `Server` so the pong can read `started`); documented entrypoints (`uvicorn.run`, the CLI) are unaffected. Two behavior changes: a `SIGHUP` restart is slower (it waits per worker for readiness instead of terminating immediately), and a failed restart can leave a mixed old/new fleet since it aborts on the first replacement that never becomes ready.
