### PR TITLE
Remove colorama from the standard extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Moreover, "optional extras" means that:
 
 - the websocket protocol will be handled by `websockets` (should you want to use `wsproto` you'd need to install it manually) if possible.
 - the `--reload` flag in development mode will use `watchfiles`.
-- windows users will have `colorama` installed for the colored logs.
 - `python-dotenv` will be installed should you want to use the `--env-file` option.
 - `PyYAML` will be installed to allow you to provide a `.yaml` file to `--log-config`, if desired.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,11 +60,6 @@ The `standard` extra installs the following dependencies:
 
     When `watchfiles` is installed, Uvicorn will use it by default for the `--reload` option.
 
-- **[`colorama`](https://github.com/tartley/colorama) — Cross-platform support for ANSI terminal
-    colors.**
-
-    This is installed only on Windows, to provide colored logs.
-
 - **[`python-dotenv`](https://github.com/theskumar/python-dotenv) — Reads key-value pairs from a `.env` file
     and adds them to the environment.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
 
 [project.optional-dependencies]
 standard = [
-    "colorama>=0.4; sys_platform == 'win32'",
     "httptools>=0.8.0",
     "python-dotenv>=0.13",
     "PyYAML>=5.1",

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-httptools = "2026-05-26T22:00:00Z"
+httptools = "2026-05-27T00:00:00Z"
 
 [[package]]
 name = "a2wsgi"
@@ -526,7 +526,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -676,7 +676,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.15'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1701,7 +1701,6 @@ dependencies = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "httptools" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -1739,7 +1738,6 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=7.0" },
-    { name = "colorama", marker = "sys_platform == 'win32' and extra == 'standard'", specifier = ">=0.4" },
     { name = "h11", specifier = ">=0.8" },
     { name = "httptools", marker = "extra == 'standard'", specifier = ">=0.8.0" },
     { name = "python-dotenv", marker = "extra == 'standard'", specifier = ">=0.13" },
@@ -1747,7 +1745,7 @@ requires-dist = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0" },
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'", specifier = ">=0.15.1" },
     { name = "watchfiles", marker = "extra == 'standard'", specifier = ">=0.20" },
-    { name = "websockets", marker = "extra == 'standard'", specifier = ">=11.0" },
+    { name = "websockets", marker = "extra == 'standard'", specifier = ">=13.0" },
 ]
 provides-extras = ["standard"]
 


### PR DESCRIPTION
Colorama was never imported or initialized by uvicorn - colored logs are raw ANSI codes from `uvicorn/_ansi.py` written through a plain `logging.StreamHandler`, so colorama never translated them. Click is dropping it as well in 8.5.0 since supported Windows versions enable ANSI terminal styles by default (pallets/click#2986).

Note: colorama still reaches Windows installs transitively via click <= 8.4, and disappears fully once click 8.5 ships.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

