### PR TITLE
Version 0.51.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,12 @@
 toc_depth: 2
 ---
 
+## 0.51.0 (July 8, 2026)
+
+### Added
+
+* Restart workers one at a time on `SIGHUP`, bringing each replacement up before retiring the old worker, so reloads no longer drop requests (#3025)
+
 ## 0.50.2 (July 6, 2026)
 
 ### Fixed

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,6 +8,10 @@ toc_depth: 2
 
 * Restart workers one at a time on `SIGHUP`, bringing each replacement up before retiring the old worker, so reloads no longer drop requests (#3025)
 
+### Removed
+
+* Remove `colorama` from the `standard` extra (#3027)
+
 ## 0.50.2 (July 6, 2026)
 
 ### Fixed

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.50.2"
+__version__ = "0.51.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Release 0.51.0.

### Added

* Restart workers one at a time on `SIGHUP`, bringing each replacement up before retiring the old worker, so reloads no longer drop requests (#3025)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

