### PR TITLE
Recommend the built-in --workers manager over Gunicorn

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -3,7 +3,7 @@ Server deployment is a complex area, that will depend on what kind of service yo
 As a general rule, you probably want to:
 
 * Run `uvicorn --reload` from the command line for local development.
-* Run `gunicorn -k uvicorn.workers.UvicornWorker` for production.
+* Run `uvicorn --workers 4` (or another process manager) for production.
 * Additionally run behind Nginx for self-hosted deployments.
 * Finally, run everything behind a CDN for caching support, and serious DDOS protection.
 
@@ -66,21 +66,20 @@ A process manager will handle the socket setup, start-up multiple server process
 
 ### Built-in
 
-Uvicorn includes a `--workers` option that allows you to run multiple worker processes.
+Uvicorn includes a `--workers` option that runs multiple worker processes under a built-in process manager. This is the recommended way to run Uvicorn in production - it covers the process-management needs of most deployments without an extra dependency.
 
 ```bash
 $ uvicorn main:app --workers 4
 ```
 
-Unlike gunicorn, uvicorn does not use pre-fork, but uses [`spawn`](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods), which allows uvicorn's multiprocess manager to still work well on Windows.
+The manager provides:
 
-The default process manager monitors the status of child processes and automatically restarts child processes that die unexpectedly. Not only that, it will also monitor the status of the child process through the pipeline. When the child process is accidentally stuck, the corresponding child process will be killed through an unstoppable system signal or interface.
-
-You can also manage child processes by sending specific signals to the main process. (Not supported on Windows.)
-
-- `SIGHUP`: Gracefully restart the workers one at a time with no dropped requests. Fresh workers pick up new code on disk.
-- `SIGTTIN`: Increase the number of worker processes by one.
-- `SIGTTOU`: Decrease the number of worker processes by one.
+- **Automatic worker restarts.** Child processes that die unexpectedly are restarted. Workers are health-checked over a pipe, so a worker that becomes stuck (not just one that crashes) is detected and killed; tune the interval with `--timeout-worker-healthcheck`.
+- **Graceful, near-zero-downtime reloads.** On `SIGHUP` the workers are restarted one at a time, each replacement brought into service before the old worker is retired, so no requests are dropped. Fresh workers pick up new code on disk.
+- **Scaling on the fly.** Send `SIGTTIN` to add a worker or `SIGTTOU` to remove one, without restarting the server.
+- **Worker recycling.** Use `--limit-max-requests` (optionally with `--limit-max-requests-jitter`) to recycle workers periodically, guarding against memory leaks in long-running processes.
+- **Fail-fast startup.** If a worker cannot boot (broken app import, TLS, or socket bind), the manager stops rather than restarting a process that would fail the same way every time.
+- **Windows support.** Unlike gunicorn, uvicorn does not use pre-fork but [`spawn`](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods), so the manager works on Windows too. (Signal-based management above is not available on Windows.)
 
 ### Gunicorn
 
@@ -93,7 +92,7 @@ You can also manage child processes by sending specific signals to the main proc
     python -m pip install uvicorn-worker
     ```
 
-Gunicorn is probably the simplest way to run and manage Uvicorn in a production setting. Uvicorn includes a gunicorn worker class that means you can get set up with very little configuration.
+The built-in `--workers` manager above now covers what previously required Gunicorn, so a separate process manager is no longer needed for most deployments. Gunicorn remains a fine choice if you already rely on it or need one of its specific features (for example in-place binary upgrades via `SIGUSR2`). Note that the bundled worker class is deprecated in favor of the [`uvicorn-worker`](https://github.com/Kludex/uvicorn-worker) package.
 
 The following will start Gunicorn with four worker processes:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -177,14 +177,12 @@ if __name__ == "__main__":
 
 [Gunicorn](https://gunicorn.org/) is a mature, fully featured server and process manager.
 
-Uvicorn includes a Gunicorn worker class allowing you to run ASGI applications,
-with all of Uvicorn's performance benefits, while also giving you Gunicorn's
-fully-featured process management.
-
-This allows you to increase or decrease the number of worker processes on the
-fly, restart worker processes gracefully, or perform server upgrades without downtime.
-
-For production deployments we recommend using gunicorn with the uvicorn worker class.
+For production deployments we recommend Uvicorn's [built-in `--workers` process
+manager](deployment/index.md#built-in), which handles scaling workers on the fly
+and graceful, near-zero-downtime restarts without an extra dependency. Gunicorn
+remains a supported option if you already rely on it - Uvicorn includes a Gunicorn
+worker class so you can run ASGI applications with all of Uvicorn's performance
+benefits under Gunicorn's process management.
 
 ```
 gunicorn example:app -w 4 -k uvicorn.workers.UvicornWorker


### PR DESCRIPTION
The deployment docs still headline `gunicorn -k uvicorn.workers.UvicornWorker` as the recommended production setup, which is now both stale and self-contradictory - the bundled Gunicorn worker is already deprecated in favor of [`uvicorn-worker`](https://github.com/Kludex/uvicorn-worker).

Meanwhile the built-in `--workers` manager (`uvicorn/supervisors/multiprocess.py`) has reached parity with what the docs credit Gunicorn for:

- Live scaling via `SIGTTIN` / `SIGTTOU`
- Graceful, near-zero-downtime rolling restarts via `SIGHUP` (overlap restart, #3025)
- Pipe-based health checks that detect *hung* workers, not just crashed ones (`--timeout-worker-healthcheck`)
- Worker recycling via `--limit-max-requests`
- Fail-fast on startup errors (#3001)
- Windows support (`spawn`)

### Changes
- `docs/deployment/index.md`: top-level recommendation now points at `--workers`; the Built-in section is framed as the recommended path with a concrete feature list; the Gunicorn section is demoted to a still-supported option.
- `docs/index.md`: the "Running with Gunicorn" section now recommends the built-in manager first and keeps Gunicorn as a supported alternative.

Docs only. Gunicorn remains documented for those who need it (e.g. `SIGUSR2` in-place binary upgrades).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

