### PR TITLE
Add opt-in --preload flag for a pre-fork worker model

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -75,6 +75,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 ## Production
 
 * `--workers <int>` - Number of worker processes. Defaults to the `$WEB_CONCURRENCY` environment variable if available, or 1. Not valid with `--reload`.
+* `--preload` - Load the application in the parent process and fork workers from it, so they share the loaded app copy-on-write. Reduces memory use and startup time. POSIX only (ignored on Windows). Note that import-time resources (e.g. database connections) are shared across workers, and `SIGHUP` reloads will not pick up new code. **Default:** *False*.
 * `--env-file <path>` - Environment configuration file for the ASGI application. **Default:** *None*.
 * `--timeout-worker-healthcheck <int>` - Maximum number of seconds to wait for a worker to respond to a healthcheck. **Default:** *5*.
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -237,3 +237,24 @@ def test_multiprocess_sigttou() -> None:
     assert len(supervisor.processes) == 1
     supervisor.signal_queue.append(signal.SIGINT)
     supervisor.join_all()
+
+
+def _noop_target(sockets: Any = None) -> None:
+    pass  # pragma: no cover
+
+
+@pytest.mark.skipif(os.name == "nt", reason="fork is not available on Windows")
+def test_get_subprocess_forks_when_preloading() -> None:
+    from uvicorn._subprocess import get_subprocess
+
+    config = Config(app=app, workers=2, preload=True)
+    process = get_subprocess(config, target=_noop_target, sockets=[])
+    assert type(process).__name__ == "ForkProcess"
+
+
+def test_get_subprocess_spawns_by_default() -> None:
+    from uvicorn._subprocess import get_subprocess
+
+    config = Config(app=app, workers=2)
+    process = get_subprocess(config, target=_noop_target, sockets=[])
+    assert type(process).__name__ == "SpawnProcess"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -668,3 +668,25 @@ def test_setup_event_loop_is_removed(caplog: pytest.LogCaptureFixture) -> None:
         AttributeError, match="The `setup_event_loop` method was replaced by `get_loop_factory` in uvicorn 0.36.0."
     ):
         config.setup_event_loop()
+
+
+def test_preload_enables_fork_on_posix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(os, "name", "posix")
+    config = Config(app=asgi_app, workers=2, preload=True)
+    assert config.preload is True
+    assert config.use_fork is True
+
+
+def test_preload_disabled_on_windows(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setattr(os, "name", "nt")
+    with caplog.at_level(logging.WARNING, logger="uvicorn.error"):
+        config = Config(app=asgi_app, workers=2, preload=True)
+    assert config.preload is False
+    assert config.use_fork is False
+    assert any("preload" in record.message for record in caplog.records)
+
+
+def test_no_preload_does_not_fork() -> None:
+    config = Config(app=asgi_app, workers=2)
+    assert config.preload is False
+    assert config.use_fork is False

--- a/uvicorn/_subprocess.py
+++ b/uvicorn/_subprocess.py
@@ -9,20 +9,21 @@ import multiprocessing
 import os
 import sys
 from collections.abc import Callable
-from multiprocessing.context import SpawnProcess
+from multiprocessing.process import BaseProcess
 from socket import socket
 
 from uvicorn.config import Config
 
 multiprocessing.allow_connection_pickling()
 spawn = multiprocessing.get_context("spawn")
+fork = multiprocessing.get_context("fork") if os.name != "nt" else None
 
 
 def get_subprocess(
     config: Config,
     target: Callable[..., None],
     sockets: list[socket],
-) -> SpawnProcess:
+) -> BaseProcess:
     """
     Called in the parent process, to instantiate a new child process instance.
     The child is not yet started at this point.
@@ -32,6 +33,9 @@ def get_subprocess(
                be the `Server.run()` method.
     * sockets - A list of sockets to pass to the server. Sockets are bound once
                 by the parent process, and then passed to the child processes.
+
+    When ``config.use_fork`` is set (preload on POSIX), the child is forked so it
+    inherits the app the parent has already loaded, rather than importing it again.
     """
     # We pass across the stdin fileno, and reopen it in the child process.
     # This is required for some debugging environments.
@@ -48,7 +52,8 @@ def get_subprocess(
         "stdin_fileno": stdin_fileno,
     }
 
-    return spawn.Process(target=subprocess_started, kwargs=kwargs)
+    context = fork if config.use_fork and fork is not None else spawn
+    return context.Process(target=subprocess_started, kwargs=kwargs)
 
 
 def subprocess_started(

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -242,6 +242,7 @@ class Config:
         factory: bool = False,
         h11_max_incomplete_event_size: int | None = None,
         reset_contextvars: bool = False,
+        preload: bool = False,
     ):
         self.app = app
         self.host = host
@@ -291,6 +292,7 @@ class Config:
         self.factory = factory
         self.h11_max_incomplete_event_size = h11_max_incomplete_event_size
         self.reset_contextvars = reset_contextvars
+        self.preload = preload
 
         self.loaded = False
         self.configure_logging()
@@ -359,6 +361,15 @@ class Config:
 
         if self.reload and self.workers > 1:
             logger.warning('"workers" flag is ignored when reloading is enabled.')
+
+        if self.preload and os.name == "nt":  # pragma: py-not-win32
+            logger.warning('"preload" is not supported on Windows and will be ignored.')
+            self.preload = False
+
+    @property
+    def use_fork(self) -> bool:
+        """Whether workers should be forked from a preloaded parent instead of spawned."""
+        return self.preload and os.name != "nt"
 
     @property
     def asgi_version(self) -> Literal["2.0", "3.0"]:

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -116,6 +116,15 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     " variable if available, or 1. Not valid with --reload.",
 )
 @click.option(
+    "--preload",
+    is_flag=True,
+    default=False,
+    help="Load the application in the parent process and fork workers from it (POSIX only)."
+    " Reduces memory use and startup time, but shares import-time resources across workers"
+    " and prevents SIGHUP reloads from picking up new code.",
+    show_default=True,
+)
+@click.option(
     "--loop",
     type=str,
     metavar=_metavar_from_type(LoopFactoryType),
@@ -407,6 +416,7 @@ def main(
     reload_excludes: list[str],
     reload_delay: float,
     workers: int,
+    preload: bool,
     env_file: str,
     log_config: str,
     log_level: str,
@@ -463,6 +473,7 @@ def main(
         reload_excludes=reload_excludes or None,
         reload_delay=reload_delay,
         workers=workers,
+        preload=preload,
         proxy_headers=proxy_headers,
         server_header=server_header,
         date_header=date_header,
@@ -514,6 +525,7 @@ def run(
     reload_excludes: list[str] | str | None = None,
     reload_delay: float = 0.25,
     workers: int | None = None,
+    preload: bool = False,
     env_file: str | os.PathLike[str] | None = None,
     log_config: dict[str, Any] | str | os.PathLike[str] | RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
     log_level: str | int | None = None,
@@ -570,6 +582,7 @@ def run(
         reload_excludes=reload_excludes,
         reload_delay=reload_delay,
         workers=workers,
+        preload=preload,
         env_file=env_file,
         log_config=log_config,
         log_level=log_level,
@@ -615,6 +628,10 @@ def run(
             sock = config.bind_socket()
             ChangeReload(config, target=server.run, sockets=[sock]).run()
         elif config.workers > 1:
+            if config.use_fork:
+                # Preload: load the app once here so forked workers inherit it
+                # copy-on-write instead of importing it in each child.
+                config.load()
             sock = config.bind_socket()
             Multiprocess(config, sockets=[sock]).run()
         else:


### PR DESCRIPTION
**Draft / prototype** for discussion - proof of concept that Uvicorn's built-in `--workers` manager can support a pre-fork model, closing the last real gap vs gunicorn.

### What

Adds an opt-in `--preload` flag (POSIX only). When set:
1. The app is loaded **once in the parent** (`config.load()` before `Multiprocess.run()`).
2. Workers are created with the `fork` start method, so they inherit the loaded app copy-on-write instead of importing it in each child.

Falls back to `spawn` on Windows (with a warning). Default behavior is unchanged.

### Why

Today every worker imports the app independently under `spawn`. Preload + fork gives lower memory (shared read-only pages) and faster worker startup - the main reason people still reach for gunicorn's pre-fork model.

### Verified locally

With an app that prints at import time:

- `--workers 2 --preload` -> app imported **once** (parent); both workers serve.
- `--workers 2` (default) -> app imported **twice** (once per spawned worker).

### Trade-offs (documented, and why it's opt-in)

- **Windows** has no fork -> falls back to spawn.
- **macOS** fork is unsafe with system frameworks (Python already defaults to spawn there); effectively a Linux feature.
- **Import-time resources** (DB connections, sockets, file handles) are inherited by every worker - same footgun as gunicorn `--preload`.
- **`SIGHUP` no longer picks up new code**, since the parent's app is already imported. Rolling restarts still cycle workers, but they run the preloaded code. gunicorn `--preload` has the identical limitation.

### Changes
- `config.py`: `preload` option + `use_fork` property; disables preload on Windows.
- `_subprocess.py`: selects the `fork` context when `use_fork`.
- `main.py`: `--preload` CLI flag; preloads the app in the parent for the workers path.
- Tests for config behavior and fork/spawn context selection; `docs/settings.md` entry.

### Not yet done (draft)
- Deeper docs (deployment guide) - deferred until #3030 lands to avoid conflicts.
- Broader test coverage of the `run()` workers+preload path.
- Decide whether to warn when `--preload` is combined with `--reload` or `--workers 1` (currently a no-op).

Would appreciate a gut check on the approach before polishing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

