### PR TITLE
Prepare compatibility with websockets 17.0.

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 import httpx
 import pytest
 import websockets.exceptions
+from websockets import __version__ as websockets_version
 from websockets.asyncio.client import ClientConnection, connect
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
 from websockets.frames import Opcode
@@ -211,7 +212,14 @@ async def test_headers(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProto
             await self.send({"type": "websocket.accept"})
 
     async def open_connection(url: str):
-        async with connect(url, additional_headers=[("username", "abraão")]):
+        # websockets 17.0 documents that non-ASCII header values must be encoded
+        # with ISO-8859-1. Earlier versions didn't document the behavior but we
+        # can see in the code that it used UTF-8 (accidentally!) This affects
+        # only the websockets.connect() call in the test, not uvicorn itself.
+        username = "abraão"
+        if websockets_version >= "17.0":  # pragma: no cover
+            username = username.encode().decode("latin-1")
+        async with connect(url, additional_headers=[("username", username)]):
             return True
 
     config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote
 
 import websockets
 import websockets.legacy.handshake
+from websockets import __version__ as websockets_version
 from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosed
 from websockets.extensions.base import ServerExtensionFactory
@@ -176,10 +177,19 @@ class WebSocketProtocol(WebSocketServerProtocol):
         for header in request_headers.get_all("Sec-WebSocket-Protocol"):
             subprotocols.extend([token.strip() for token in header.split(",")])
 
-        asgi_headers = [
-            (name.encode("ascii"), value.encode("ascii", errors="surrogateescape"))
-            for name, value in request_headers.raw_items()
-        ]
+        # websockets 17.0 documents that non-ASCII header values are encoded
+        # with ISO-8859-1. Earlier versions didn't document the behavior but
+        # we can see in the code that it used surrogate escape encoding.
+        # Move the pragma: no cover to the else: branch when 17.0 is released.
+        if websockets_version >= "17.0":  # pragma: no cover
+            asgi_headers = [
+                (name.encode("ascii"), value.encode("latin-1")) for name, value in request_headers.raw_items()
+            ]
+        else:
+            asgi_headers = [
+                (name.encode("ascii"), value.encode("ascii", errors="surrogateescape"))
+                for name, value in request_headers.raw_items()
+            ]
         path = unquote(path_portion)
         full_path = self.root_path + path
         full_raw_path = self.root_path.encode("ascii") + path_portion.encode("ascii")

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -11,6 +11,7 @@ from http import HTTPStatus
 from typing import Any, Literal, cast
 from urllib.parse import unquote
 
+from websockets import __version__ as websockets_version
 from websockets.exceptions import InvalidState
 from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFactory
 from websockets.frames import Frame, Opcode
@@ -192,10 +193,17 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             self.transport.close()
             return
 
-        headers = [
-            (key.encode("ascii"), value.encode("ascii", errors="surrogateescape"))
-            for key, value in event.headers.raw_items()
-        ]
+        # websockets 17.0 documents that non-ASCII header values are encoded
+        # with ISO-8859-1. Earlier versions didn't document the behavior but
+        # we can see in the code that it used surrogate escape encoding.
+        # Move the pragma: no cover to the else: branch when 17.0 is released.
+        if websockets_version >= "17.0":  # pragma: no cover
+            headers = [(key.encode("ascii"), value.encode("latin-1")) for key, value in event.headers.raw_items()]
+        else:
+            headers = [
+                (key.encode("ascii"), value.encode("ascii", errors="surrogateescape"))
+                for key, value in event.headers.raw_items()
+            ]
         raw_path, _, query_string = event.path.partition("?")
         subprotocols: list[str] = []
         for header in event.headers.get_all("Sec-WebSocket-Protocol"):


### PR DESCRIPTION
* Convert headers back to the original bytes in handle_connect().
* Ensure consistency across versions in test_headers().

Fix #3035.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

