### PR TITLE
Split standard dependencies into feature-specific extras

### DIFF
--- a/docs/concepts/logging.md
+++ b/docs/concepts/logging.md
@@ -64,7 +64,7 @@ Uvicorn supports three file formats:
 | Extension      | Loader                       | Notes                                       |
 |----------------|------------------------------|---------------------------------------------|
 | `.json`        | `logging.config.dictConfig`  | Standard JSON `dictConfig` schema.          |
-| `.yaml`/`.yml` | `logging.config.dictConfig`  | Requires **PyYAML** (`uvicorn[standard]`).  |
+| `.yaml`/`.yml` | `logging.config.dictConfig`  | Requires **PyYAML** (`uvicorn[yaml]`).  |
 | Any other      | `logging.config.fileConfig`  | Classic INI-style format.                   |
 
 ### YAML Example

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,29 @@ If you are running on Python 3.10 or early versions,
 
 There are many optional dependencies that can be installed to add support for various features.
 
-If you just want to install all of them at once, you can use the `standard` extra:
+Optional dependencies are grouped by feature, so you can install only what you need:
+
+| Extra | Dependencies | Purpose |
+| --- | --- | --- |
+| `development` | `watchfiles` | Improved `--reload` support. |
+| `dotenv` | `python-dotenv` | Support for `--env-file`. |
+| `performance` | `httptools`, `uvloop` | Faster HTTP parsing and event loop, where supported. |
+| `websockets` | `websockets` | WebSocket protocol support. |
+| `yaml` | `PyYAML` | YAML files for `--log-config`. |
+
+For example, to install reload and YAML configuration support:
+
+=== "pip"
+    ```bash
+    pip install 'uvicorn[development,yaml]'
+    ```
+
+=== "uv"
+    ```bash
+    uv add 'uvicorn[development,yaml]'
+    ```
+
+If you want to install all optional dependencies at once, use the `standard` extra:
 
 === "pip"
     ```bash
@@ -36,7 +58,7 @@ If you just want to install all of them at once, you can use the `standard` extr
     uv add 'uvicorn[standard]'
     ```
 
-The `standard` extra installs the following dependencies:
+The `standard` extra combines all of the feature-specific extras and installs the following dependencies:
 
 - **[`uvloop`](https://github.com/MagicStack/uvloop) — Fast, drop-in replacement of the built-in asyncio event loop.**
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -60,7 +60,7 @@ If Uvicorn _cannot_ load [watchfiles](https://pypi.org/project/watchfiles/) at r
 
 ### Reloading with watchfiles
 
-For more nuanced control over which file modifications trigger reloads, install `uvicorn[standard]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Uvicorn can see it.
+For more nuanced control over which file modifications trigger reloads, install `uvicorn[development]`, which includes watchfiles as a dependency. Alternatively, install [watchfiles](https://pypi.org/project/watchfiles/) where Uvicorn can see it.
 
 Using Uvicorn with watchfiles will enable the following options (which are otherwise ignored):
 
@@ -84,7 +84,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 ## Logging
 
 * `--log-config <path>` - Logging configuration file. **Options:** *`dictConfig()` formats: .json, .yaml*. Any other format will be processed with `fileConfig()`. Set the `formatters.default.use_colors` and `formatters.access.use_colors` values to override the auto-detected behavior.
-    * If you wish to use a YAML file for your logging config, you will need to include PyYAML as a dependency for your project or install uvicorn with the `[standard]` optional extras.
+    * If you wish to use a YAML file for your logging config, you will need to include PyYAML as a dependency for your project or install uvicorn with the `[yaml]` optional extra.
 * `--log-level <str>` - Set the log level. **Options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.* **Default:** *'info'*.
 * `--no-access-log` - Disable access log only, without changing log level.
 * `--use-colors / --no-use-colors` - Enable / disable colorized formatting of the log records. If not set, colors will be auto-detected. This option is ignored if the `--log-config` CLI option is used.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,24 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-standard = [
-    "httptools>=0.8.0",
-    "python-dotenv>=0.13",
-    "PyYAML>=5.1",
-    "uvloop>=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
+development = [
     "watchfiles>=0.20",
+]
+dotenv = [
+    "python-dotenv>=0.13",
+]
+performance = [
+    "httptools>=0.8.0",
+    "uvloop>=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
+]
+websockets = [
     "websockets>=13.0",
+]
+yaml = [
+    "PyYAML>=5.1",
+]
+standard = [
+    "uvicorn[development,dotenv,performance,websockets,yaml]",
 ]
 
 [dependency-groups]

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -862,7 +862,7 @@ async def test_unsupported_ws_upgrade_request_warn_on_auto(
     assert b"Hello, world" in protocol.transport.buffer
     warnings = [record.msg for record in filter(lambda record: record.levelname == "WARNING", caplog.records)]
     assert "Unsupported upgrade request." in warnings
-    msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
+    msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[websockets]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
     assert msg in warnings
 
 
@@ -1134,7 +1134,7 @@ async def test_header_upgrade_is_not_websocket_depend_installed(
     protocol.data_received(UPGRADE_REQUEST_ERROR_FIELD)
     await protocol.loop.run_one()
     assert "Unsupported upgrade request." in caplog.text
-    msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
+    msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[websockets]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
     assert msg not in caplog.text
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Hello, world" in protocol.transport.buffer
@@ -1150,7 +1150,7 @@ async def test_header_upgrade_is_websocket_depend_not_installed(
     protocol.data_received(UPGRADE_REQUEST_ERROR_FIELD)
     await protocol.loop.run_one()
     assert "Unsupported upgrade request." in caplog.text
-    msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
+    msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[websockets]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
     assert msg in caplog.text
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Hello, world" in protocol.transport.buffer

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -371,7 +371,7 @@ def test_log_config_yaml_missing_pyyaml(mocked_logging_config_module: MagicMock,
     Test that a helpful error is raised when PyYAML is not installed.
     """
     mocker.patch.dict(sys.modules, {"yaml": None})
-    with pytest.raises(ImportError, match=r"Install the PyYAML package or uvicorn\[standard\]"):
+    with pytest.raises(ImportError, match=r"Install the PyYAML package or uvicorn\[yaml\]"):
         Config(app=asgi_app, log_config="log_config.yaml")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-httptools = "2026-05-26T18:30:00Z"
+httptools = "2026-05-27T00:00:00Z"
 
 [[package]]
 name = "a2wsgi"

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-httptools = "2026-05-27T00:00:00Z"
+httptools = "2026-05-26T18:30:00Z"
 
 [[package]]
 name = "a2wsgi"
@@ -1700,6 +1700,16 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+development = [
+    { name = "watchfiles" },
+]
+dotenv = [
+    { name = "python-dotenv" },
+]
+performance = [
+    { name = "httptools" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+]
 standard = [
     { name = "httptools" },
     { name = "python-dotenv" },
@@ -1707,6 +1717,12 @@ standard = [
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+websockets = [
+    { name = "websockets" },
+]
+yaml = [
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -1739,15 +1755,21 @@ docs = [
 requires-dist = [
     { name = "click", specifier = ">=7.0" },
     { name = "h11", specifier = ">=0.8" },
+    { name = "httptools", marker = "extra == 'performance'", specifier = ">=0.8.0" },
     { name = "httptools", marker = "extra == 'standard'", specifier = ">=0.8.0" },
+    { name = "python-dotenv", marker = "extra == 'dotenv'", specifier = ">=0.13" },
     { name = "python-dotenv", marker = "extra == 'standard'", specifier = ">=0.13" },
     { name = "pyyaml", marker = "extra == 'standard'", specifier = ">=5.1" },
+    { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=5.1" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'performance'", specifier = ">=0.15.1" },
     { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'", specifier = ">=0.15.1" },
+    { name = "watchfiles", marker = "extra == 'development'", specifier = ">=0.20" },
     { name = "watchfiles", marker = "extra == 'standard'", specifier = ">=0.20" },
     { name = "websockets", marker = "extra == 'standard'", specifier = ">=13.0" },
+    { name = "websockets", marker = "extra == 'websockets'", specifier = ">=13.0" },
 ]
-provides-extras = ["standard"]
+provides-extras = ["development", "dotenv", "performance", "standard", "websockets", "yaml"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -398,7 +398,7 @@ class Config:
                     import yaml
                 except ImportError as e:
                     raise ImportError(
-                        "Install the PyYAML package or uvicorn[standard] to use `--log-config` with YAML files."
+                        "Install the PyYAML package or uvicorn[yaml] to use `--log-config` with YAML files."
                     ) from e
 
                 with open(self.log_config) as file:

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -158,7 +158,7 @@ class H11Protocol(asyncio.Protocol):
         msg = "Unsupported upgrade request."
         self.logger.warning(msg)
         if not self._should_upgrade_to_ws():
-            msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
+            msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[websockets]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
             self.logger.warning(msg)
 
     def _should_upgrade(self) -> bool:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -160,7 +160,7 @@ class HttpToolsProtocol(asyncio.Protocol):
     def _unsupported_upgrade_warning(self) -> None:
         self.logger.warning("Unsupported upgrade request.")
         if not self._should_upgrade_to_ws():
-            msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
+            msg = "No supported WebSocket library detected. Please use \"pip install 'uvicorn[websockets]'\", or install 'websockets' or 'wsproto' manually."  # noqa: E501
             self.logger.warning(msg)
 
     def _should_upgrade(self) -> bool:


### PR DESCRIPTION
Closes #2714.

# Summary

- Add focused `development`, `dotenv`, `performance`, `websockets`, and `yaml` extras.
- Keep `standard` as a backwards-compatible umbrella containing every optional dependency.
- Document feature-specific installation and point runtime error messages to the smallest relevant extra.
- Update the lockfile and affected assertions for the new package metadata and guidance.

# Validation

- `uv run pytest -n 0 tests/test_config.py::test_log_config_yaml_missing_pyyaml tests/protocols/test_http.py::test_unsupported_ws_upgrade_request_warn_on_auto tests/protocols/test_http.py::test_header_upgrade_is_not_websocket_depend_installed tests/protocols/test_http.py::test_header_upgrade_is_websocket_depend_not_installed` (7 passed)
- `uv run ruff format --check --diff uvicorn tests`
- `uv run ruff check uvicorn tests`
- `uv build`
- Installed the built wheel with `[development,yaml]` and `[standard]` in clean virtual environments; all expected imports passed.
- `uv run zensical build` (succeeded with three pre-existing unresolved-link warnings)

Full `uv run mypy uvicorn tests` was also attempted on Windows. It reports 20 existing platform-specific errors for Unix-only socket and signal attributes; none are in the changed behavior.

# Checklist

- [x] This change follows the existing issue and discussion.
- [x] I updated affected tests and kept the change atomic.
- [x] I updated the documentation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

