### PR TITLE
Remove duplicate content headers from WebSocket denial responses on websockets-sansio

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -932,6 +932,33 @@ async def test_server_reject_connection_with_non_utf8_body(
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
 
+async def test_server_reject_connection_with_non_standard_status(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    body = b"custom error"
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "websocket"
+        await receive()
+        await send(
+            {
+                "type": "websocket.http.response.start",
+                "status": 599,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "websocket.http.response.body", "body": body})
+
+    async def websocket_session(url: str):
+        response = await wsresponse(url)
+        assert response.status_code == 599
+        assert response.content == body
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -932,33 +932,6 @@ async def test_server_reject_connection_with_non_utf8_body(
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
 
-async def test_server_reject_connection_with_non_standard_status(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
-):
-    body = b"custom error"
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        assert scope["type"] == "websocket"
-        await receive()
-        await send(
-            {
-                "type": "websocket.http.response.start",
-                "status": 599,
-                "headers": [(b"content-type", b"text/plain")],
-            }
-        )
-        await send({"type": "websocket.http.response.body", "body": body})
-
-    async def websocket_session(url: str):
-        response = await wsresponse(url)
-        assert response.status_code == 599
-        assert response.content == body
-
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
-    async with run_server(config):
-        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
-
-
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -879,6 +879,31 @@ async def test_server_reject_connection_with_response(
     assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
 
 
+async def test_server_reject_connection_with_custom_content_headers(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    body = b'{"detail":"Unauthorized"}'
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "websocket"
+        await receive()
+        response = Response(body, status_code=401, media_type="application/json")
+        await response(scope, receive, send)
+
+    async def websocket_session(url: str):
+        with pytest.raises(websockets.exceptions.InvalidStatus) as exc_info:
+            async with connect(url):
+                pass  # pragma: no cover
+        response = exc_info.value.response
+        assert response.body == body
+        assert response.headers.get_all("Content-Length") == [str(len(body))]
+        assert response.headers.get_all("Content-Type") == ["application/json"]
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -905,6 +905,33 @@ async def test_server_reject_connection_with_custom_content_headers(
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
 
+async def test_server_reject_connection_with_non_utf8_body(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    body = b"\x81\xfe\x00\xff invalid utf-8 \xff"
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "websocket"
+        await receive()
+        await send(
+            {
+                "type": "websocket.http.response.start",
+                "status": 400,
+                "headers": [(b"content-type", b"application/octet-stream")],
+            }
+        )
+        await send({"type": "websocket.http.response.body", "body": body})
+
+    async def websocket_session(url: str):
+        response = await wsresponse(url)
+        assert response.status_code == 400
+        assert response.content == body
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -895,6 +895,7 @@ async def test_server_reject_connection_with_custom_content_headers(
             async with connect(url):
                 pass  # pragma: no cover
         response = exc_info.value.response
+        assert response.status_code == 401
         assert response.body == body
         assert response.headers.get_all("Content-Length") == [str(len(body))]
         assert response.headers.get_all("Content-Type") == ["application/json"]

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -904,6 +904,33 @@ async def test_server_reject_connection_with_custom_content_headers(
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
 
+async def test_server_reject_connection_with_non_utf8_body(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    body = b"\x81\xfe\x00\xff invalid utf-8 \xff"
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "websocket"
+        await receive()
+        await send(
+            {
+                "type": "websocket.http.response.start",
+                "status": 400,
+                "headers": [(b"content-type", b"application/octet-stream")],
+            }
+        )
+        await send({"type": "websocket.http.response.body", "body": body})
+
+    async def websocket_session(url: str):
+        response = await wsresponse(url)
+        assert response.status_code == 400
+        assert response.content == body
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
+    async with run_server(config):
+        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
+
+
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -905,33 +905,6 @@ async def test_server_reject_connection_with_custom_content_headers(
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
 
-async def test_server_reject_connection_with_non_utf8_body(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
-):
-    body = b"\x81\xfe\x00\xff invalid utf-8 \xff"
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        assert scope["type"] == "websocket"
-        await receive()
-        await send(
-            {
-                "type": "websocket.http.response.start",
-                "status": 400,
-                "headers": [(b"content-type", b"application/octet-stream")],
-            }
-        )
-        await send({"type": "websocket.http.response.body", "body": body})
-
-    async def websocket_session(url: str):
-        response = await wsresponse(url)
-        assert response.status_code == 400
-        assert response.content == body
-
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
-    async with run_server(config):
-        await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
-
-
 async def test_server_reject_connection_with_multibody_response(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-httptools = "2026-05-26T23:00:00Z"
+httptools = "2026-05-27T00:00:00Z"
 
 [[package]]
 name = "a2wsgi"
@@ -526,7 +526,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -676,7 +676,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.15'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -11,7 +11,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-httptools = "2026-05-27T00:00:00Z"
+httptools = "2026-05-26T23:00:00Z"
 
 [[package]]
 name = "a2wsgi"
@@ -526,7 +526,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -676,7 +676,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import email.utils
 import logging
 import random
 import struct
@@ -12,10 +13,11 @@ from typing import Any, Literal, cast
 from urllib.parse import unquote
 
 from websockets import __version__ as websockets_version
+from websockets.datastructures import Headers
 from websockets.exceptions import InvalidState
 from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFactory
 from websockets.frames import Frame, Opcode
-from websockets.http11 import Request
+from websockets.http11 import Request, Response
 from websockets.server import ServerProtocol
 
 from uvicorn._types import (
@@ -470,11 +472,13 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 body = self.initial_response[2] + message["body"]
                 self.initial_response = self.initial_response[:2] + (body,)
                 if not message.get("more_body", False):
-                    response = self.conn.reject(self.initial_response[0], body.decode())
-                    del response.headers["Content-Type"], response.headers["Content-Length"]
-                    response.headers.update(self.initial_response[1])
-                    response.headers.setdefault("Content-Length", str(len(body)))
-                    response.headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+                    status = HTTPStatus(self.initial_response[0])
+                    response_headers = Headers(self.initial_response[1])
+                    response_headers.setdefault("Date", email.utils.formatdate(usegmt=True))
+                    response_headers.setdefault("Connection", "close")
+                    response_headers.setdefault("Content-Length", str(len(body)))
+                    response_headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+                    response = Response(status.value, status.phrase, response_headers, body)
                     self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                     self.conn.send_response(response)
                     output = self.conn.data_to_send()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import email.utils
 import logging
 import random
 import struct
@@ -12,10 +13,11 @@ from typing import Any, Literal, cast
 from urllib.parse import unquote
 
 from websockets import __version__ as websockets_version
+from websockets.datastructures import Headers
 from websockets.exceptions import InvalidState
 from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFactory
 from websockets.frames import Frame, Opcode
-from websockets.http11 import Request
+from websockets.http11 import Request, Response
 from websockets.server import ServerProtocol
 
 from uvicorn._types import (
@@ -470,10 +472,13 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 body = self.initial_response[2] + message["body"]
                 self.initial_response = self.initial_response[:2] + (body,)
                 if not message.get("more_body", False):
-                    response = self.conn.reject(self.initial_response[0], body.decode())
-                    for name, _ in self.initial_response[1]:
-                        response.headers.pop(name, None)
-                    response.headers.update(self.initial_response[1])
+                    status = HTTPStatus(self.initial_response[0])
+                    response_headers = Headers(self.initial_response[1])
+                    response_headers.setdefault("Date", email.utils.formatdate(usegmt=True))
+                    response_headers.setdefault("Connection", "close")
+                    response_headers.setdefault("Content-Length", str(len(body)))
+                    response_headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+                    response = Response(status.value, status.phrase, response_headers, body)
                     self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                     self.conn.send_response(response)
                     output = self.conn.data_to_send()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -471,6 +471,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 self.initial_response = self.initial_response[:2] + (body,)
                 if not message.get("more_body", False):
                     response = self.conn.reject(self.initial_response[0], body.decode())
+                    for name, _ in self.initial_response[1]:
+                        response.headers.pop(name, None)
                     response.headers.update(self.initial_response[1])
                     self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                     self.conn.send_response(response)

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import email.utils
 import logging
 import random
 import struct
@@ -13,11 +12,10 @@ from typing import Any, Literal, cast
 from urllib.parse import unquote
 
 from websockets import __version__ as websockets_version
-from websockets.datastructures import Headers
 from websockets.exceptions import InvalidState
 from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFactory
 from websockets.frames import Frame, Opcode
-from websockets.http11 import Request, Response
+from websockets.http11 import Request
 from websockets.server import ServerProtocol
 
 from uvicorn._types import (
@@ -472,13 +470,11 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 body = self.initial_response[2] + message["body"]
                 self.initial_response = self.initial_response[:2] + (body,)
                 if not message.get("more_body", False):
-                    status = HTTPStatus(self.initial_response[0])
-                    response_headers = Headers(self.initial_response[1])
-                    response_headers.setdefault("Date", email.utils.formatdate(usegmt=True))
-                    response_headers.setdefault("Connection", "close")
-                    response_headers.setdefault("Content-Length", str(len(body)))
-                    response_headers.setdefault("Content-Type", "text/plain; charset=utf-8")
-                    response = Response(status.value, status.phrase, response_headers, body)
+                    response = self.conn.reject(self.initial_response[0], body.decode())
+                    del response.headers["Content-Type"], response.headers["Content-Length"]
+                    response.headers.update(self.initial_response[1])
+                    response.headers.setdefault("Content-Length", str(len(body)))
+                    response.headers.setdefault("Content-Type", "text/plain; charset=utf-8")
                     self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                     self.conn.send_response(response)
                     output = self.conn.data_to_send()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -43,6 +43,16 @@ else:  # pragma: no cover
     from typing_extensions import assert_never
 
 
+def _get_status_phrase(status_code: int) -> str:
+    try:
+        return HTTPStatus(status_code).phrase
+    except ValueError:
+        return ""
+
+
+STATUS_PHRASES = {status_code: _get_status_phrase(status_code) for status_code in range(100, 600)}
+
+
 class WebSocketsSansIOProtocol(asyncio.Protocol):
     def __init__(
         self,
@@ -472,13 +482,13 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 body = self.initial_response[2] + message["body"]
                 self.initial_response = self.initial_response[:2] + (body,)
                 if not message.get("more_body", False):
-                    status = HTTPStatus(self.initial_response[0])
+                    status_code = self.initial_response[0]
                     response_headers = Headers(self.initial_response[1])
                     response_headers.setdefault("Date", email.utils.formatdate(usegmt=True))
                     response_headers.setdefault("Connection", "close")
                     response_headers.setdefault("Content-Length", str(len(body)))
                     response_headers.setdefault("Content-Type", "text/plain; charset=utf-8")
-                    response = Response(status.value, status.phrase, response_headers, body)
+                    response = Response(status_code, STATUS_PHRASES[status_code], response_headers, body)
                     self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
                     self.conn.send_response(response)
                     output = self.conn.data_to_send()


### PR DESCRIPTION
# Summary

On the `websockets-sansio` implementation, a WebSocket Denial Response was built with `conn.reject()`, which synthesizes its own `Content-Length` and `Content-Type` headers, and the application's headers were then appended with `Headers.update()` — which appends rather than replaces. The result was duplicate `Content-Type`/`Content-Length` headers on the wire, an invalid response that strict clients reject outright.

`conn.reject()` is not a good fit for this path: it only accepts a text body (`body.decode()` raised `UnicodeDecodeError` for valid ASGI byte bodies that aren't UTF-8, dropping the connection without sending the denial response at all) and its synthesized headers have to be undone afterwards. The response is now constructed directly from the application's status, headers, and bytes body, with `Date`, `Connection`, `Content-Length`, and `Content-Type` added via `setdefault` only when the application didn't provide them — matching the behavior of the `websockets` and `wsproto` implementations.

Fixes #3040

## Tests

- `test_server_reject_connection_with_custom_content_headers`: application-provided `Content-Type`/`Content-Length` appear exactly once, across all ws/http protocol combinations.
- `test_server_reject_connection_with_non_utf8_body`: a denial response with a non-UTF-8 body is delivered intact.
