### PR TITLE
Version 0.52.0

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,10 @@ toc_depth: 2
 
 ## 0.52.0 (July 29, 2026)
 
+This release adds an experimental HTTP/1.1 implementation backed by [zttp](https://zttp.marcelotryle.com/), a sans-IO HTTP parser I've been developing on the side: a core written in Zig, with bindings to Python. It has been running under a fuzzer for some weeks now, and has been through multiple rounds of security auditing.
+
+It is still **experimental**, so don't put it in front of production traffic yet. Try it with `--http zttp`, and please send any feedback to the [issue tracker](https://github.com/Kludex/uvicorn/issues).
+
 ### Added
 
 * Add an experimental `zttp` HTTP/1.1 implementation, selectable with `--http zttp` (#2979)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,16 @@
 toc_depth: 2
 ---
 
+## 0.52.0 (July 29, 2026)
+
+### Added
+
+* Add an experimental `zttp` HTTP/1.1 implementation, selectable with `--http zttp` (#2979)
+
+### Fixed
+
+* Keep non-ASCII WebSocket request headers intact with websockets 17.0, which encodes them with ISO-8859-1 (#3036)
+
 ## 0.51.0 (July 8, 2026)
 
 ### Added

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
Release 0.52.0.

This release adds an experimental HTTP/1.1 implementation backed by [zttp](https://zttp.marcelotryle.com/), a sans-IO HTTP parser I've been developing on the side: a core written in Zig, with bindings to Python. It has been running under a fuzzer for some weeks now, and has been through multiple rounds of security auditing.

It is still **experimental**, so don't put it in front of production traffic yet. Try it with `--http zttp`, and please send any feedback to the [issue tracker](https://github.com/Kludex/uvicorn/issues).

### Added

* Add an experimental `zttp` HTTP/1.1 implementation, selectable with `--http zttp` (#2979)

### Fixed

* Keep non-ASCII WebSocket request headers intact with websockets 17.0, which encodes them with ISO-8859-1 (#3036)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an experimental HTTP/1.1 implementation, selectable with `--http zttp`.
  - Released version 0.52.0.

- **Bug Fixes**
  - Fixed preservation of non-ASCII WebSocket request headers by using ISO-8859-1 encoding with websockets 17.0.

- **Documentation**
  - Added release notes describing the new HTTP option and WebSocket header fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->