### PR TITLE
Add missing write flow control to `websockets-sansio`

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1388,39 +1388,32 @@ async def test_server_keepalive_ping_timeout(
             assert exc_info.value.rcvd.reason == "keepalive ping timeout"
 
 
+class MockWriteTransport:
+    """Minimal transport for driving a websocket protocol's write path in-process."""
+
+    def __init__(self) -> None:
+        self.buffer = b""
+        self.closed = False
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
+
+    def write(self, data: bytes) -> None:
+        self.buffer += data
+
+    def close(self) -> None:
+        self.closed = True
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+
 async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that `send()` blocks while the transport's write buffer is full.
 
     Without backpressure, a server-initiated close can outrun in-flight data.
     See https://github.com/Kludex/uvicorn/issues/3047.
     """
-
-    class MockTransport:
-        def __init__(self) -> None:
-            self.buffer = b""
-            self.closed = False
-
-        def get_extra_info(self, name: str, default: Any = None) -> Any:
-            return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
-
-        def write(self, data: bytes) -> None:
-            self.buffer += data
-
-        def close(self) -> None:
-            self.closed = True
-
-        def is_closing(self) -> bool:
-            return self.closed
-
-        def pause_reading(self) -> None:
-            pass
-
-        def resume_reading(self) -> None:
-            pass
-
-        def set_write_buffer_limits(self, high: int | None = None, low: int | None = None) -> None:
-            pass
-
     handshake = (
         b"GET / HTTP/1.1\r\n"
         b"Host: 127.0.0.1\r\n"
@@ -1445,7 +1438,7 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
     config.load()
     protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
-    transport = MockTransport()
+    transport = MockWriteTransport()
     protocol.connection_made(transport)  # type: ignore[arg-type]
     protocol.data_received(handshake)
     await accepted.wait()
@@ -1473,33 +1466,6 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
     asyncio never calls resume_writing() on a transport that is lost while paused, so
     connection_lost() must wake pending senders or the ASGI task leaks forever.
     """
-
-    class MockTransport:
-        def __init__(self) -> None:
-            self.buffer = b""
-            self.closed = False
-
-        def get_extra_info(self, name: str, default: Any = None) -> Any:
-            return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
-
-        def write(self, data: bytes) -> None:
-            self.buffer += data
-
-        def close(self) -> None:
-            self.closed = True
-
-        def is_closing(self) -> bool:
-            return self.closed
-
-        def pause_reading(self) -> None:
-            pass
-
-        def resume_reading(self) -> None:
-            pass
-
-        def set_write_buffer_limits(self, high: int | None = None, low: int | None = None) -> None:
-            pass
-
     handshake = (
         b"GET / HTTP/1.1\r\n"
         b"Host: 127.0.0.1\r\n"
@@ -1526,7 +1492,7 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
     config.load()
     protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
-    transport = MockTransport()
+    transport = MockWriteTransport()
     protocol.connection_made(transport)  # type: ignore[arg-type]
     protocol.data_received(handshake)
     await accepted.wait()

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1397,8 +1397,6 @@ WS_HANDSHAKE_REQUEST = (
     b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
     b"Sec-WebSocket-Version: 13\r\n\r\n"
 )
-CLIENT_CLOSE_FRAME = b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # masked close, code 1000
-CLIENT_TEXT_FRAME = b"\x81\x81\x00\x00\x00\x00x"  # masked text frame, payload "x"
 
 
 class MockWriteTransport:
@@ -1407,7 +1405,6 @@ class MockWriteTransport:
     def __init__(self) -> None:
         self.buffer = b""
         self.closed = False
-        self.reading_paused = False
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:
         return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
@@ -1420,12 +1417,6 @@ class MockWriteTransport:
 
     def is_closing(self) -> bool:
         return self.closed
-
-    def pause_reading(self) -> None:
-        self.reading_paused = True
-
-    def resume_reading(self) -> None:
-        self.reading_paused = False
 
 
 def connected_ws_protocol(
@@ -1462,7 +1453,6 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
-    # The transport reports a full write buffer: send() must block.
     protocol.pause_writing()
     close_requested.set()
     # Yield repeatedly so the app task can progress through send() and (wrongly) complete the close if unblocked.
@@ -1471,139 +1461,15 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     assert not close_sent.is_set()
     assert not transport.closed
 
-    # The buffer drained: the pending close goes through.
     protocol.resume_writing()
     await close_sent.wait()
-
-    protocol.data_received(CLIENT_CLOSE_FRAME)
     assert transport.closed
 
     protocol.connection_lost(None)
 
 
-async def test_close_waits_for_client_close_reply(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
-    """Test that a server-initiated close keeps the transport open until the client replies.
-
-    Closing it right away makes the client's reply (RFC 6455 5.5.1) land on a closed
-    socket, which the kernel answers with a TCP RST that discards data the client has
-    not read yet. See https://github.com/Kludex/uvicorn/issues/3047.
-    """
-    accepted = asyncio.Event()
-    app_finished = asyncio.Event()
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        await receive()  # websocket.connect
-        await send({"type": "websocket.accept"})
-        accepted.set()
-        await send({"type": "websocket.send", "text": "x"})
-        await send({"type": "websocket.close", "code": 1000})
-        app_finished.set()
-
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
-    await app_finished.wait()
-    # The app is done, but the closing handshake is not: even run_asgi must leave it open.
-    for _ in range(10):
-        await asyncio.sleep(0)
-    assert not transport.closed
-
-    protocol.data_received(CLIENT_CLOSE_FRAME)
-    assert transport.closed
-
-    protocol.connection_lost(None)
-
-
-async def test_close_gives_up_when_client_never_replies(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
-    """Test that a client that never echoes the close frame cannot keep the connection.
-
-    RFC 6455 7.1.1 lets the server close the connection once the reply is late.
-    """
-    accepted = asyncio.Event()
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        await receive()  # websocket.connect
-        await send({"type": "websocket.accept"})
-        accepted.set()
-        await send({"type": "websocket.close", "code": 1000})
-
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
-    for _ in range(10):
-        await asyncio.sleep(0)
-    assert not transport.closed
-    assert protocol.close_timer is not None
-
-    protocol.close_transport()  # the close timeout expires
-    assert transport.closed
-    assert protocol.close_timer is None
-
-    protocol.connection_lost(None)
-
-
-async def test_close_resumes_paused_reads(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
-    """Test that waiting for the client's close reply resumes paused reads.
-
-    Reads stay paused until the app consumes a message, so an app that closes without
-    consuming one would otherwise never see the close reply it is waiting for.
-    """
-    accepted = asyncio.Event()
-    message_queued = asyncio.Event()
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        await receive()  # websocket.connect
-        await send({"type": "websocket.accept"})
-        accepted.set()
-        await message_queued.wait()
-        # Close without consuming the queued message, leaving reads paused.
-        await send({"type": "websocket.close", "code": 1000})
-
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
-
-    protocol.data_received(CLIENT_TEXT_FRAME)
-    assert transport.reading_paused
-    message_queued.set()
-    for _ in range(10):
-        await asyncio.sleep(0)
-    assert not transport.reading_paused
-
-    protocol.data_received(CLIENT_CLOSE_FRAME)
-    assert transport.closed
-
-    protocol.connection_lost(None)
-
-
-async def test_connection_lost_cancels_pending_close_timer(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
-):
-    """Test that losing the connection stops waiting for the client's close reply.
-
-    The reply can no longer arrive, so the pending timer must not outlive the connection.
-    """
-    accepted = asyncio.Event()
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        await receive()  # websocket.connect
-        await send({"type": "websocket.accept"})
-        accepted.set()
-        await send({"type": "websocket.close", "code": 1000})
-
-    protocol, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
-    for _ in range(10):
-        await asyncio.sleep(0)
-    assert protocol.close_timer is not None
-
-    protocol.connection_lost(None)
-    assert protocol.close_timer is None
-
-
-async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
-    """Test that a send() blocked on backpressure is released when the connection is lost.
-
-    asyncio never calls resume_writing() on a transport that is lost while paused, so
-    connection_lost() must wake pending senders or the ASGI task leaks forever.
-    """
+async def test_sansio_connection_lost_unblocks_paused_send(http_protocol_cls: HTTPProtocol):
+    """Test that connection loss releases a sansio send blocked on backpressure."""
     accepted = asyncio.Event()
     send_requested = asyncio.Event()
     app_finished = asyncio.Event()
@@ -1618,18 +1484,17 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
         finally:
             app_finished.set()
 
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol, _ = connected_ws_protocol(app, WebSocketsSansIOProtocol, http_protocol_cls)
     await accepted.wait()
 
-    # The write buffer fills up, then the client aborts while send() is blocked.
     protocol.pause_writing()
     send_requested.set()
     # Yield repeatedly so the app task reaches the blocking wait inside send().
     for _ in range(10):
         await asyncio.sleep(0)
     assert not app_finished.is_set()
-    protocol.connection_lost(None)
 
+    protocol.connection_lost(None)
     await asyncio.wait_for(app_finished.wait(), timeout=1)
 
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -28,6 +28,7 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.protocols.websockets.websockets_sansio_impl import WebSocketsSansIOProtocol
+from uvicorn.server import ServerState
 
 try:
     from uvicorn.protocols.websockets.wsproto_impl import WSProtocol as _WSProtocol
@@ -1385,6 +1386,161 @@ async def test_server_keepalive_ping_timeout(
             assert exc_info.value.rcvd is not None
             assert exc_info.value.rcvd.code == 1011
             assert exc_info.value.rcvd.reason == "keepalive ping timeout"
+
+
+async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that `send()` blocks while the transport's write buffer is full.
+
+    Without backpressure, a server-initiated close can outrun in-flight data.
+    See https://github.com/Kludex/uvicorn/issues/3047.
+    """
+
+    class MockTransport:
+        def __init__(self) -> None:
+            self.buffer = b""
+            self.closed = False
+
+        def get_extra_info(self, name: str, default: Any = None) -> Any:
+            return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
+
+        def write(self, data: bytes) -> None:
+            self.buffer += data
+
+        def close(self) -> None:
+            self.closed = True
+
+        def is_closing(self) -> bool:
+            return self.closed
+
+        def pause_reading(self) -> None:
+            pass
+
+        def resume_reading(self) -> None:
+            pass
+
+        def set_write_buffer_limits(self, high: int | None = None, low: int | None = None) -> None:
+            pass
+
+    handshake = (
+        b"GET / HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Connection: Upgrade\r\n"
+        b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        b"Sec-WebSocket-Version: 13\r\n\r\n"
+    )
+
+    accepted = asyncio.Event()
+    close_requested = asyncio.Event()
+    close_sent = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await close_requested.wait()
+        await send({"type": "websocket.close", "code": 1000})
+        close_sent.set()
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config.load()
+    protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
+    transport = MockTransport()
+    protocol.connection_made(transport)  # type: ignore[arg-type]
+    protocol.data_received(handshake)
+    await accepted.wait()
+
+    # The transport reports a full write buffer: send() must block.
+    protocol.pause_writing()
+    close_requested.set()
+    # Yield repeatedly so the app task can progress through send() and (wrongly) complete the close if unblocked.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not close_sent.is_set()
+    assert not transport.closed
+
+    # The buffer drained: the pending close goes through.
+    protocol.resume_writing()
+    await close_sent.wait()
+    assert transport.closed
+
+    protocol.connection_lost(None)
+
+
+async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that a send() blocked on backpressure is released when the connection is lost.
+
+    asyncio never calls resume_writing() on a transport that is lost while paused, so
+    connection_lost() must wake pending senders or the ASGI task leaks forever.
+    """
+
+    class MockTransport:
+        def __init__(self) -> None:
+            self.buffer = b""
+            self.closed = False
+
+        def get_extra_info(self, name: str, default: Any = None) -> Any:
+            return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
+
+        def write(self, data: bytes) -> None:
+            self.buffer += data
+
+        def close(self) -> None:
+            self.closed = True
+
+        def is_closing(self) -> bool:
+            return self.closed
+
+        def pause_reading(self) -> None:
+            pass
+
+        def resume_reading(self) -> None:
+            pass
+
+        def set_write_buffer_limits(self, high: int | None = None, low: int | None = None) -> None:
+            pass
+
+    handshake = (
+        b"GET / HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Connection: Upgrade\r\n"
+        b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        b"Sec-WebSocket-Version: 13\r\n\r\n"
+    )
+
+    accepted = asyncio.Event()
+    send_requested = asyncio.Event()
+    app_finished = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await send_requested.wait()
+        try:
+            await send({"type": "websocket.send", "text": "x"})
+        finally:
+            app_finished.set()
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config.load()
+    protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
+    transport = MockTransport()
+    protocol.connection_made(transport)  # type: ignore[arg-type]
+    protocol.data_received(handshake)
+    await accepted.wait()
+
+    # The write buffer fills up, then the client aborts while send() is blocked.
+    protocol.pause_writing()
+    send_requested.set()
+    # Yield repeatedly so the app task reaches the blocking wait inside send().
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not app_finished.is_set()
+    protocol.connection_lost(None)
+
+    await asyncio.wait_for(app_finished.wait(), timeout=1)
 
 
 async def test_server_keepalive_disabled(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -16,6 +16,7 @@ from websockets.typing import Subprotocol
 from tests.response import Response
 from tests.utils import run_server
 from uvicorn._types import (
+    ASGIApplication,
     ASGIReceiveCallable,
     ASGIReceiveEvent,
     ASGISendCallable,
@@ -1388,12 +1389,25 @@ async def test_server_keepalive_ping_timeout(
             assert exc_info.value.rcvd.reason == "keepalive ping timeout"
 
 
+WS_HANDSHAKE_REQUEST = (
+    b"GET / HTTP/1.1\r\n"
+    b"Host: 127.0.0.1\r\n"
+    b"Upgrade: websocket\r\n"
+    b"Connection: Upgrade\r\n"
+    b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+    b"Sec-WebSocket-Version: 13\r\n\r\n"
+)
+CLIENT_CLOSE_FRAME = b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # masked close, code 1000
+CLIENT_TEXT_FRAME = b"\x81\x81\x00\x00\x00\x00x"  # masked text frame, payload "x"
+
+
 class MockWriteTransport:
     """Minimal transport for driving a websocket protocol's write path in-process."""
 
     def __init__(self) -> None:
         self.buffer = b""
         self.closed = False
+        self.reading_paused = False
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:
         return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
@@ -1407,6 +1421,25 @@ class MockWriteTransport:
     def is_closing(self) -> bool:
         return self.closed
 
+    def pause_reading(self) -> None:
+        self.reading_paused = True
+
+    def resume_reading(self) -> None:
+        self.reading_paused = False
+
+
+def connected_ws_protocol(
+    app: ASGIApplication, ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
+) -> tuple[Any, MockWriteTransport]:
+    """Return a websocket protocol driven by a mock transport, past the handshake."""
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+    config.load()
+    protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
+    transport = MockWriteTransport()
+    protocol.connection_made(transport)  # type: ignore[arg-type]
+    protocol.data_received(WS_HANDSHAKE_REQUEST)
+    return protocol, transport
+
 
 async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that `send()` blocks while the transport's write buffer is full.
@@ -1414,15 +1447,6 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     Without backpressure, a server-initiated close can outrun in-flight data.
     See https://github.com/Kludex/uvicorn/issues/3047.
     """
-    handshake = (
-        b"GET / HTTP/1.1\r\n"
-        b"Host: 127.0.0.1\r\n"
-        b"Upgrade: websocket\r\n"
-        b"Connection: Upgrade\r\n"
-        b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-        b"Sec-WebSocket-Version: 13\r\n\r\n"
-    )
-
     accepted = asyncio.Event()
     close_requested = asyncio.Event()
     close_sent = asyncio.Event()
@@ -1435,12 +1459,7 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
-    config.load()
-    protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
-    transport = MockWriteTransport()
-    protocol.connection_made(transport)  # type: ignore[arg-type]
-    protocol.data_received(handshake)
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
     # The transport reports a full write buffer: send() must block.
@@ -1455,9 +1474,128 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     # The buffer drained: the pending close goes through.
     protocol.resume_writing()
     await close_sent.wait()
+
+    protocol.data_received(CLIENT_CLOSE_FRAME)
     assert transport.closed
 
     protocol.connection_lost(None)
+
+
+async def test_close_waits_for_client_close_reply(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that a server-initiated close keeps the transport open until the client replies.
+
+    Closing it right away makes the client's reply (RFC 6455 5.5.1) land on a closed
+    socket, which the kernel answers with a TCP RST that discards data the client has
+    not read yet. See https://github.com/Kludex/uvicorn/issues/3047.
+    """
+    accepted = asyncio.Event()
+    app_finished = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await send({"type": "websocket.send", "text": "x"})
+        await send({"type": "websocket.close", "code": 1000})
+        app_finished.set()
+
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    await accepted.wait()
+    await app_finished.wait()
+    # The app is done, but the closing handshake is not: even run_asgi must leave it open.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not transport.closed
+
+    protocol.data_received(CLIENT_CLOSE_FRAME)
+    assert transport.closed
+
+    protocol.connection_lost(None)
+
+
+async def test_close_gives_up_when_client_never_replies(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that a client that never echoes the close frame cannot keep the connection.
+
+    RFC 6455 7.1.1 lets the server close the connection once the reply is late.
+    """
+    accepted = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await send({"type": "websocket.close", "code": 1000})
+
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    await accepted.wait()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not transport.closed
+    assert protocol.close_timer is not None
+
+    protocol.close_transport()  # the close timeout expires
+    assert transport.closed
+    assert protocol.close_timer is None
+
+    protocol.connection_lost(None)
+
+
+async def test_close_resumes_paused_reads(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that waiting for the client's close reply resumes paused reads.
+
+    Reads stay paused until the app consumes a message, so an app that closes without
+    consuming one would otherwise never see the close reply it is waiting for.
+    """
+    accepted = asyncio.Event()
+    message_queued = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await message_queued.wait()
+        # Close without consuming the queued message, leaving reads paused.
+        await send({"type": "websocket.close", "code": 1000})
+
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    await accepted.wait()
+
+    protocol.data_received(CLIENT_TEXT_FRAME)
+    assert transport.reading_paused
+    message_queued.set()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not transport.reading_paused
+
+    protocol.data_received(CLIENT_CLOSE_FRAME)
+    assert transport.closed
+
+    protocol.connection_lost(None)
+
+
+async def test_connection_lost_cancels_pending_close_timer(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
+):
+    """Test that losing the connection stops waiting for the client's close reply.
+
+    The reply can no longer arrive, so the pending timer must not outlive the connection.
+    """
+    accepted = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await send({"type": "websocket.close", "code": 1000})
+
+    protocol, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    await accepted.wait()
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert protocol.close_timer is not None
+
+    protocol.connection_lost(None)
+    assert protocol.close_timer is None
 
 
 async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1466,15 +1604,6 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
     asyncio never calls resume_writing() on a transport that is lost while paused, so
     connection_lost() must wake pending senders or the ASGI task leaks forever.
     """
-    handshake = (
-        b"GET / HTTP/1.1\r\n"
-        b"Host: 127.0.0.1\r\n"
-        b"Upgrade: websocket\r\n"
-        b"Connection: Upgrade\r\n"
-        b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-        b"Sec-WebSocket-Version: 13\r\n\r\n"
-    )
-
     accepted = asyncio.Event()
     send_requested = asyncio.Event()
     app_finished = asyncio.Event()
@@ -1489,12 +1618,7 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
         finally:
             app_finished.set()
 
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
-    config.load()
-    protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
-    transport = MockWriteTransport()
-    protocol.connection_made(transport)  # type: ignore[arg-type]
-    protocol.data_received(handshake)
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
     # The write buffer fills up, then the client aborts while send() is blocked.

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -134,11 +134,26 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
         self.handshake_complete = True
+        # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
+        # transport that is lost while paused, and the buffer will never drain now.
+        self.writable.set()
         if exc is None:
             self.transport.close()
 
     def eof_received(self) -> None:
         pass
+
+    def pause_writing(self) -> None:
+        """
+        Called by the transport when the write buffer exceeds the high water mark.
+        """
+        self.writable.clear()  # pragma: full coverage
+
+    def resume_writing(self) -> None:
+        """
+        Called by the transport when the write buffer drops below the low water mark.
+        """
+        self.writable.set()  # pragma: full coverage
 
     def shutdown(self) -> None:
         self.stop_keepalive()

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -76,10 +76,6 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.handshake_initiated = False
         self.handshake_complete = False
         self.close_sent = False
-        # Pending deferred transport close, while we wait for the peer's close reply.
-        self.close_timer: TimerHandle | None = None
-        # Matches the default close_timeout of the websockets library.
-        self.close_timeout = 10.0
         self.initial_response: tuple[int, list[tuple[str, str]], bytes] | None = None
 
         extensions = []
@@ -141,9 +137,6 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
         # transport that is lost while paused, and the buffer will never drain now.
         self.writable.set()
-        if self.close_timer is not None:
-            self.close_timer.cancel()
-            self.close_timer = None
         if exc is None:
             self.transport.close()
 
@@ -351,12 +344,6 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.transport.close()
 
     def handle_close(self, event: Frame) -> None:
-        if self.close_timer is not None:
-            # Our close frame has been echoed: the closing handshake is complete.
-            self.close_timer.cancel()
-            self.close_timer = None
-            self.transport.close()
-            return
         if not self.close_sent and not self.transport.is_closing():
             assert self.conn.close_rcvd is not None
             code = self.conn.close_rcvd.code
@@ -366,26 +353,6 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             output = self.conn.data_to_send()
             self.transport.write(b"".join(output))
             self.transport.close()
-
-    def defer_close(self) -> None:
-        """Close the transport once the peer echoes our close frame, or on timeout.
-
-        RFC 6455 §5.5.1 requires the peer to echo our close frame. Closing the transport
-        right away makes that reply land on a closed socket, which the kernel answers
-        with a TCP RST, discarding whatever the peer had not read yet. §7.1.1 allows us
-        to close first once the reply is late, hence the timeout.
-        """
-        # Reads may be paused waiting for the app to consume a message; the close reply
-        # would then never be read, so resume them for the duration of the handshake.
-        if self.read_paused:
-            self.read_paused = False
-            self.transport.resume_reading()
-        self.close_timer = self.loop.call_later(self.close_timeout, self.close_transport)
-
-    def close_transport(self) -> None:
-        # The peer never echoed our close frame; stop waiting for it.
-        self.close_timer = None
-        self.transport.close()
 
     def handle_parser_exception(self) -> None:  # pragma: no cover
         assert self.conn.close_sent is not None
@@ -415,9 +382,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 self.send_500_response()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-        if self.close_timer is None:
-            # Leave the transport open while the closing handshake is pending.
-            self.transport.close()
+        self.transport.close()
 
     def send_500_response(self) -> None:
         if self.initial_response or self.handshake_complete:
@@ -508,7 +473,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                         output = self.conn.data_to_send()
                         self.transport.write(b"".join(output))
                         self.close_sent = True
-                        self.defer_close()
+                        self.transport.close()
                 else:
                     raise RuntimeError(
                         f"Expected ASGI message 'websocket.send' or 'websocket.close', but got '{message['type']}'."

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -76,6 +76,10 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.handshake_initiated = False
         self.handshake_complete = False
         self.close_sent = False
+        # Pending deferred transport close, while we wait for the peer's close reply.
+        self.close_timer: TimerHandle | None = None
+        # Matches the default close_timeout of the websockets library.
+        self.close_timeout = 10.0
         self.initial_response: tuple[int, list[tuple[str, str]], bytes] | None = None
 
         extensions = []
@@ -137,6 +141,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
         # transport that is lost while paused, and the buffer will never drain now.
         self.writable.set()
+        if self.close_timer is not None:
+            self.close_timer.cancel()
+            self.close_timer = None
         if exc is None:
             self.transport.close()
 
@@ -344,6 +351,12 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.transport.close()
 
     def handle_close(self, event: Frame) -> None:
+        if self.close_timer is not None:
+            # Our close frame has been echoed: the closing handshake is complete.
+            self.close_timer.cancel()
+            self.close_timer = None
+            self.transport.close()
+            return
         if not self.close_sent and not self.transport.is_closing():
             assert self.conn.close_rcvd is not None
             code = self.conn.close_rcvd.code
@@ -353,6 +366,26 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             output = self.conn.data_to_send()
             self.transport.write(b"".join(output))
             self.transport.close()
+
+    def defer_close(self) -> None:
+        """Close the transport once the peer echoes our close frame, or on timeout.
+
+        RFC 6455 §5.5.1 requires the peer to echo our close frame. Closing the transport
+        right away makes that reply land on a closed socket, which the kernel answers
+        with a TCP RST, discarding whatever the peer had not read yet. §7.1.1 allows us
+        to close first once the reply is late, hence the timeout.
+        """
+        # Reads may be paused waiting for the app to consume a message; the close reply
+        # would then never be read, so resume them for the duration of the handshake.
+        if self.read_paused:
+            self.read_paused = False
+            self.transport.resume_reading()
+        self.close_timer = self.loop.call_later(self.close_timeout, self.close_transport)
+
+    def close_transport(self) -> None:
+        # The peer never echoed our close frame; stop waiting for it.
+        self.close_timer = None
+        self.transport.close()
 
     def handle_parser_exception(self) -> None:  # pragma: no cover
         assert self.conn.close_sent is not None
@@ -382,7 +415,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 self.send_500_response()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-        self.transport.close()
+        if self.close_timer is None:
+            # Leave the transport open while the closing handshake is pending.
+            self.transport.close()
 
     def send_500_response(self) -> None:
         if self.initial_response or self.handshake_complete:
@@ -473,7 +508,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                         output = self.conn.data_to_send()
                         self.transport.write(b"".join(output))
                         self.close_sent = True
-                        self.transport.close()
+                        self.defer_close()
                 else:
                     raise RuntimeError(
                         f"Expected ASGI message 'websocket.send' or 'websocket.close', but got '{message['type']}'."

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -99,6 +99,10 @@ class WSProtocol(asyncio.Protocol):
         self.queue: asyncio.Queue[WebSocketEvent] = asyncio.Queue()
         self.handshake_complete = False
         self.close_sent = False
+        # Pending deferred transport close, while we wait for the peer's close reply.
+        self.close_timer: TimerHandle | None = None
+        # Matches the default close_timeout of the websockets library.
+        self.close_timeout = 10.0
 
         # Rejection state
         self.response_started = False
@@ -148,6 +152,9 @@ class WSProtocol(asyncio.Protocol):
         # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
         # transport that is lost while paused, and the buffer will never drain now.
         self.writable.set()
+        if self.close_timer is not None:
+            self.close_timer.cancel()
+            self.close_timer = None
         if exc is None:
             self.transport.close()
 
@@ -171,6 +178,9 @@ class WSProtocol(asyncio.Protocol):
     def handle_events(self) -> None:
         for event in self.conn.events():
             if self.close_sent:
+                # We already closed; the peer's close frame completes the handshake.
+                if isinstance(event, events.CloseConnection):
+                    self.complete_closing_handshake()
                 return
             if isinstance(event, events.Request):
                 self.handle_connect(event)
@@ -350,7 +360,9 @@ class WSProtocol(asyncio.Protocol):
                 self.send_500_response()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-        self.transport.close()
+        if self.close_timer is None:
+            # Leave the transport open while the closing handshake is pending.
+            self.transport.close()
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
@@ -438,7 +450,7 @@ class WSProtocol(asyncio.Protocol):
                     output = self.conn.send(wsproto.events.CloseConnection(code=code, reason=reason))
                     if not self.transport.is_closing():
                         self.transport.write(output)
-                        self.transport.close()
+                        self.defer_close()
 
                 else:
                     raise RuntimeError(
@@ -463,6 +475,32 @@ class WSProtocol(asyncio.Protocol):
 
         else:
             raise RuntimeError(f"Unexpected ASGI message '{message['type']}', after sending 'websocket.close'.")
+
+    def defer_close(self) -> None:
+        """Close the transport once the peer echoes our close frame, or on timeout.
+
+        RFC 6455 §5.5.1 requires the peer to echo our close frame. Closing the transport
+        right away makes that reply land on a closed socket, which the kernel answers
+        with a TCP RST, discarding whatever the peer had not read yet. §7.1.1 allows us
+        to close first once the reply is late, hence the timeout.
+        """
+        # Reads may be paused waiting for the app to consume a message; the close reply
+        # would then never be read, so resume them for the duration of the handshake.
+        if self.read_paused:
+            self.read_paused = False
+            self.transport.resume_reading()
+        self.close_timer = self.loop.call_later(self.close_timeout, self.close_transport)
+
+    def complete_closing_handshake(self) -> None:
+        if self.close_timer is not None:
+            self.close_timer.cancel()
+            self.close_timer = None
+            self.transport.close()
+
+    def close_transport(self) -> None:
+        # The peer never echoed our close frame; stop waiting for it.
+        self.close_timer = None
+        self.transport.close()
 
     async def receive(self) -> WebSocketEvent:
         message = await self.queue.get()

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -99,10 +99,6 @@ class WSProtocol(asyncio.Protocol):
         self.queue: asyncio.Queue[WebSocketEvent] = asyncio.Queue()
         self.handshake_complete = False
         self.close_sent = False
-        # Pending deferred transport close, while we wait for the peer's close reply.
-        self.close_timer: TimerHandle | None = None
-        # Matches the default close_timeout of the websockets library.
-        self.close_timeout = 10.0
 
         # Rejection state
         self.response_started = False
@@ -149,12 +145,6 @@ class WSProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
         self.handshake_complete = True
-        # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
-        # transport that is lost while paused, and the buffer will never drain now.
-        self.writable.set()
-        if self.close_timer is not None:
-            self.close_timer.cancel()
-            self.close_timer = None
         if exc is None:
             self.transport.close()
 
@@ -178,9 +168,6 @@ class WSProtocol(asyncio.Protocol):
     def handle_events(self) -> None:
         for event in self.conn.events():
             if self.close_sent:
-                # We already closed; the peer's close frame completes the handshake.
-                if isinstance(event, events.CloseConnection):
-                    self.complete_closing_handshake()
                 return
             if isinstance(event, events.Request):
                 self.handle_connect(event)
@@ -360,9 +347,7 @@ class WSProtocol(asyncio.Protocol):
                 self.send_500_response()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-        if self.close_timer is None:
-            # Leave the transport open while the closing handshake is pending.
-            self.transport.close()
+        self.transport.close()
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
@@ -450,7 +435,7 @@ class WSProtocol(asyncio.Protocol):
                     output = self.conn.send(wsproto.events.CloseConnection(code=code, reason=reason))
                     if not self.transport.is_closing():
                         self.transport.write(output)
-                        self.defer_close()
+                        self.transport.close()
 
                 else:
                     raise RuntimeError(
@@ -475,32 +460,6 @@ class WSProtocol(asyncio.Protocol):
 
         else:
             raise RuntimeError(f"Unexpected ASGI message '{message['type']}', after sending 'websocket.close'.")
-
-    def defer_close(self) -> None:
-        """Close the transport once the peer echoes our close frame, or on timeout.
-
-        RFC 6455 §5.5.1 requires the peer to echo our close frame. Closing the transport
-        right away makes that reply land on a closed socket, which the kernel answers
-        with a TCP RST, discarding whatever the peer had not read yet. §7.1.1 allows us
-        to close first once the reply is late, hence the timeout.
-        """
-        # Reads may be paused waiting for the app to consume a message; the close reply
-        # would then never be read, so resume them for the duration of the handshake.
-        if self.read_paused:
-            self.read_paused = False
-            self.transport.resume_reading()
-        self.close_timer = self.loop.call_later(self.close_timeout, self.close_transport)
-
-    def complete_closing_handshake(self) -> None:
-        if self.close_timer is not None:
-            self.close_timer.cancel()
-            self.close_timer = None
-            self.transport.close()
-
-    def close_transport(self) -> None:
-        # The peer never echoed our close frame; stop waiting for it.
-        self.close_timer = None
-        self.transport.close()
 
     async def receive(self) -> WebSocketEvent:
         message = await self.queue.get()

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -145,6 +145,9 @@ class WSProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
         self.handshake_complete = True
+        # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
+        # transport that is lost while paused, and the buffer will never drain now.
+        self.writable.set()
         if exc is None:
             self.transport.close()
 


### PR DESCRIPTION
## Summary

Addresses the missing flow-control part of #3047. The complete WebSocket closing-handshake behavior is intentionally split into a separate PR.

`WebSocketsSansIOProtocol.send()` awaits `self.writable.wait()`, but the protocol never implemented `pause_writing()` / `resume_writing()`. The event was therefore never cleared and backpressure never engaged.

## Changes

- Add `pause_writing()` and `resume_writing()` to `WebSocketsSansIOProtocol`, matching `wsproto`.
- Set `writable` in the sansio `connection_lost()` path. asyncio doesn’t call `resume_writing()` when a paused transport is lost, so without this a pending ASGI `send()` would remain blocked indefinitely.
- Add deterministic mock-transport tests; no sockets or sleeps:
  - `send()` blocks while writes are paused and resumes afterward, across all WebSocket/HTTP protocol combinations.
  - A paused sansio sender is released when the connection is lost.

## Scope

This PR deliberately does **not** change WebSocket closing-handshake or TCP-close behavior, and it does not modify `wsproto`. Those changes are being split into focused follow-up PRs.

## Verification

- Targeted tests: 9 passed.
- Ruff and mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket send reliability when transport write buffers are under backpressure.
  * Ensured pending sends are released when a connection is lost.
  * Simplified WebSocket connection shutdown so transports close immediately after ASGI handling or an explicit close request.
* **Tests**
  * Updated WebSocket coverage for backpressure handling and connection-loss behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->