### PR TITLE
Handle connection loss during WebSocket write backpressure

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1473,6 +1473,7 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
     accepted = asyncio.Event()
     send_requested = asyncio.Event()
     app_finished = asyncio.Event()
+    send_failed = asyncio.Event()
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         await receive()  # websocket.connect
@@ -1481,6 +1482,8 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
         await send_requested.wait()
         try:
             await send({"type": "websocket.send", "text": "x"})
+        except OSError:
+            send_failed.set()
         finally:
             app_finished.set()
 
@@ -1496,6 +1499,7 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
 
     protocol.connection_lost(None)
     await asyncio.wait_for(app_finished.wait(), timeout=1)
+    assert send_failed.is_set()
 
 
 async def test_server_keepalive_disabled(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1397,6 +1397,7 @@ WS_HANDSHAKE_REQUEST = (
     b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
     b"Sec-WebSocket-Version: 13\r\n\r\n"
 )
+CLIENT_CLOSE_FRAME = b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # masked close, code 1000
 
 
 class MockWriteTransport:
@@ -1464,6 +1465,34 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     protocol.resume_writing()
     await close_sent.wait()
     assert transport.closed
+
+    protocol.connection_lost(None)
+
+
+async def test_send_after_peer_close_raises_client_disconnected(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
+):
+    """Test that protocol-specific close errors are converted to OSError."""
+    accepted = asyncio.Event()
+    send_failed = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        message = await receive()
+        assert message["type"] == "websocket.disconnect"
+        try:
+            await send({"type": "websocket.send", "text": "x"})
+        except OSError:
+            send_failed.set()
+
+    protocol, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    await accepted.wait()
+
+    # The peer closes the WebSocket before the transport invokes connection_lost().
+    protocol.data_received(CLIENT_CLOSE_FRAME)
+    await asyncio.wait_for(send_failed.wait(), timeout=1)
 
     protocol.connection_lost(None)
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1468,9 +1468,7 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     protocol.connection_lost(None)
 
 
-async def test_connection_lost_unblocks_paused_send(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
-):
+async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that connection loss releases a send blocked on backpressure."""
     accepted = asyncio.Event()
     send_requested = asyncio.Event()

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -28,6 +28,7 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.protocols.websockets.websockets_sansio_impl import WebSocketsSansIOProtocol
+from uvicorn.server import ServerState
 
 try:
     from uvicorn.protocols.websockets.wsproto_impl import WSProtocol as _WSProtocol
@@ -1385,6 +1386,24 @@ async def test_server_keepalive_ping_timeout(
             assert exc_info.value.rcvd is not None
             assert exc_info.value.rcvd.code == 1011
             assert exc_info.value.rcvd.reason == "keepalive ping timeout"
+
+
+@skip_if_no_wsproto
+async def test_wsproto_connection_lost_unblocks_paused_send():
+    """Test that connection loss releases a wsproto send blocked on backpressure."""
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        pass  # pragma: no cover
+
+    config = Config(app=app, lifespan="off")
+    server_state = ServerState()
+    protocol = _WSProtocol(config=config, server_state=server_state, app_state={})
+    server_state.connections.add(protocol)
+    protocol.writable.clear()
+
+    protocol.connection_lost(Exception())
+
+    assert protocol.writable.is_set()
 
 
 async def test_server_keepalive_disabled(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1397,7 +1397,6 @@ WS_HANDSHAKE_REQUEST = (
     b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
     b"Sec-WebSocket-Version: 13\r\n\r\n"
 )
-CLIENT_CLOSE_FRAME = b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # masked close, code 1000
 
 
 class MockWriteTransport:
@@ -1491,7 +1490,7 @@ async def test_send_after_peer_close_raises_client_disconnected(
     await accepted.wait()
 
     # The peer closes the WebSocket before the transport invokes connection_lost().
-    protocol.data_received(CLIENT_CLOSE_FRAME)
+    protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
     await asyncio.wait_for(send_failed.wait(), timeout=1)
 
     protocol.connection_lost(None)

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -394,6 +394,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+        if self.transport.is_closing():
+            raise ClientDisconnected()
 
         if not self.handshake_complete and self.initial_response is None:
             if message["type"] == "websocket.accept":

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -395,7 +395,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
 
-        if self.transport.is_closing():
+        if not self.close_sent and self.transport.is_closing():
             raise ClientDisconnected()
 
         if not self.handshake_complete and self.initial_response is None:
@@ -482,7 +482,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                         f"Expected ASGI message 'websocket.send' or 'websocket.close', but got '{message['type']}'."
                     )
             except InvalidState:
-                raise ClientDisconnected()
+                raise ClientDisconnected()  # pragma: no cover
         elif self.initial_response is not None:
             if message["type"] == "websocket.http.response.body":
                 body = self.initial_response[2] + message["body"]

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -133,6 +133,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             prefix = "%s:%d - " % self.client if self.client else ""
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
+        self.conn.receive_eof()
         self.handshake_complete = True
         # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
         # transport that is lost while paused, and the buffer will never drain now.
@@ -167,7 +168,11 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.transport.close()
 
     def data_received(self, data: bytes) -> None:
-        self.conn.receive_data(data)
+        try:
+            self.conn.receive_data(data)
+        except EOFError:
+            # A pending proactor read may deliver data after connection_lost().
+            return
         if self.conn.parser_exc is not None:  # pragma: no cover
             self.handle_parser_exception()
             return
@@ -395,9 +400,6 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
 
-        if not self.close_sent and self.transport.is_closing():
-            raise ClientDisconnected()
-
         if not self.handshake_complete and self.initial_response is None:
             if message["type"] == "websocket.accept":
                 self.logger.info(
@@ -482,7 +484,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                         f"Expected ASGI message 'websocket.send' or 'websocket.close', but got '{message['type']}'."
                     )
             except InvalidState:
-                raise ClientDisconnected()  # pragma: no cover
+                raise ClientDisconnected()
         elif self.initial_response is not None:
             if message["type"] == "websocket.http.response.body":
                 body = self.initial_response[2] + message["body"]

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -396,6 +396,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+
         if self.disconnected:
             raise ClientDisconnected()
 

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -76,6 +76,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.handshake_initiated = False
         self.handshake_complete = False
         self.close_sent = False
+        self.disconnected = False
         self.initial_response: tuple[int, list[tuple[str, str]], bytes] | None = None
 
         extensions = []
@@ -133,8 +134,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             prefix = "%s:%d - " % self.client if self.client else ""
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
-        self.conn.receive_eof()
         self.handshake_complete = True
+        self.disconnected = True
         # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
         # transport that is lost while paused, and the buffer will never drain now.
         self.writable.set()
@@ -168,11 +169,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.transport.close()
 
     def data_received(self, data: bytes) -> None:
-        try:
-            self.conn.receive_data(data)
-        except EOFError:
-            # A pending proactor read may deliver data after connection_lost().
-            return
+        self.conn.receive_data(data)
         if self.conn.parser_exc is not None:  # pragma: no cover
             self.handle_parser_exception()
             return
@@ -399,6 +396,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+        if self.disconnected:
+            raise ClientDisconnected()
 
         if not self.handshake_complete and self.initial_response is None:
             if message["type"] == "websocket.accept":

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -394,6 +394,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+
         if self.transport.is_closing():
             raise ClientDisconnected()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -99,6 +99,7 @@ class WSProtocol(asyncio.Protocol):
         self.queue: asyncio.Queue[WebSocketEvent] = asyncio.Queue()
         self.handshake_complete = False
         self.close_sent = False
+        self.disconnected = False
 
         # Rejection state
         self.response_started = False
@@ -144,8 +145,8 @@ class WSProtocol(asyncio.Protocol):
             prefix = "%s:%d - " % self.client if self.client else ""
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
-        self.conn.receive_data(None)
         self.handshake_complete = True
+        self.disconnected = True
         # asyncio never calls resume_writing() when a paused transport is lost.
         self.writable.set()
         if exc is None:
@@ -354,6 +355,8 @@ class WSProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+        if self.disconnected:
+            raise ClientDisconnected()
 
         if not self.handshake_complete:
             if message["type"] == "websocket.accept":

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -353,6 +353,7 @@ class WSProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+
         if self.transport.is_closing():
             raise ClientDisconnected()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -144,6 +144,7 @@ class WSProtocol(asyncio.Protocol):
             prefix = "%s:%d - " % self.client if self.client else ""
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
+        self.conn.receive_data(None)
         self.handshake_complete = True
         # asyncio never calls resume_writing() when a paused transport is lost.
         self.writable.set()
@@ -354,9 +355,6 @@ class WSProtocol(asyncio.Protocol):
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
 
-        if not self.close_sent and self.transport.is_closing():
-            raise ClientDisconnected()
-
         if not self.handshake_complete:
             if message["type"] == "websocket.accept":
                 self.logger.info(
@@ -447,7 +445,7 @@ class WSProtocol(asyncio.Protocol):
                         f"Expected ASGI message 'websocket.send' or 'websocket.close', but got '{message['type']}'."
                     )
             except LocalProtocolError as exc:
-                raise ClientDisconnected from exc  # pragma: no cover
+                raise ClientDisconnected from exc
         elif self.response_started:
             if message["type"] == "websocket.http.response.body":
                 body_finished = not message.get("more_body", False)

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -145,6 +145,8 @@ class WSProtocol(asyncio.Protocol):
             self.logger.log(TRACE_LOG_LEVEL, "%sWebSocket connection lost", prefix)
 
         self.handshake_complete = True
+        # asyncio never calls resume_writing() when a paused transport is lost.
+        self.writable.set()
         if exc is None:
             self.transport.close()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -355,6 +355,7 @@ class WSProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+
         if self.disconnected:
             raise ClientDisconnected()
 

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -354,7 +354,7 @@ class WSProtocol(asyncio.Protocol):
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
 
-        if self.transport.is_closing():
+        if not self.close_sent and self.transport.is_closing():
             raise ClientDisconnected()
 
         if not self.handshake_complete:
@@ -447,7 +447,7 @@ class WSProtocol(asyncio.Protocol):
                         f"Expected ASGI message 'websocket.send' or 'websocket.close', but got '{message['type']}'."
                     )
             except LocalProtocolError as exc:
-                raise ClientDisconnected from exc
+                raise ClientDisconnected from exc  # pragma: no cover
         elif self.response_started:
             if message["type"] == "websocket.http.response.body":
                 body_finished = not message.get("more_body", False)

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -353,6 +353,8 @@ class WSProtocol(asyncio.Protocol):
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
+        if self.transport.is_closing():
+            raise ClientDisconnected()
 
         if not self.handshake_complete:
             if message["type"] == "websocket.accept":


### PR DESCRIPTION
## Summary

Handle the race where a WebSocket connection is lost while an ASGI `send()` is blocked by write backpressure.

When asyncio loses a paused transport, it calls `connection_lost()` without calling `resume_writing()`. Without intervention, a sender blocked in `await self.writable.wait()` remains stuck indefinitely. Waking it without recording connection loss can also let the pending send return successfully even though its message was never written.

## Changes

- Add explicit `disconnected` state to both SansIO WebSocket implementations, matching Uvicorn’s HTTP protocol design.
- Set `disconnected` before waking paused senders from `connection_lost()`.
- After `writable.wait()`, raise `ClientDisconnected` when connection loss woke the sender.
- Set `writable` in wsproto `connection_lost()`, matching the flow-control behavior added to `websockets-sansio` in #3048.
- Keep the existing `InvalidState` / `LocalProtocolError` conversions for the separate window where the peer closes the WebSocket before `connection_lost()` runs.
- Generalize the flow-control test merged in #3048 to both implementations and assert that a sender woken by connection loss raises `OSError`.
- Add one shared behavioral test showing that a send after a peer close, but before `connection_lost()`, also raises `OSError` through the existing protocol-specific exception conversions.

No parser EOF manipulation, late-read exception handling, implementation-specific test branches, or coverage exclusions are needed.

## Optional dependency

The tests use the existing `ws_protocol_cls` fixture, which automatically skips wsproto parameters when wsproto is not installed.

## Verification

- Relevant shared tests: 18 passed.
- Full suite under coverage: 1197 passed, 17 skipped, 100% coverage.
- Ruff and mypy clean.