### PR TITLE
Complete server-initiated closes in SansIO WebSocket protocols

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1476,7 +1476,9 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     protocol.connection_lost(None)
 
 
-@pytest.mark.parametrize("outcome", ["reply", "data_then_reply", "same_read", "timeout", "connection_lost", "shutdown"])
+@pytest.mark.parametrize(
+    "outcome", ["reply", "data_then_reply", "same_read", "ping_then_reply", "timeout", "connection_lost", "shutdown"]
+)
 async def test_server_initiated_close(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, outcome: str):
     """Test that a server close waits for its reply, with bounded cleanup."""
     accepted = asyncio.Event()
@@ -1520,6 +1522,11 @@ async def test_server_initiated_close(ws_protocol_cls: WSProtocol, http_protocol
             b"\x81\x81\x00\x00\x00\x00x"  # masked text, payload "x"
             b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # masked close, code 1000
         )
+    elif outcome == "ping_then_reply":
+        protocol.data_received(b"\x89\x80\x00\x00\x00\x00")  # masked ping
+        assert not transport.reading_paused
+        assert not transport.closed
+        protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
     elif outcome == "connection_lost":
         assert not transport.closed
         protocol.connection_lost(None)

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -10,7 +10,7 @@ import websockets.exceptions
 from websockets import __version__ as websockets_version
 from websockets.asyncio.client import ClientConnection, connect
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
-from websockets.frames import Opcode
+from websockets.frames import Close, CloseCode, Frame, Opcode
 from websockets.typing import Subprotocol
 
 from tests.response import Response
@@ -1397,9 +1397,9 @@ WS_HANDSHAKE_REQUEST = (
     b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
     b"Sec-WebSocket-Version: 13\r\n\r\n"
 )
-MASKED_TEXT_FRAME = b"\x81\x81\x00\x00\x00\x00x"  # payload "x"
-MASKED_PING_FRAME = b"\x89\x80\x00\x00\x00\x00"
-MASKED_CLOSE_FRAME = b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # code 1000
+MASKED_TEXT_FRAME = Frame(Opcode.TEXT, b"x").serialize(mask=True)
+MASKED_PING_FRAME = Frame(Opcode.PING, b"").serialize(mask=True)
+MASKED_CLOSE_FRAME = Frame(Opcode.CLOSE, Close(CloseCode.NORMAL_CLOSURE, "").serialize()).serialize(mask=True)
 
 
 class MockWriteTransport:

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1680,7 +1680,8 @@ async def test_close_gives_up_when_the_peer_never_replies(ws_protocol_cls: WSPro
         accept_then_close_app, ws_protocol_cls, http_protocol_cls, close_timeout=0
     ) as connection:
         await connection.app_finished()
-        # The zero-delay close timer has already fired while the app task was awaited.
+        # The zero-delay close timer fires on the next event-loop iteration.
+        await asyncio.sleep(0)
         assert connection.transport_closed
 
     assert not connection.awaiting_close_reply

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1397,6 +1397,9 @@ WS_HANDSHAKE_REQUEST = (
     b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
     b"Sec-WebSocket-Version: 13\r\n\r\n"
 )
+MASKED_TEXT_FRAME = b"\x81\x81\x00\x00\x00\x00x"  # payload "x"
+MASKED_PING_FRAME = b"\x89\x80\x00\x00\x00\x00"
+MASKED_CLOSE_FRAME = b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # code 1000
 
 
 class MockWriteTransport:
@@ -1476,70 +1479,159 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     protocol.connection_lost(None)
 
 
-@pytest.mark.parametrize(
-    "outcome", ["reply", "data_then_reply", "same_read", "ping_then_reply", "timeout", "connection_lost", "shutdown"]
-)
-async def test_server_initiated_close(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, outcome: str):
-    """Test that a server close waits for its reply, with bounded cleanup."""
+async def closing_ws_protocol(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, close_timeout: float = 10.0
+) -> tuple[Any, MockWriteTransport]:
+    """Return a protocol just past a server-initiated `websocket.close`, and its transport."""
     accepted = asyncio.Event()
-    close_requested = asyncio.Event()
     close_sent = asyncio.Event()
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         await receive()  # websocket.connect
         await send({"type": "websocket.accept"})
         accepted.set()
-        await close_requested.wait()
+        await send({"type": "websocket.close", "code": 1000})
+        close_sent.set()
+
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol.close_timeout = close_timeout
+    await accepted.wait()
+    await close_sent.wait()
+    # Yield repeatedly so run_asgi() finishes and (wrongly) closes the transport if broken.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    return protocol, transport
+
+
+async def test_close_waits_for_the_peer_close_frame(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that a server close leaves the transport open until the peer echoes it.
+
+    Closing it right away makes the peer\'s reply (RFC 6455 5.5.1) land on a closed socket,
+    which the kernel answers with a TCP RST that discards data the peer has not read yet.
+    See https://github.com/Kludex/uvicorn/issues/3047.
+    """
+    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    assert not transport.closed
+
+    protocol.data_received(MASKED_CLOSE_FRAME)
+    assert transport.closed
+    assert protocol.close_timer is None
+
+    protocol.connection_lost(None)
+
+
+async def test_close_resumes_reads_paused_on_an_unconsumed_message(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
+):
+    """Test that closing resumes paused reads, so the peer close frame can be received."""
+    accepted = asyncio.Event()
+    message_queued = asyncio.Event()
+    close_sent = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await message_queued.wait()
+        # Close without consuming the queued message, leaving reads paused.
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
     protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
-    if outcome == "reply":
-        # Leave a message unconsumed so reads are paused when the app closes.
-        protocol.data_received(b"\x81\x81\x00\x00\x00\x00x")  # masked text, payload "x"
-        assert transport.reading_paused
-    elif outcome == "timeout":
-        protocol.close_timeout = 0
-
-    close_requested.set()
+    protocol.data_received(MASKED_TEXT_FRAME)
+    assert transport.reading_paused
+    message_queued.set()
     await close_sent.wait()
     for _ in range(10):
         await asyncio.sleep(0)
+    assert not transport.reading_paused
+    assert not transport.closed
 
-    if outcome == "reply":
-        assert not transport.reading_paused
-        assert not transport.closed
-        protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
-    elif outcome == "data_then_reply":
-        protocol.data_received(b"\x81\x81\x00\x00\x00\x00x")  # masked text, payload "x"
-        assert not transport.reading_paused
-        assert not transport.closed
-        protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
-    elif outcome == "same_read":
-        protocol.data_received(
-            b"\x81\x81\x00\x00\x00\x00x"  # masked text, payload "x"
-            b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # masked close, code 1000
-        )
-    elif outcome == "ping_then_reply":
-        protocol.data_received(b"\x89\x80\x00\x00\x00\x00")  # masked ping
-        assert not transport.reading_paused
-        assert not transport.closed
-        protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
-    elif outcome == "connection_lost":
-        assert not transport.closed
-        protocol.connection_lost(None)
-    elif outcome == "shutdown":
-        assert not transport.closed
-        protocol.shutdown()
-    else:
-        assert transport.closed
-
+    protocol.data_received(MASKED_CLOSE_FRAME)
     assert transport.closed
-    if outcome != "connection_lost":
-        protocol.connection_lost(None)
+
+    protocol.connection_lost(None)
+
+
+async def test_data_frame_while_closing_does_not_pause_reads(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
+):
+    """Test that a data frame crossing the server close cannot block the peer close frame."""
+    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+
+    protocol.data_received(MASKED_TEXT_FRAME)
+    assert not transport.reading_paused
+    assert not transport.closed
+
+    protocol.data_received(MASKED_CLOSE_FRAME)
+    assert transport.closed
+
+    protocol.connection_lost(None)
+
+
+async def test_data_frame_and_peer_close_frame_in_one_read(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
+):
+    """Test that a peer close frame is processed even when preceded by data in the same read."""
+    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+
+    protocol.data_received(MASKED_TEXT_FRAME + MASKED_CLOSE_FRAME)
+    assert transport.closed
     assert protocol.close_timer is None
+
+    protocol.connection_lost(None)
+
+
+async def test_ping_while_closing(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that a ping crossing the server close cannot break the closing handshake."""
+    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+
+    protocol.data_received(MASKED_PING_FRAME)
+    assert not transport.reading_paused
+    assert not transport.closed
+
+    protocol.data_received(MASKED_CLOSE_FRAME)
+    assert transport.closed
+
+    protocol.connection_lost(None)
+
+
+async def test_close_gives_up_when_the_peer_never_replies(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that a peer that never echoes the close frame cannot keep the connection.
+
+    RFC 6455 7.1.1 lets the server close the connection once the reply is late.
+    """
+    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls, close_timeout=0)
+    # The zero-delay close timer has already fired during the helper's yields.
+    assert transport.closed
+
+    protocol.connection_lost(None)
+    assert protocol.close_timer is None
+
+
+async def test_connection_lost_cancels_the_pending_close_timer(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
+):
+    """Test that losing the connection stops waiting for the peer close frame."""
+    protocol, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    assert protocol.close_timer is not None
+
+    protocol.connection_lost(None)
+    assert protocol.close_timer is None
+
+
+async def test_shutdown_while_the_close_reply_is_pending(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
+    """Test that server shutdown does not send a second close frame during the handshake."""
+    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    assert not transport.closed
+
+    protocol.shutdown()
+    assert transport.closed
+    assert protocol.close_timer is None
+
+    protocol.connection_lost(None)
 
 
 async def test_send_after_peer_close_raises_client_disconnected(
@@ -1564,7 +1656,7 @@ async def test_send_after_peer_close_raises_client_disconnected(
     await accepted.wait()
 
     # The peer closes the WebSocket before the transport invokes connection_lost().
-    protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
+    protocol.data_received(MASKED_CLOSE_FRAME)
     await asyncio.wait_for(send_failed.wait(), timeout=1)
 
     protocol.connection_lost(None)

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1405,6 +1405,7 @@ class MockWriteTransport:
     def __init__(self) -> None:
         self.buffer = b""
         self.closed = False
+        self.reading_paused = False
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:
         return {"sockname": ("127.0.0.1", 8000), "peername": ("127.0.0.1", 8001)}.get(name, default)
@@ -1417,6 +1418,12 @@ class MockWriteTransport:
 
     def is_closing(self) -> bool:
         return self.closed
+
+    def pause_reading(self) -> None:
+        self.reading_paused = True
+
+    def resume_reading(self) -> None:
+        self.reading_paused = False
 
 
 def connected_ws_protocol(
@@ -1439,6 +1446,40 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     See https://github.com/Kludex/uvicorn/issues/3047.
     """
     accepted = asyncio.Event()
+    send_requested = asyncio.Event()
+    send_completed = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        accepted.set()
+        await send_requested.wait()
+        await send({"type": "websocket.send", "text": "x"})
+        send_completed.set()
+
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    await accepted.wait()
+
+    initial_buffer = transport.buffer
+    protocol.pause_writing()
+    send_requested.set()
+    # Yield repeatedly so the app task can progress through send() and (wrongly) complete it if unblocked.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not send_completed.is_set()
+    assert transport.buffer == initial_buffer
+
+    protocol.resume_writing()
+    await send_completed.wait()
+    assert transport.buffer != initial_buffer
+
+    protocol.connection_lost(None)
+
+
+@pytest.mark.parametrize("outcome", ["reply", "timeout", "connection_lost"])
+async def test_sansio_server_initiated_close(http_protocol_cls: HTTPProtocol, outcome: str):
+    """Test that a server close waits for its reply, with bounded cleanup."""
+    accepted = asyncio.Event()
     close_requested = asyncio.Event()
     close_sent = asyncio.Event()
 
@@ -1450,22 +1491,35 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol, transport = connected_ws_protocol(app, WebSocketsSansIOProtocol, http_protocol_cls)
     await accepted.wait()
 
-    protocol.pause_writing()
+    if outcome == "reply":
+        # Leave a message unconsumed so reads are paused when the app closes.
+        protocol.data_received(b"\x81\x81\x00\x00\x00\x00x")  # masked text, payload "x"
+        assert transport.reading_paused
+    elif outcome == "timeout":
+        protocol.close_timeout = 0
+
     close_requested.set()
-    # Yield repeatedly so the app task can progress through send() and (wrongly) complete the close if unblocked.
+    await close_sent.wait()
     for _ in range(10):
         await asyncio.sleep(0)
-    assert not close_sent.is_set()
-    assert not transport.closed
 
-    protocol.resume_writing()
-    await close_sent.wait()
+    if outcome == "reply":
+        assert not transport.reading_paused
+        assert not transport.closed
+        protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
+    elif outcome == "connection_lost":
+        assert not transport.closed
+        protocol.connection_lost(None)
+    else:
+        assert transport.closed
+
     assert transport.closed
-
-    protocol.connection_lost(None)
+    if outcome != "connection_lost":
+        protocol.connection_lost(None)
+    assert protocol.close_timer is None
 
 
 async def test_send_after_peer_close_raises_client_disconnected(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1477,7 +1477,7 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
 
 
 @pytest.mark.parametrize("outcome", ["reply", "timeout", "connection_lost"])
-async def test_sansio_server_initiated_close(http_protocol_cls: HTTPProtocol, outcome: str):
+async def test_server_initiated_close(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, outcome: str):
     """Test that a server close waits for its reply, with bounded cleanup."""
     accepted = asyncio.Event()
     close_requested = asyncio.Event()
@@ -1491,7 +1491,7 @@ async def test_sansio_server_initiated_close(http_protocol_cls: HTTPProtocol, ou
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
-    protocol, transport = connected_ws_protocol(app, WebSocketsSansIOProtocol, http_protocol_cls)
+    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
     if outcome == "reply":

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -9,9 +9,11 @@ import pytest
 import websockets.exceptions
 from websockets import __version__ as websockets_version
 from websockets.asyncio.client import ClientConnection, connect
+from websockets.client import ClientProtocol
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
-from websockets.frames import Close, CloseCode, Frame, Opcode
+from websockets.frames import CloseCode, Opcode
 from websockets.typing import Subprotocol
+from websockets.uri import parse_uri
 
 from tests.response import Response
 from tests.utils import run_server
@@ -1389,17 +1391,43 @@ async def test_server_keepalive_ping_timeout(
             assert exc_info.value.rcvd.reason == "keepalive ping timeout"
 
 
-WS_HANDSHAKE_REQUEST = (
-    b"GET / HTTP/1.1\r\n"
-    b"Host: 127.0.0.1\r\n"
-    b"Upgrade: websocket\r\n"
-    b"Connection: Upgrade\r\n"
-    b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
-    b"Sec-WebSocket-Version: 13\r\n\r\n"
-)
-MASKED_TEXT_FRAME = Frame(Opcode.TEXT, b"x").serialize(mask=True)
-MASKED_PING_FRAME = Frame(Opcode.PING, b"").serialize(mask=True)
-MASKED_CLOSE_FRAME = Frame(Opcode.CLOSE, Close(CloseCode.NORMAL_CLOSURE, "").serialize()).serialize(mask=True)
+class MockClient:
+    """A sans-io websockets client for driving a server protocol in-process."""
+
+    def __init__(self) -> None:
+        self.protocol = ClientProtocol(parse_uri("ws://127.0.0.1/"))
+        self._read = 0
+
+    def handshake_request(self) -> bytes:
+        self.protocol.send_request(self.protocol.connect())
+        return b"".join(self.protocol.data_to_send())
+
+    def read_response(self, transport: MockWriteTransport) -> None:
+        """Read only the HTTP 101 response, leaving later server frames unread."""
+        self._read = transport.buffer.index(b"\r\n\r\n") + 4
+        self.protocol.receive_data(transport.buffer[: self._read])
+
+    def read_frames(self, transport: MockWriteTransport) -> bytes:
+        """Read the server frames sent since, returning the client's conforming replies.
+
+        Reading the server's close frame makes the client echo it, per RFC 6455 5.5.1.
+        """
+        data = transport.buffer[self._read :]
+        self._read = len(transport.buffer)
+        self.protocol.receive_data(data)
+        return b"".join(self.protocol.data_to_send())
+
+    def send_text(self, text: str) -> bytes:
+        self.protocol.send_text(text.encode())
+        return b"".join(self.protocol.data_to_send())
+
+    def send_ping(self) -> bytes:
+        self.protocol.send_ping(b"")
+        return b"".join(self.protocol.data_to_send())
+
+    def send_close(self, code: int = CloseCode.NORMAL_CLOSURE) -> bytes:
+        self.protocol.send_close(code)
+        return b"".join(self.protocol.data_to_send())
 
 
 class MockWriteTransport:
@@ -1431,15 +1459,16 @@ class MockWriteTransport:
 
 def connected_ws_protocol(
     app: ASGIApplication, ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
-) -> tuple[Any, MockWriteTransport]:
-    """Return a websocket protocol driven by a mock transport, past the handshake."""
+) -> tuple[Any, MockWriteTransport, MockClient]:
+    """Return a websocket protocol driven by a mock transport and client, past the handshake."""
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
     config.load()
     protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
     transport = MockWriteTransport()
+    client = MockClient()
     protocol.connection_made(transport)  # type: ignore[arg-type]
-    protocol.data_received(WS_HANDSHAKE_REQUEST)
-    return protocol, transport
+    protocol.data_received(client.handshake_request())
+    return protocol, transport, client
 
 
 async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1460,7 +1489,7 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
         await send({"type": "websocket.send", "text": "x"})
         send_completed.set()
 
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol, transport, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
     initial_buffer = transport.buffer
@@ -1481,7 +1510,7 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
 
 async def closing_ws_protocol(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, close_timeout: float = 10.0
-) -> tuple[Any, MockWriteTransport]:
+) -> tuple[Any, MockWriteTransport, MockClient]:
     """Return a protocol just past a server-initiated `websocket.close`, and its transport."""
     accepted = asyncio.Event()
     close_sent = asyncio.Event()
@@ -1493,14 +1522,16 @@ async def closing_ws_protocol(
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol, transport, client = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     protocol.close_timeout = close_timeout
     await accepted.wait()
     await close_sent.wait()
     # Yield repeatedly so run_asgi() finishes and (wrongly) closes the transport if broken.
     for _ in range(10):
         await asyncio.sleep(0)
-    return protocol, transport
+    # The client has read the 101 response; the server's close frame is still in flight.
+    client.read_response(transport)
+    return protocol, transport, client
 
 
 async def test_close_waits_for_the_peer_close_frame(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1510,10 +1541,10 @@ async def test_close_waits_for_the_peer_close_frame(ws_protocol_cls: WSProtocol,
     which the kernel answers with a TCP RST that discards data the peer has not read yet.
     See https://github.com/Kludex/uvicorn/issues/3047.
     """
-    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
     assert not transport.closed
 
-    protocol.data_received(MASKED_CLOSE_FRAME)
+    protocol.data_received(client.read_frames(transport))  # the client echoes the close
     assert transport.closed
     assert protocol.close_timer is None
 
@@ -1537,10 +1568,11 @@ async def test_close_resumes_reads_paused_on_an_unconsumed_message(
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
-    protocol, transport = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol, transport, client = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
+    client.read_response(transport)
 
-    protocol.data_received(MASKED_TEXT_FRAME)
+    protocol.data_received(client.send_text("x"))
     assert transport.reading_paused
     message_queued.set()
     await close_sent.wait()
@@ -1549,7 +1581,7 @@ async def test_close_resumes_reads_paused_on_an_unconsumed_message(
     assert not transport.reading_paused
     assert not transport.closed
 
-    protocol.data_received(MASKED_CLOSE_FRAME)
+    protocol.data_received(client.read_frames(transport))  # the client echoes the close
     assert transport.closed
 
     protocol.connection_lost(None)
@@ -1559,13 +1591,13 @@ async def test_data_frame_while_closing_does_not_pause_reads(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that a data frame crossing the server close cannot block the peer close frame."""
-    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
 
-    protocol.data_received(MASKED_TEXT_FRAME)
+    protocol.data_received(client.send_text("x"))
     assert not transport.reading_paused
     assert not transport.closed
 
-    protocol.data_received(MASKED_CLOSE_FRAME)
+    protocol.data_received(client.read_frames(transport))  # the client echoes the close
     assert transport.closed
 
     protocol.connection_lost(None)
@@ -1575,9 +1607,9 @@ async def test_data_frame_and_peer_close_frame_in_one_read(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that a peer close frame is processed even when preceded by data in the same read."""
-    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
 
-    protocol.data_received(MASKED_TEXT_FRAME + MASKED_CLOSE_FRAME)
+    protocol.data_received(client.send_text("x") + client.read_frames(transport))
     assert transport.closed
     assert protocol.close_timer is None
 
@@ -1586,13 +1618,13 @@ async def test_data_frame_and_peer_close_frame_in_one_read(
 
 async def test_ping_while_closing(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that a ping crossing the server close cannot break the closing handshake."""
-    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
 
-    protocol.data_received(MASKED_PING_FRAME)
+    protocol.data_received(client.send_ping())
     assert not transport.reading_paused
     assert not transport.closed
 
-    protocol.data_received(MASKED_CLOSE_FRAME)
+    protocol.data_received(client.read_frames(transport))  # the client echoes the close
     assert transport.closed
 
     protocol.connection_lost(None)
@@ -1603,7 +1635,7 @@ async def test_close_gives_up_when_the_peer_never_replies(ws_protocol_cls: WSPro
 
     RFC 6455 7.1.1 lets the server close the connection once the reply is late.
     """
-    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls, close_timeout=0)
+    protocol, transport, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls, close_timeout=0)
     # The zero-delay close timer has already fired during the helper's yields.
     assert transport.closed
 
@@ -1615,7 +1647,7 @@ async def test_connection_lost_cancels_the_pending_close_timer(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that losing the connection stops waiting for the peer close frame."""
-    protocol, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    protocol, _, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
     assert protocol.close_timer is not None
 
     protocol.connection_lost(None)
@@ -1624,7 +1656,7 @@ async def test_connection_lost_cancels_the_pending_close_timer(
 
 async def test_shutdown_while_the_close_reply_is_pending(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that server shutdown does not send a second close frame during the handshake."""
-    protocol, transport = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    protocol, transport, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
     assert not transport.closed
 
     protocol.shutdown()
@@ -1652,11 +1684,12 @@ async def test_send_after_peer_close_raises_client_disconnected(
         except OSError:
             send_failed.set()
 
-    protocol, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol, transport, client = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
+    client.read_response(transport)
 
     # The peer closes the WebSocket before the transport invokes connection_lost().
-    protocol.data_received(MASKED_CLOSE_FRAME)
+    protocol.data_received(client.send_close())
     await asyncio.wait_for(send_failed.wait(), timeout=1)
 
     protocol.connection_lost(None)
@@ -1681,7 +1714,7 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
         finally:
             app_finished.set()
 
-    protocol, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    protocol, _, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
     protocol.pause_writing()

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1435,15 +1435,27 @@ class MockWebSocketConnection:
     ) -> None:
         config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
         config.load()
-        self._protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
+        self._server_state = ServerState()
+        self._protocol = ws_protocol_cls(config=config, server_state=self._server_state, app_state={})
         self._protocol.close_timeout = close_timeout
         self._transport = MockWriteTransport()
         self._client = ClientProtocol(parse_uri("ws://127.0.0.1/"))
         self._bytes_read = 0  # how much of the server output the client has read
         self._outbox = b""  # client frames not yet delivered to the server
+        self._connection_lost = False
+
+    async def __aenter__(self) -> MockWebSocketConnection:
         self._protocol.connection_made(self._transport)  # type: ignore[arg-type]
         self._client.send_request(self._client.connect())
         self._protocol.data_received(b"".join(self._client.data_to_send()))
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        self.connection_lost()
+
+    async def app_finished(self) -> None:
+        """Wait for the ASGI application task to complete."""
+        await asyncio.gather(*self._server_state.tasks)
 
     # Client actions.
 
@@ -1488,7 +1500,9 @@ class MockWebSocketConnection:
         self._protocol.resume_writing()
 
     def connection_lost(self) -> None:
-        self._protocol.connection_lost(None)
+        if not self._connection_lost:
+            self._connection_lost = True
+            self._protocol.connection_lost(None)
 
     def shutdown(self) -> None:
         self._protocol.shutdown()
@@ -1527,24 +1541,11 @@ class MockWebSocketConnection:
         return self._client.events_received()
 
 
-async def closing_websocket(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, close_timeout: float = 10.0
-) -> MockWebSocketConnection:
-    """Return a connection whose application accepted and then initiated a close."""
-    close_sent = asyncio.Event()
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        await receive()  # websocket.connect
-        await send({"type": "websocket.accept"})
-        await send({"type": "websocket.close", "code": 1000})
-        close_sent.set()
-
-    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls, close_timeout=close_timeout)
-    await close_sent.wait()
-    # Yield repeatedly so run_asgi() finishes and (wrongly) closes the transport if broken.
-    for _ in range(10):
-        await asyncio.sleep(0)
-    return connection
+async def accept_then_close_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+    """Accept the connection and immediately start the closing handshake."""
+    await receive()  # websocket.connect
+    await send({"type": "websocket.accept"})
+    await send({"type": "websocket.close", "code": 1000})
 
 
 async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1565,22 +1566,20 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
         await send({"type": "websocket.send", "text": "x"})
         send_completed.set()
 
-    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
+    async with MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls) as connection:
+        await accepted.wait()
 
-    connection.pause_writing()
-    send_requested.set()
-    # Yield repeatedly so the app task can progress through send() and (wrongly) complete it if unblocked.
-    for _ in range(10):
-        await asyncio.sleep(0)
-    assert not send_completed.is_set()
-    assert connection.receive_text() == []
+        connection.pause_writing()
+        send_requested.set()
+        # Yield repeatedly so the app task can progress through send() and (wrongly) complete it if unblocked.
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert not send_completed.is_set()
+        assert connection.receive_text() == []
 
-    connection.resume_writing()
-    await send_completed.wait()
-    assert connection.receive_text() == ["x"]
-
-    connection.connection_lost()
+        connection.resume_writing()
+        await send_completed.wait()
+        assert connection.receive_text() == ["x"]
 
 
 async def test_close_waits_for_the_peer_close_frame(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1590,14 +1589,13 @@ async def test_close_waits_for_the_peer_close_frame(ws_protocol_cls: WSProtocol,
     which the kernel answers with a TCP RST that discards data the peer has not read yet.
     See https://github.com/Kludex/uvicorn/issues/3047.
     """
-    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
-    assert not connection.transport_closed
+    async with MockWebSocketConnection(accept_then_close_app, ws_protocol_cls, http_protocol_cls) as connection:
+        await connection.app_finished()
+        assert not connection.transport_closed
 
-    connection.reply_to_server_close()
-    assert connection.transport_closed
-    assert not connection.awaiting_close_reply
-
-    connection.connection_lost()
+        connection.reply_to_server_close()
+        assert connection.transport_closed
+        assert not connection.awaiting_close_reply
 
 
 async def test_close_resumes_reads_paused_on_an_unconsumed_message(
@@ -1617,67 +1615,60 @@ async def test_close_resumes_reads_paused_on_an_unconsumed_message(
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
-    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
+    async with MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls) as connection:
+        await accepted.wait()
 
-    connection.send_text("x")
-    assert connection.reading_paused
-    message_queued.set()
-    await close_sent.wait()
-    for _ in range(10):
-        await asyncio.sleep(0)
-    assert not connection.reading_paused
-    assert not connection.transport_closed
+        connection.send_text("x")
+        assert connection.reading_paused
+        message_queued.set()
+        await connection.app_finished()
+        assert not connection.reading_paused
+        assert not connection.transport_closed
 
-    connection.reply_to_server_close()
-    assert connection.transport_closed
-
-    connection.connection_lost()
+        connection.reply_to_server_close()
+        assert connection.transport_closed
 
 
 async def test_data_frame_while_closing_does_not_pause_reads(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that a data frame crossing the server close cannot block the peer close frame."""
-    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
+    async with MockWebSocketConnection(accept_then_close_app, ws_protocol_cls, http_protocol_cls) as connection:
+        await connection.app_finished()
 
-    connection.send_text("x")
-    assert not connection.reading_paused
-    assert not connection.transport_closed
+        connection.send_text("x")
+        assert not connection.reading_paused
+        assert not connection.transport_closed
 
-    connection.reply_to_server_close()
-    assert connection.transport_closed
-
-    connection.connection_lost()
+        connection.reply_to_server_close()
+        assert connection.transport_closed
 
 
 async def test_data_frame_and_peer_close_frame_in_one_read(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that a peer close frame is processed even when preceded by data in the same read."""
-    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
+    async with MockWebSocketConnection(accept_then_close_app, ws_protocol_cls, http_protocol_cls) as connection:
+        await connection.app_finished()
 
-    connection.send_text("x", flush=False)
-    connection.reply_to_server_close(flush=False)
-    connection.flush()
-    assert connection.transport_closed
-    assert not connection.awaiting_close_reply
-
-    connection.connection_lost()
+        connection.send_text("x", flush=False)
+        connection.reply_to_server_close(flush=False)
+        connection.flush()
+        assert connection.transport_closed
+        assert not connection.awaiting_close_reply
 
 
 async def test_ping_while_closing(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that a ping crossing the server close cannot break the closing handshake."""
-    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
+    async with MockWebSocketConnection(accept_then_close_app, ws_protocol_cls, http_protocol_cls) as connection:
+        await connection.app_finished()
 
-    connection.send_ping()
-    assert not connection.reading_paused
-    assert not connection.transport_closed
+        connection.send_ping()
+        assert not connection.reading_paused
+        assert not connection.transport_closed
 
-    connection.reply_to_server_close()
-    assert connection.transport_closed
-
-    connection.connection_lost()
+        connection.reply_to_server_close()
+        assert connection.transport_closed
 
 
 async def test_close_gives_up_when_the_peer_never_replies(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1685,11 +1676,13 @@ async def test_close_gives_up_when_the_peer_never_replies(ws_protocol_cls: WSPro
 
     RFC 6455 7.1.1 lets the server close the connection once the reply is late.
     """
-    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls, close_timeout=0)
-    # The zero-delay close timer has already fired during the helper's yields.
-    assert connection.transport_closed
+    async with MockWebSocketConnection(
+        accept_then_close_app, ws_protocol_cls, http_protocol_cls, close_timeout=0
+    ) as connection:
+        await connection.app_finished()
+        # The zero-delay close timer has already fired while the app task was awaited.
+        assert connection.transport_closed
 
-    connection.connection_lost()
     assert not connection.awaiting_close_reply
 
 
@@ -1697,23 +1690,22 @@ async def test_connection_lost_cancels_the_pending_close_timer(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that losing the connection stops waiting for the peer close frame."""
-    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
-    assert connection.awaiting_close_reply
+    async with MockWebSocketConnection(accept_then_close_app, ws_protocol_cls, http_protocol_cls) as connection:
+        await connection.app_finished()
+        assert connection.awaiting_close_reply
 
-    connection.connection_lost()
     assert not connection.awaiting_close_reply
 
 
 async def test_shutdown_while_the_close_reply_is_pending(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that server shutdown does not send a second close frame during the handshake."""
-    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
-    assert not connection.transport_closed
+    async with MockWebSocketConnection(accept_then_close_app, ws_protocol_cls, http_protocol_cls) as connection:
+        await connection.app_finished()
+        assert not connection.transport_closed
 
-    connection.shutdown()
-    assert connection.transport_closed
-    assert not connection.awaiting_close_reply
-
-    connection.connection_lost()
+        connection.shutdown()
+        assert connection.transport_closed
+        assert not connection.awaiting_close_reply
 
 
 async def test_send_after_peer_close_raises_client_disconnected(
@@ -1734,14 +1726,12 @@ async def test_send_after_peer_close_raises_client_disconnected(
         except OSError:
             send_failed.set()
 
-    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
+    async with MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls) as connection:
+        await accepted.wait()
 
-    # The peer closes the WebSocket before the transport invokes connection_lost().
-    connection.send_close()
-    await asyncio.wait_for(send_failed.wait(), timeout=1)
-
-    connection.connection_lost()
+        # The peer closes the WebSocket before the transport invokes connection_lost().
+        connection.send_close()
+        await asyncio.wait_for(send_failed.wait(), timeout=1)
 
 
 async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1763,19 +1753,19 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
         finally:
             app_finished.set()
 
-    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
-    await accepted.wait()
+    async with MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls) as connection:
+        await accepted.wait()
 
-    connection.pause_writing()
-    send_requested.set()
-    # Yield repeatedly so the app task reaches the blocking wait inside send().
-    for _ in range(10):
-        await asyncio.sleep(0)
-    assert not app_finished.is_set()
+        connection.pause_writing()
+        send_requested.set()
+        # Yield repeatedly so the app task reaches the blocking wait inside send().
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert not app_finished.is_set()
 
-    connection.connection_lost()
-    await asyncio.wait_for(app_finished.wait(), timeout=1)
-    assert send_failed.is_set()
+        connection.connection_lost()
+        await asyncio.wait_for(app_finished.wait(), timeout=1)
+        assert send_failed.is_set()
 
 
 async def test_server_keepalive_disabled(

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -11,7 +11,7 @@ from websockets import __version__ as websockets_version
 from websockets.asyncio.client import ClientConnection, connect
 from websockets.client import ClientProtocol
 from websockets.extensions.permessage_deflate import ClientPerMessageDeflateFactory
-from websockets.frames import CloseCode, Opcode
+from websockets.frames import CloseCode, Frame, Opcode
 from websockets.typing import Subprotocol
 from websockets.uri import parse_uri
 
@@ -1391,45 +1391,6 @@ async def test_server_keepalive_ping_timeout(
             assert exc_info.value.rcvd.reason == "keepalive ping timeout"
 
 
-class MockClient:
-    """A sans-io websockets client for driving a server protocol in-process."""
-
-    def __init__(self) -> None:
-        self.protocol = ClientProtocol(parse_uri("ws://127.0.0.1/"))
-        self._read = 0
-
-    def handshake_request(self) -> bytes:
-        self.protocol.send_request(self.protocol.connect())
-        return b"".join(self.protocol.data_to_send())
-
-    def read_response(self, transport: MockWriteTransport) -> None:
-        """Read only the HTTP 101 response, leaving later server frames unread."""
-        self._read = transport.buffer.index(b"\r\n\r\n") + 4
-        self.protocol.receive_data(transport.buffer[: self._read])
-
-    def read_frames(self, transport: MockWriteTransport) -> bytes:
-        """Read the server frames sent since, returning the client's conforming replies.
-
-        Reading the server's close frame makes the client echo it, per RFC 6455 5.5.1.
-        """
-        data = transport.buffer[self._read :]
-        self._read = len(transport.buffer)
-        self.protocol.receive_data(data)
-        return b"".join(self.protocol.data_to_send())
-
-    def send_text(self, text: str) -> bytes:
-        self.protocol.send_text(text.encode())
-        return b"".join(self.protocol.data_to_send())
-
-    def send_ping(self) -> bytes:
-        self.protocol.send_ping(b"")
-        return b"".join(self.protocol.data_to_send())
-
-    def send_close(self, code: int = CloseCode.NORMAL_CLOSURE) -> bytes:
-        self.protocol.send_close(code)
-        return b"".join(self.protocol.data_to_send())
-
-
 class MockWriteTransport:
     """Minimal transport for driving a websocket protocol's write path in-process."""
 
@@ -1457,18 +1418,133 @@ class MockWriteTransport:
         self.reading_paused = False
 
 
-def connected_ws_protocol(
-    app: ASGIApplication, ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
-) -> tuple[Any, MockWriteTransport, MockClient]:
-    """Return a websocket protocol driven by a mock transport and client, past the handshake."""
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
-    config.load()
-    protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
-    transport = MockWriteTransport()
-    client = MockClient()
-    protocol.connection_made(transport)  # type: ignore[arg-type]
-    protocol.data_received(client.handshake_request())
-    return protocol, transport, client
+class MockWebSocketConnection:
+    """An in-process WebSocket connection: a sans-io client wired to a server protocol.
+
+    Tests act as the client and observe the server, without real sockets. Each client
+    action is delivered to the server as its own transport read; pass `flush=False` and
+    call `flush()` to coalesce several frames into a single read.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApplication,
+        ws_protocol_cls: WSProtocol,
+        http_protocol_cls: HTTPProtocol,
+        close_timeout: float = 10.0,
+    ) -> None:
+        config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off")
+        config.load()
+        self._protocol = ws_protocol_cls(config=config, server_state=ServerState(), app_state={})
+        self._protocol.close_timeout = close_timeout
+        self._transport = MockWriteTransport()
+        self._client = ClientProtocol(parse_uri("ws://127.0.0.1/"))
+        self._bytes_read = 0  # how much of the server output the client has read
+        self._outbox = b""  # client frames not yet delivered to the server
+        self._protocol.connection_made(self._transport)  # type: ignore[arg-type]
+        self._client.send_request(self._client.connect())
+        self._protocol.data_received(b"".join(self._client.data_to_send()))
+
+    # Client actions.
+
+    def send_text(self, text: str, flush: bool = True) -> None:
+        self._read_response()
+        self._client.send_text(text.encode())
+        self._stage(flush)
+
+    def send_ping(self, flush: bool = True) -> None:
+        self._read_response()
+        self._client.send_ping(b"")
+        self._stage(flush)
+
+    def send_close(self, flush: bool = True) -> None:
+        self._read_response()
+        self._client.send_close(CloseCode.NORMAL_CLOSURE)
+        self._stage(flush)
+
+    def reply_to_server_close(self, flush: bool = True) -> None:
+        """Read the server frames; the client echoes the close frame, per RFC 6455 5.5.1."""
+        self._read_server_output()
+        self._stage(flush)
+
+    def receive_text(self) -> list[str]:
+        """Read the server frames, returning the text messages they carried."""
+        events = self._read_server_output()
+        return [
+            bytes(event.data).decode() for event in events if isinstance(event, Frame) and event.opcode == Opcode.TEXT
+        ]
+
+    def flush(self) -> None:
+        """Deliver the pending client frames to the server as a single read."""
+        data, self._outbox = self._outbox, b""
+        self._protocol.data_received(data)
+
+    # Transport events and server operations.
+
+    def pause_writing(self) -> None:
+        self._protocol.pause_writing()
+
+    def resume_writing(self) -> None:
+        self._protocol.resume_writing()
+
+    def connection_lost(self) -> None:
+        self._protocol.connection_lost(None)
+
+    def shutdown(self) -> None:
+        self._protocol.shutdown()
+
+    # Server-side observations.
+
+    @property
+    def transport_closed(self) -> bool:
+        return self._transport.closed
+
+    @property
+    def reading_paused(self) -> bool:
+        return self._transport.reading_paused
+
+    @property
+    def awaiting_close_reply(self) -> bool:
+        return self._protocol.close_timer is not None
+
+    # Internals.
+
+    def _stage(self, flush: bool) -> None:
+        self._outbox += b"".join(self._client.data_to_send())
+        if flush:
+            self.flush()
+
+    def _read_response(self) -> None:
+        if self._bytes_read == 0:
+            self._bytes_read = self._transport.buffer.index(b"\r\n\r\n") + 4
+            self._client.receive_data(self._transport.buffer[: self._bytes_read])
+
+    def _read_server_output(self) -> list[Any]:
+        self._read_response()
+        data = self._transport.buffer[self._bytes_read :]
+        self._bytes_read = len(self._transport.buffer)
+        self._client.receive_data(data)
+        return self._client.events_received()
+
+
+async def closing_websocket(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, close_timeout: float = 10.0
+) -> MockWebSocketConnection:
+    """Return a connection whose application accepted and then initiated a close."""
+    close_sent = asyncio.Event()
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        await receive()  # websocket.connect
+        await send({"type": "websocket.accept"})
+        await send({"type": "websocket.close", "code": 1000})
+        close_sent.set()
+
+    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls, close_timeout=close_timeout)
+    await close_sent.wait()
+    # Yield repeatedly so run_asgi() finishes and (wrongly) closes the transport if broken.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    return connection
 
 
 async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1489,66 +1565,39 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
         await send({"type": "websocket.send", "text": "x"})
         send_completed.set()
 
-    protocol, transport, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
-    initial_buffer = transport.buffer
-    protocol.pause_writing()
+    connection.pause_writing()
     send_requested.set()
     # Yield repeatedly so the app task can progress through send() and (wrongly) complete it if unblocked.
     for _ in range(10):
         await asyncio.sleep(0)
     assert not send_completed.is_set()
-    assert transport.buffer == initial_buffer
+    assert connection.receive_text() == []
 
-    protocol.resume_writing()
+    connection.resume_writing()
     await send_completed.wait()
-    assert transport.buffer != initial_buffer
+    assert connection.receive_text() == ["x"]
 
-    protocol.connection_lost(None)
-
-
-async def closing_ws_protocol(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, close_timeout: float = 10.0
-) -> tuple[Any, MockWriteTransport, MockClient]:
-    """Return a protocol just past a server-initiated `websocket.close`, and its transport."""
-    accepted = asyncio.Event()
-    close_sent = asyncio.Event()
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        await receive()  # websocket.connect
-        await send({"type": "websocket.accept"})
-        accepted.set()
-        await send({"type": "websocket.close", "code": 1000})
-        close_sent.set()
-
-    protocol, transport, client = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
-    protocol.close_timeout = close_timeout
-    await accepted.wait()
-    await close_sent.wait()
-    # Yield repeatedly so run_asgi() finishes and (wrongly) closes the transport if broken.
-    for _ in range(10):
-        await asyncio.sleep(0)
-    # The client has read the 101 response; the server's close frame is still in flight.
-    client.read_response(transport)
-    return protocol, transport, client
+    connection.connection_lost()
 
 
 async def test_close_waits_for_the_peer_close_frame(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that a server close leaves the transport open until the peer echoes it.
 
-    Closing it right away makes the peer\'s reply (RFC 6455 5.5.1) land on a closed socket,
+    Closing it right away makes the peer's reply (RFC 6455 5.5.1) land on a closed socket,
     which the kernel answers with a TCP RST that discards data the peer has not read yet.
     See https://github.com/Kludex/uvicorn/issues/3047.
     """
-    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
-    assert not transport.closed
+    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
+    assert not connection.transport_closed
 
-    protocol.data_received(client.read_frames(transport))  # the client echoes the close
-    assert transport.closed
-    assert protocol.close_timer is None
+    connection.reply_to_server_close()
+    assert connection.transport_closed
+    assert not connection.awaiting_close_reply
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
 
 
 async def test_close_resumes_reads_paused_on_an_unconsumed_message(
@@ -1568,66 +1617,67 @@ async def test_close_resumes_reads_paused_on_an_unconsumed_message(
         await send({"type": "websocket.close", "code": 1000})
         close_sent.set()
 
-    protocol, transport, client = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
-    client.read_response(transport)
 
-    protocol.data_received(client.send_text("x"))
-    assert transport.reading_paused
+    connection.send_text("x")
+    assert connection.reading_paused
     message_queued.set()
     await close_sent.wait()
     for _ in range(10):
         await asyncio.sleep(0)
-    assert not transport.reading_paused
-    assert not transport.closed
+    assert not connection.reading_paused
+    assert not connection.transport_closed
 
-    protocol.data_received(client.read_frames(transport))  # the client echoes the close
-    assert transport.closed
+    connection.reply_to_server_close()
+    assert connection.transport_closed
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
 
 
 async def test_data_frame_while_closing_does_not_pause_reads(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that a data frame crossing the server close cannot block the peer close frame."""
-    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
 
-    protocol.data_received(client.send_text("x"))
-    assert not transport.reading_paused
-    assert not transport.closed
+    connection.send_text("x")
+    assert not connection.reading_paused
+    assert not connection.transport_closed
 
-    protocol.data_received(client.read_frames(transport))  # the client echoes the close
-    assert transport.closed
+    connection.reply_to_server_close()
+    assert connection.transport_closed
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
 
 
 async def test_data_frame_and_peer_close_frame_in_one_read(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that a peer close frame is processed even when preceded by data in the same read."""
-    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
 
-    protocol.data_received(client.send_text("x") + client.read_frames(transport))
-    assert transport.closed
-    assert protocol.close_timer is None
+    connection.send_text("x", flush=False)
+    connection.reply_to_server_close(flush=False)
+    connection.flush()
+    assert connection.transport_closed
+    assert not connection.awaiting_close_reply
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
 
 
 async def test_ping_while_closing(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that a ping crossing the server close cannot break the closing handshake."""
-    protocol, transport, client = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
+    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
 
-    protocol.data_received(client.send_ping())
-    assert not transport.reading_paused
-    assert not transport.closed
+    connection.send_ping()
+    assert not connection.reading_paused
+    assert not connection.transport_closed
 
-    protocol.data_received(client.read_frames(transport))  # the client echoes the close
-    assert transport.closed
+    connection.reply_to_server_close()
+    assert connection.transport_closed
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
 
 
 async def test_close_gives_up_when_the_peer_never_replies(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1635,35 +1685,35 @@ async def test_close_gives_up_when_the_peer_never_replies(ws_protocol_cls: WSPro
 
     RFC 6455 7.1.1 lets the server close the connection once the reply is late.
     """
-    protocol, transport, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls, close_timeout=0)
+    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls, close_timeout=0)
     # The zero-delay close timer has already fired during the helper's yields.
-    assert transport.closed
+    assert connection.transport_closed
 
-    protocol.connection_lost(None)
-    assert protocol.close_timer is None
+    connection.connection_lost()
+    assert not connection.awaiting_close_reply
 
 
 async def test_connection_lost_cancels_the_pending_close_timer(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol
 ):
     """Test that losing the connection stops waiting for the peer close frame."""
-    protocol, _, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
-    assert protocol.close_timer is not None
+    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
+    assert connection.awaiting_close_reply
 
-    protocol.connection_lost(None)
-    assert protocol.close_timer is None
+    connection.connection_lost()
+    assert not connection.awaiting_close_reply
 
 
 async def test_shutdown_while_the_close_reply_is_pending(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
     """Test that server shutdown does not send a second close frame during the handshake."""
-    protocol, transport, _ = await closing_ws_protocol(ws_protocol_cls, http_protocol_cls)
-    assert not transport.closed
+    connection = await closing_websocket(ws_protocol_cls, http_protocol_cls)
+    assert not connection.transport_closed
 
-    protocol.shutdown()
-    assert transport.closed
-    assert protocol.close_timer is None
+    connection.shutdown()
+    assert connection.transport_closed
+    assert not connection.awaiting_close_reply
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
 
 
 async def test_send_after_peer_close_raises_client_disconnected(
@@ -1684,15 +1734,14 @@ async def test_send_after_peer_close_raises_client_disconnected(
         except OSError:
             send_failed.set()
 
-    protocol, transport, client = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
-    client.read_response(transport)
 
     # The peer closes the WebSocket before the transport invokes connection_lost().
-    protocol.data_received(client.send_close())
+    connection.send_close()
     await asyncio.wait_for(send_failed.wait(), timeout=1)
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
 
 
 async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol):
@@ -1714,17 +1763,17 @@ async def test_connection_lost_unblocks_paused_send(ws_protocol_cls: WSProtocol,
         finally:
             app_finished.set()
 
-    protocol, _, _ = connected_ws_protocol(app, ws_protocol_cls, http_protocol_cls)
+    connection = MockWebSocketConnection(app, ws_protocol_cls, http_protocol_cls)
     await accepted.wait()
 
-    protocol.pause_writing()
+    connection.pause_writing()
     send_requested.set()
     # Yield repeatedly so the app task reaches the blocking wait inside send().
     for _ in range(10):
         await asyncio.sleep(0)
     assert not app_finished.is_set()
 
-    protocol.connection_lost(None)
+    connection.connection_lost()
     await asyncio.wait_for(app_finished.wait(), timeout=1)
     assert send_failed.is_set()
 

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1476,7 +1476,7 @@ async def test_send_respects_write_backpressure(ws_protocol_cls: WSProtocol, htt
     protocol.connection_lost(None)
 
 
-@pytest.mark.parametrize("outcome", ["reply", "timeout", "connection_lost"])
+@pytest.mark.parametrize("outcome", ["reply", "data_then_reply", "same_read", "timeout", "connection_lost", "shutdown"])
 async def test_server_initiated_close(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, outcome: str):
     """Test that a server close waits for its reply, with bounded cleanup."""
     accepted = asyncio.Event()
@@ -1510,9 +1510,22 @@ async def test_server_initiated_close(ws_protocol_cls: WSProtocol, http_protocol
         assert not transport.reading_paused
         assert not transport.closed
         protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
+    elif outcome == "data_then_reply":
+        protocol.data_received(b"\x81\x81\x00\x00\x00\x00x")  # masked text, payload "x"
+        assert not transport.reading_paused
+        assert not transport.closed
+        protocol.data_received(b"\x88\x82\x00\x00\x00\x00\x03\xe8")  # masked close, code 1000
+    elif outcome == "same_read":
+        protocol.data_received(
+            b"\x81\x81\x00\x00\x00\x00x"  # masked text, payload "x"
+            b"\x88\x82\x00\x00\x00\x00\x03\xe8"  # masked close, code 1000
+        )
     elif outcome == "connection_lost":
         assert not transport.closed
         protocol.connection_lost(None)
+    elif outcome == "shutdown":
+        assert not transport.closed
+        protocol.shutdown()
     else:
         assert transport.closed
 

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -188,10 +188,6 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     def handle_events(self) -> None:
         for event in self.conn.events_received():
-            if self.close_sent and isinstance(event, Frame):
-                if event.opcode == Opcode.CLOSE:
-                    self.handle_close(event)
-                continue
             if isinstance(event, Request):
                 self.handle_connect(event)
             if isinstance(event, Frame):
@@ -281,6 +277,10 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
     def send_receive_event_to_app(self) -> None:
         data = self.frames[0] if len(self.frames) == 1 else b"".join(self.frames)
         self.frames = []
+        if self.close_sent:
+            # The app is past `websocket.close`: discard the message rather than queueing
+            # it, so reads stay active until the peer's close reply arrives.
+            return
         if self.curr_msg_data_type == "text":
             try:
                 self.queue.put_nowait({"type": "websocket.receive", "text": data.decode()})

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -361,12 +361,14 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.transport.close()
 
     def handle_close(self, event: Frame) -> None:
-        if self.close_timer is not None:
-            self.close_timer.cancel()
-            self.close_timer = None
-            self.transport.close()
+        if self.close_sent:
+            # The peer echoed our close frame: the closing handshake is complete.
+            if self.close_timer is not None:
+                self.close_timer.cancel()
+                self.close_timer = None
+                self.transport.close()
             return
-        if not self.close_sent and not self.transport.is_closing():
+        if not self.transport.is_closing():
             assert self.conn.close_rcvd is not None
             code = self.conn.close_rcvd.code
             reason = self.conn.close_rcvd.reason

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -77,6 +77,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.handshake_complete = False
         self.close_sent = False
         self.disconnected = False
+        self.close_timer: TimerHandle | None = None
+        self.close_timeout = 10.0
         self.initial_response: tuple[int, list[tuple[str, str]], bytes] | None = None
 
         extensions = []
@@ -139,6 +141,9 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         # Unblock any send() awaiting writable: asyncio never calls resume_writing() on a
         # transport that is lost while paused, and the buffer will never drain now.
         self.writable.set()
+        if self.close_timer is not None:
+            self.close_timer.cancel()
+            self.close_timer = None
         if exc is None:
             self.transport.close()
 
@@ -346,6 +351,11 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
         self.transport.close()
 
     def handle_close(self, event: Frame) -> None:
+        if self.close_timer is not None:
+            self.close_timer.cancel()
+            self.close_timer = None
+            self.transport.close()
+            return
         if not self.close_sent and not self.transport.is_closing():
             assert self.conn.close_rcvd is not None
             code = self.conn.close_rcvd.code
@@ -384,7 +394,8 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 self.send_500_response()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-        self.transport.close()
+        if self.close_timer is None:
+            self.transport.close()
 
     def send_500_response(self) -> None:
         if self.initial_response or self.handshake_complete:
@@ -478,7 +489,10 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                         output = self.conn.data_to_send()
                         self.transport.write(b"".join(output))
                         self.close_sent = True
-                        self.transport.close()
+                        if self.read_paused:
+                            self.read_paused = False
+                            self.transport.resume_reading()
+                        self.close_timer = self.loop.call_later(self.close_timeout, self.transport.close)
                 else:
                     raise RuntimeError(
                         f"Expected ASGI message 'websocket.send' or 'websocket.close', but got '{message['type']}'."

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -164,6 +164,12 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     def shutdown(self) -> None:
         self.stop_keepalive()
+        if self.close_sent:
+            if self.close_timer is not None:
+                self.close_timer.cancel()
+                self.close_timer = None
+            self.transport.close()
+            return
         if self.handshake_complete:
             self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
             self.conn.send_close(1012)
@@ -182,6 +188,10 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
 
     def handle_events(self) -> None:
         for event in self.conn.events_received():
+            if self.close_sent and isinstance(event, Frame):
+                if event.opcode == Opcode.CLOSE:
+                    self.handle_close(event)
+                continue
             if isinstance(event, Request):
                 self.handle_connect(event)
             if isinstance(event, Frame):

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -181,7 +181,7 @@ class WSProtocol(asyncio.Protocol):
                     self.close_timer.cancel()
                     self.close_timer = None
                     self.transport.close()
-                return
+                continue
             if isinstance(event, events.Request):
                 self.handle_connect(event)
             elif isinstance(event, (events.TextMessage, events.BytesMessage)):
@@ -207,6 +207,12 @@ class WSProtocol(asyncio.Protocol):
 
     def shutdown(self) -> None:
         self.stop_keepalive()
+        if self.close_sent:
+            if self.close_timer is not None:
+                self.close_timer.cancel()
+                self.close_timer = None
+            self.transport.close()
+            return
         if self.handshake_complete:
             self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
             output = self.conn.send(wsproto.events.CloseConnection(code=1012))

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -177,10 +177,8 @@ class WSProtocol(asyncio.Protocol):
     def handle_events(self) -> None:
         for event in self.conn.events():
             if self.close_sent:
-                if isinstance(event, events.CloseConnection) and self.close_timer is not None:
-                    self.close_timer.cancel()
-                    self.close_timer = None
-                    self.transport.close()
+                if isinstance(event, events.CloseConnection):
+                    self.handle_close(event)
                 continue
             if isinstance(event, events.Request):
                 self.handle_connect(event)
@@ -273,6 +271,13 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.pause_reading()
 
     def handle_close(self, event: events.CloseConnection) -> None:
+        if self.close_sent:
+            # The peer echoed our close frame: the closing handshake is complete.
+            if self.close_timer is not None:
+                self.close_timer.cancel()
+                self.close_timer = None
+                self.transport.close()
+            return
         if self.conn.state == ConnectionState.REMOTE_CLOSING:
             self.transport.write(self.conn.send(event.response()))
         self.queue.put_nowait({"type": "websocket.disconnect", "code": event.code, "reason": event.reason})

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -100,6 +100,8 @@ class WSProtocol(asyncio.Protocol):
         self.handshake_complete = False
         self.close_sent = False
         self.disconnected = False
+        self.close_timer: TimerHandle | None = None
+        self.close_timeout = 10.0
 
         # Rejection state
         self.response_started = False
@@ -149,6 +151,9 @@ class WSProtocol(asyncio.Protocol):
         self.disconnected = True
         # asyncio never calls resume_writing() when a paused transport is lost.
         self.writable.set()
+        if self.close_timer is not None:
+            self.close_timer.cancel()
+            self.close_timer = None
         if exc is None:
             self.transport.close()
 
@@ -172,6 +177,10 @@ class WSProtocol(asyncio.Protocol):
     def handle_events(self) -> None:
         for event in self.conn.events():
             if self.close_sent:
+                if isinstance(event, events.CloseConnection) and self.close_timer is not None:
+                    self.close_timer.cancel()
+                    self.close_timer = None
+                    self.transport.close()
                 return
             if isinstance(event, events.Request):
                 self.handle_connect(event)
@@ -351,7 +360,8 @@ class WSProtocol(asyncio.Protocol):
                 self.send_500_response()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-        self.transport.close()
+        if self.close_timer is None:
+            self.transport.close()
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()
@@ -442,7 +452,10 @@ class WSProtocol(asyncio.Protocol):
                     output = self.conn.send(wsproto.events.CloseConnection(code=code, reason=reason))
                     if not self.transport.is_closing():
                         self.transport.write(output)
-                        self.transport.close()
+                        if self.read_paused:
+                            self.read_paused = False
+                            self.transport.resume_reading()
+                        self.close_timer = self.loop.call_later(self.close_timeout, self.transport.close)
 
                 else:
                     raise RuntimeError(


### PR DESCRIPTION
## Summary

Fixes the remaining server-initiated close race from #3047 and #3049 in both SansIO WebSocket implementations.

After writing a close frame, both implementations currently call `transport.close()` immediately. The peer’s required close reply then lands on a closed socket, producing a TCP RST that can discard unread payload. Write flow control only masks this above the backpressure threshold; smaller payloads can still be reset or lost.

## Changes

In both `websockets-sansio` and wsproto:

- Keep the transport open after a server-initiated close frame.
- Close it when the peer’s close frame arrives.
- Schedule `transport.close()` after 10 seconds if the peer never replies, matching the `websockets` default.
- Resume reads if they were paused on an unconsumed ASGI message.
- Cancel the pending fallback when the peer replies or the connection is lost.
- If server shutdown interrupts a pending handshake, cancel the timer and close the transport without sending a duplicate close frame.

While waiting:

- `websockets-sansio` discards non-close frames so application-message backpressure cannot pause reads before the close reply.
- wsproto continues draining all events from each read, so a data/control event cannot hide a following `CloseConnection` event.

The fallback is scheduled inline with `loop.call_later`; there is no `defer_close` helper or additional close abstraction.

## Test

One parametrized closing-handshake test runs the same scenarios against both implementations:

- peer reply;
- data followed by a close reply in a later read;
- data and close reply in the same read;
- bounded no-reply timeout;
- connection loss while waiting;
- server shutdown while waiting.

The existing flow-control test sends a data message rather than using `websocket.close`, keeping flow control and closing-handshake behavior independently tested.

## Verification

- Closing-handshake test: 36 passed.
- Full suite under coverage: 1233 passed, 17 skipped, 100% coverage.
- All three reported review scenarios reproduce before `cf3b0f7` and pass after it.
- Payload-size/RTT matrix: all 18 rows pass across legacy `websockets`, `websockets-sansio`, and wsproto.
- Ruff and mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket backpressure handling so sending pauses safely when the connection cannot accept more data and resumes when available.
  * Improved graceful WebSocket shutdown by allowing close responses to complete before closing the connection.
  * Added safeguards for peer disconnects, connection loss, and shutdown, including cleanup of pending close operations and timers.
  * Ensured paused reads resume correctly during application-initiated WebSocket closes.

* **Tests**
  * Added coverage for paused writes, resumed sends, close handshakes, timeouts, shutdown, and unexpected connection loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->