### PR TITLE
Version 0.52.1

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,15 @@
 toc_depth: 2
 ---
 
+## 0.52.1 (August 1, 2026)
+
+### Fixed
+
+* Complete the closing handshake on server-initiated WebSocket closes in the `websockets-sansio` and `wsproto` implementations, waiting for the client's close reply with a 10 second timeout instead of resetting the connection (#3053)
+* Add missing write flow control to the `websockets-sansio` implementation, preventing data truncation on server-initiated closes with large in-flight payloads (#3048)
+* Handle connection loss while a WebSocket write is waiting on backpressure (#3050)
+* Remove duplicate `Content-Type` and `Content-Length` headers from WebSocket denial responses on the `websockets-sansio` implementation, and deliver non-UTF-8 denial bodies intact (#3041)
+
 ## 0.52.0 (July 29, 2026)
 
 This release adds an experimental HTTP/1.1 implementation backed by [zttp](https://zttp.marcelotryle.com/), a sans-IO HTTP parser I've been developing on the side: a core written in Zig, with bindings to Python. It has been running under a fuzzer for some weeks now, and has been through multiple rounds of security auditing.

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.52.0"
+__version__ = "0.52.1"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## Fixed

* Complete the closing handshake on server-initiated WebSocket closes in the websockets-sansio and wsproto implementations (#3053)
* Add missing write flow control to the websockets-sansio implementation (#3048)
* Handle connection loss while a WebSocket write is waiting on backpressure (#3050)
* Remove duplicate content headers from WebSocket denial responses on websockets-sansio (#3041)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

