### PR TITLE
Add regression test for client disconnect before websocket.accept

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -529,6 +529,52 @@ async def test_client_close(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTP
     assert disconnect_message == {"type": "websocket.disconnect", "code": 1001, "reason": "custom reason"}
 
 
+async def test_client_disconnect_before_accept(
+    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
+):
+    """A peer that disconnects before the application accepts must not look like a
+    duplicate accept.
+
+    ``connection_lost`` marks the handshake as complete, so an application that calls
+    ``websocket.accept`` afterwards used to fall into the post-handshake branch of
+    ``send`` and raise ``RuntimeError: Expected ASGI message 'websocket.send' or
+    'websocket.close'``. The disconnect should surface as ``ClientDisconnected``
+    instead, which ``run_asgi`` already handles.
+    """
+    send_error: BaseException | None = None
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        nonlocal send_error
+        message = await receive()
+        assert message["type"] == "websocket.connect"
+        # Give the client time to drop the connection before we accept it.
+        await asyncio.sleep(0.1)
+        try:
+            await send({"type": "websocket.accept"})
+        except BaseException as exc:  # pragma: no cover - recorded for the assertion
+            send_error = exc
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
+    async with run_server(config):
+        _, writer = await asyncio.open_connection("127.0.0.1", unused_tcp_port)
+        writer.write(
+            (
+                "GET /ws HTTP/1.1\r\n"
+                f"Host: 127.0.0.1:{unused_tcp_port}\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                "Sec-WebSocket-Version: 13\r\n\r\n"
+            ).encode()
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+        await asyncio.sleep(0.25)
+
+    assert not isinstance(send_error, RuntimeError), f"accept after disconnect raised {send_error!r}"
+
+
 async def test_client_connection_lost(
     ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
 ):

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -30,6 +30,7 @@ from uvicorn._types import (
     WebSocketResponseStartEvent,
 )
 from uvicorn.config import Config
+from uvicorn.protocols.utils import ClientDisconnected
 from uvicorn.protocols.websockets.websockets_sansio_impl import WebSocketsSansIOProtocol
 from uvicorn.server import ServerState
 
@@ -541,18 +542,23 @@ async def test_client_disconnect_before_accept(
     'websocket.close'``. The disconnect should surface as ``ClientDisconnected``
     instead, which ``run_asgi`` already handles.
     """
-    send_error: BaseException | None = None
+    send_error: Exception | None = None
+    app_finished = asyncio.Event()
 
     async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
         nonlocal send_error
         message = await receive()
         assert message["type"] == "websocket.connect"
-        # Give the client time to drop the connection before we accept it.
-        await asyncio.sleep(0.1)
+        # Wait for the peer to actually go away instead of sleeping a fixed amount, so
+        # the accept below is guaranteed to happen after connection_lost().
+        message = await receive()
+        assert message["type"] == "websocket.disconnect"
         try:
             await send({"type": "websocket.accept"})
-        except BaseException as exc:  # pragma: no cover - recorded for the assertion
+        except Exception as exc:
             send_error = exc
+        finally:
+            app_finished.set()
 
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
     async with run_server(config):
@@ -570,9 +576,9 @@ async def test_client_disconnect_before_accept(
         await writer.drain()
         writer.close()
         await writer.wait_closed()
-        await asyncio.sleep(0.25)
+        await asyncio.wait_for(app_finished.wait(), timeout=5)
 
-    assert not isinstance(send_error, RuntimeError), f"accept after disconnect raised {send_error!r}"
+    assert isinstance(send_error, ClientDisconnected), f"expected ClientDisconnected, got {send_error!r}"
 
 
 async def test_client_connection_lost(


### PR DESCRIPTION
Adds a regression test for the pre-handshake disconnect reported in #3052.

## The bug

When a peer disconnects after the WebSocket request is parsed but before the ASGI
application accepts it, `connection_lost()` marks the handshake as complete. A later
`websocket.accept` from the application then falls into the post-handshake branch of `send()`:

```
RuntimeError: Expected ASGI message 'websocket.send' or 'websocket.close', but got 'websocket.accept'.
```

## Why this is a test-only PR

This is already fixed on master — but as a **side effect** of a different change, so nothing
currently guards it.

#3050 ("Handle connection loss during WebSocket write backpressure") introduced a separate
`disconnected` flag and a guard at the very top of `send()`:

```python
self.disconnected = True     # connection_lost()

await self.writable.wait()   # send()
if self.disconnected:
    raise ClientDisconnected()
```

Because that check runs *before* any handshake-state branching, a pre-handshake disconnect now
raises `ClientDisconnected` — which `run_asgi()` already handles — instead of the RuntimeError.
That is exactly the behaviour asked for in #3052.

Since #3050 was aimed at write backpressure rather than this race, the pre-handshake case is
fixed but untested, and a future refactor of the disconnect handling could quietly reintroduce it.

## Verification

The test asserts that `websocket.accept` after a client disconnect does not raise `RuntimeError`.
I ran it against both implementations by swapping in the 0.52.0 `websockets_sansio_impl.py`:

```
0.52.0 implementation   1 failed, 1 passed
master                  2 passed
```

Full websocket suite on master: `144 passed, 297 skipped`. `ruff check` and `ruff format --check`
are clean.

The test is parametrised over the existing `ws_protocol_cls` / `http_protocol_cls` fixtures, so it
covers wsproto as well as websockets-sansio.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a client disconnects before a WebSocket connection is accepted.
  * Prevented an unexpected runtime error during interrupted connection handshakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->