### PR TITLE
Support ASGI spec version 2.5 in WebSocket protocols

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -22,6 +22,7 @@ from uvicorn._types import (
     ASGIReceiveCallable,
     ASGIReceiveEvent,
     ASGISendCallable,
+    ASGIVersions,
     Scope,
     WebSocketCloseEvent,
     WebSocketConnectEvent,
@@ -129,6 +130,24 @@ async def test_accept_connection(ws_protocol_cls: WSProtocol, http_protocol_cls:
     async with run_server(config):
         is_open = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
         assert is_open
+
+
+async def test_asgi_spec_version(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
+    asgi: ASGIVersions | None = None
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        nonlocal asgi
+        assert scope["type"] == "websocket"
+        asgi = scope["asgi"]
+        await receive()
+        await send({"type": "websocket.accept"})
+
+    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
+    async with run_server(config):
+        async with connect(f"ws://127.0.0.1:{unused_tcp_port}"):
+            pass
+
+    assert asgi == {"version": "3.0", "spec_version": "2.5"}
 
 
 async def test_shutdown(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
@@ -621,7 +640,7 @@ async def test_connection_lost_before_handshake_complete(
         send_accept_task.set()
         await asyncio.sleep(0.1)
 
-    assert disconnect_message == {"type": "websocket.disconnect", "code": 1006}
+    assert disconnect_message == {"type": "websocket.disconnect", "code": 1006, "reason": ""}
     await task
 
 
@@ -659,7 +678,7 @@ async def test_send_close_on_server_shutdown(
     assert websocket is not None
     assert websocket.close_code == 1012
     assert disconnect_message_before_shutdown == {}
-    assert disconnect_message == {"type": "websocket.disconnect", "code": 1012}
+    assert disconnect_message == {"type": "websocket.disconnect", "code": 1012, "reason": ""}
     task.cancel()
 
 
@@ -846,7 +865,7 @@ async def test_server_reject_connection(
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
-    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
+    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006, "reason": ""}
 
 
 class EmptyDict(TypedDict): ...
@@ -880,7 +899,7 @@ async def test_server_reject_connection_with_response(
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
-    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
+    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006, "reason": ""}
 
 
 async def test_server_reject_connection_with_custom_content_headers(
@@ -973,7 +992,7 @@ async def test_server_reject_connection_with_multibody_response(
     async with run_server(config):
         await websocket_session(f"ws://127.0.0.1:{unused_tcp_port}")
 
-    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006}
+    assert disconnected_message == {"type": "websocket.disconnect", "code": 1006, "reason": ""}
 
 
 async def test_server_reject_connection_with_invalid_status(

--- a/uvicorn/_types.py
+++ b/uvicorn/_types.py
@@ -192,7 +192,7 @@ class WebSocketResponseBodyEvent(TypedDict):
 class WebSocketDisconnectEvent(TypedDict):
     type: Literal["websocket.disconnect"]
     code: int
-    reason: NotRequired[str | None]
+    reason: str
 
 
 class WebSocketCloseEvent(TypedDict):

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -196,7 +196,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
 
         self.scope = {
             "type": "websocket",
-            "asgi": {"version": self.asgi_version, "spec_version": "2.4"},
+            "asgi": {"version": self.asgi_version, "spec_version": "2.5"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,
@@ -372,18 +372,18 @@ class WebSocketProtocol(WebSocketServerProtocol):
         if self.lost_connection_before_handshake:
             # If the handshake failed or the app closed before handshake completion,
             # use 1006 Abnormal Closure.
-            return {"type": "websocket.disconnect", "code": 1006}
+            return {"type": "websocket.disconnect", "code": 1006, "reason": ""}
 
         if self.closed_event.is_set():
-            return {"type": "websocket.disconnect", "code": 1005}
+            return {"type": "websocket.disconnect", "code": 1005, "reason": ""}
 
         try:
             data = await self.recv()
         except ConnectionClosed:
             self.closed_event.set()
             if self.ws_server.closing:
-                return {"type": "websocket.disconnect", "code": 1012}
-            return {"type": "websocket.disconnect", "code": self.close_code or 1005, "reason": self.close_reason}
+                return {"type": "websocket.disconnect", "code": 1012, "reason": ""}
+            return {"type": "websocket.disconnect", "code": self.close_code or 1005, "reason": self.close_reason or ""}
 
         if isinstance(data, str):
             return {"type": "websocket.receive", "text": data}

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -141,7 +141,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
     def connection_lost(self, exc: Exception | None) -> None:
         self.stop_keepalive()
         code = 1005 if self.handshake_complete else 1006
-        self.queue.put_nowait({"type": "websocket.disconnect", "code": code})
+        self.queue.put_nowait({"type": "websocket.disconnect", "code": code, "reason": ""})
         self.connections.remove(self)
 
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -183,7 +183,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             self.transport.close()
             return
         if self.handshake_complete:
-            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
+            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012, "reason": ""})
             self.conn.send_close(1012)
             output = self.conn.data_to_send()
             self.transport.write(b"".join(output))
@@ -250,7 +250,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
             subprotocols.extend([token.strip() for token in header.split(",")])
         self.scope: WebSocketScope = {
             "type": "websocket",
-            "asgi": {"version": self.asgi_version, "spec_version": "2.4"},
+            "asgi": {"version": self.asgi_version, "spec_version": "2.5"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,
@@ -459,7 +459,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                     self.start_keepalive()
 
             elif message["type"] == "websocket.close":
-                self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
+                self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006, "reason": ""})
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     get_client_addr(self.scope),
@@ -535,7 +535,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                     response_headers.setdefault("Content-Length", str(len(body)))
                     response_headers.setdefault("Content-Type", "text/plain; charset=utf-8")
                     response = Response(status_code, STATUS_PHRASES[status_code], response_headers, body)
-                    self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
+                    self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006, "reason": ""})
                     self.conn.send_response(response)
                     output = self.conn.data_to_send()
                     self.close_sent = True

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -140,7 +140,7 @@ class WSProtocol(asyncio.Protocol):
     def connection_lost(self, exc: Exception | None) -> None:
         self.stop_keepalive()
         code = 1005 if self.handshake_complete else 1006
-        self.queue.put_nowait({"type": "websocket.disconnect", "code": code})
+        self.queue.put_nowait({"type": "websocket.disconnect", "code": code, "reason": ""})
         self.connections.remove(self)
 
         if self.logger.level <= TRACE_LOG_LEVEL:
@@ -212,7 +212,7 @@ class WSProtocol(asyncio.Protocol):
             self.transport.close()
             return
         if self.handshake_complete:
-            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012})
+            self.queue.put_nowait({"type": "websocket.disconnect", "code": 1012, "reason": ""})
             output = self.conn.send(wsproto.events.CloseConnection(code=1012))
             self.transport.write(output)
         else:
@@ -233,7 +233,7 @@ class WSProtocol(asyncio.Protocol):
         full_raw_path = self.root_path.encode("ascii") + raw_path.encode("ascii")
         self.scope: WebSocketScope = {
             "type": "websocket",
-            "asgi": {"version": self.asgi_version, "spec_version": "2.4"},
+            "asgi": {"version": self.asgi_version, "spec_version": "2.5"},
             "http_version": "1.1",
             "scheme": self.scheme,
             "server": self.server,
@@ -280,7 +280,7 @@ class WSProtocol(asyncio.Protocol):
             return
         if self.conn.state == ConnectionState.REMOTE_CLOSING:
             self.transport.write(self.conn.send(event.response()))
-        self.queue.put_nowait({"type": "websocket.disconnect", "code": event.code, "reason": event.reason})
+        self.queue.put_nowait({"type": "websocket.disconnect", "code": event.code, "reason": event.reason or ""})
         self.transport.close()
 
     def handle_ping(self, event: events.Ping) -> None:
@@ -405,7 +405,7 @@ class WSProtocol(asyncio.Protocol):
                     self.start_keepalive()
 
             elif message["type"] == "websocket.close":
-                self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
+                self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006, "reason": ""})
                 self.logger.info(
                     '%s - "WebSocket %s" 403',
                     get_client_addr(self.scope),
@@ -482,7 +482,7 @@ class WSProtocol(asyncio.Protocol):
                 self.transport.write(output)
 
                 if body_finished:
-                    self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006})
+                    self.queue.put_nowait({"type": "websocket.disconnect", "code": 1006, "reason": ""})
                     self.close_sent = True
                     self.transport.close()
 


### PR DESCRIPTION
WebSocket scopes now advertise `spec_version` `2.5`.

The only change between www spec `2.4` and `2.5` is the `reason` key on the `websocket.disconnect` event. Uvicorn already sent it on the paths where a close frame carried one, but not on the rest, so this makes it unconditional across all three implementations:

- `connection_lost` (1005/1006), `shutdown` (1012), the pre-handshake 403 close (1006), and denial-response completion (1006) now emit `"reason": ""`.
- `wsproto`'s `event.reason` and legacy `websockets`' `close_reason` are normalized with `or ""`, since both can be `None`.
- `WebSocketDisconnectEvent.reason` is now a required `str` instead of `NotRequired[str | None]`, which is what caught the remaining gaps under mypy.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated WebSocket connections to advertise ASGI WebSocket specification version 2.5.
  * WebSocket disconnect events now consistently include a reason, using an empty value when none is available.
  * Preserved provided close reasons for normal WebSocket disconnections.

* **Tests**
  * Added coverage verifying WebSocket scope metadata and disconnect reason behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->