### PR TITLE
Reject a non-numeric content-length instead of raising ValueError

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -370,11 +370,10 @@ async def test_invalid_content_length_value(
     assert b"HTTP/1.1 500 Internal Server Error" not in protocol.transport.buffer
     assert protocol.transport.is_closing()
 
-    errors = [r for r in caplog.records if r.exc_info]
-    assert errors, "the invalid header should have been reported"
-    raised = errors[-1].exc_info[0]
-    assert raised is not ValueError, "content-length must not fail with a bare ValueError"
-    assert issubclass(raised, (RuntimeError, LocalProtocolError))
+    raised = [r.exc_info[1] for r in caplog.records if r.exc_info and r.exc_info[1] is not None]
+    assert raised, "the invalid header should have been reported"
+    assert not isinstance(raised[-1], ValueError), "content-length must not fail with a bare ValueError"
+    assert isinstance(raised[-1], (RuntimeError, LocalProtocolError))
 
 
 @pytest.mark.parametrize("path", ["/", "/?foo", "/?foo=bar", "/?foo=bar&baz=1"])

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -349,6 +349,12 @@ async def test_invalid_header_name(http_protocol_cls: type[HTTPProtocol], name: 
         pytest.param("abc", id="reject_non_numeric"),
         pytest.param("", id="reject_empty"),
         pytest.param("1 2", id="reject_embedded_space"),
+        # `int()` accepts these, but RFC 9110 does not: Content-Length is
+        # 1*DIGIT, with no sign, separator or surrounding whitespace.
+        pytest.param("-1", id="reject_negative"),
+        pytest.param("+12", id="reject_leading_plus"),
+        pytest.param("1_2", id="reject_underscore_separator"),
+        pytest.param(" 12", id="reject_leading_space"),
     ],
 )
 async def test_invalid_content_length_value(

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 import pytest
-from h11._util import LocalProtocolError
+from h11 import LocalProtocolError
 
 from tests.response import Response
 from uvicorn import Server

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 import pytest
+from h11._util import LocalProtocolError
 
 from tests.response import Response
 from uvicorn import Server
@@ -340,6 +341,40 @@ async def test_invalid_header_name(http_protocol_cls: type[HTTPProtocol], name: 
     assert b"HTTP/1.1 500 Internal Server Error" not in protocol.transport.buffer
     assert name.encode() not in protocol.transport.buffer
     assert protocol.transport.is_closing()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("abc", id="reject_non_numeric"),
+        pytest.param("", id="reject_empty"),
+        pytest.param("1 2", id="reject_embedded_space"),
+    ],
+)
+async def test_invalid_content_length_value(
+    http_protocol_cls: type[HTTPProtocol], value: str, caplog: pytest.LogCaptureFixture
+):
+    """
+    A non-numeric content-length must be rejected the same way as any other bad
+    header value, rather than escaping as a bare `ValueError` from `int()`.
+    """
+    app = Response("Hello, world", media_type="text/plain", headers={"content-length": value})
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    with caplog.at_level(logging.ERROR, logger="uvicorn.error"):
+        protocol.data_received(SIMPLE_GET_REQUEST)
+        await protocol.loop.run_one()
+
+    # `response_started` is set before header validation, so the error handler
+    # only closes the connection -- the exception type is what distinguishes a
+    # handled rejection from the raw int() failure.
+    assert b"HTTP/1.1 500 Internal Server Error" not in protocol.transport.buffer
+    assert protocol.transport.is_closing()
+
+    errors = [r for r in caplog.records if r.exc_info]
+    assert errors, "the invalid header should have been reported"
+    raised = errors[-1].exc_info[0]
+    assert raised is not ValueError, "content-length must not fail with a bare ValueError"
+    assert issubclass(raised, (RuntimeError, LocalProtocolError))
 
 
 @pytest.mark.parametrize("path", ["/", "/?foo", "/?foo=bar", "/?foo=bar&baz=1"])

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -502,10 +502,15 @@ class RequestResponseCycle:
 
                 name = name.lower()
                 if name == b"content-length" and self.chunked_encoding is None:
-                    try:
-                        self.expected_content_length = int(value.decode())
-                    except ValueError:
-                        raise RuntimeError("Invalid HTTP header value for content-length.") from None
+                    # RFC 9110 requires Content-Length to be 1*DIGIT. `int()` is
+                    # more permissive than that -- it accepts a sign, underscore
+                    # separators and surrounding whitespace -- so check the bytes
+                    # before converting. A negative value would otherwise reach
+                    # the length bookkeeping below and be reported as a body
+                    # length mismatch rather than a bad header.
+                    if not value.isdigit():
+                        raise RuntimeError("Invalid HTTP header value for content-length.")
+                    self.expected_content_length = int(value)
                     self.chunked_encoding = False
                 elif name == b"transfer-encoding" and value.lower() == b"chunked":
                     self.expected_content_length = 0

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -502,7 +502,10 @@ class RequestResponseCycle:
 
                 name = name.lower()
                 if name == b"content-length" and self.chunked_encoding is None:
-                    self.expected_content_length = int(value.decode())
+                    try:
+                        self.expected_content_length = int(value.decode())
+                    except ValueError:
+                        raise RuntimeError("Invalid HTTP header value for content-length.") from None
                     self.chunked_encoding = False
                 elif name == b"transfer-encoding" and value.lower() == b"chunked":
                     self.expected_content_length = 0

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -438,7 +438,10 @@ class RequestResponseCycle:
                 name = name.lower()
                 if name == b"content-length":
                     has_content_length = True
-                    self.expected_content_length = int(value.decode())
+                    try:
+                        self.expected_content_length = int(value.decode())
+                    except ValueError:
+                        raise RuntimeError("Invalid HTTP header value for content-length.") from None
                 elif name == b"transfer-encoding":
                     # zttp only accepts a sole, final `chunked` coding - anything
                     # else raises, like h11 - and it frames the body itself, so

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -438,10 +438,11 @@ class RequestResponseCycle:
                 name = name.lower()
                 if name == b"content-length":
                     has_content_length = True
-                    try:
-                        self.expected_content_length = int(value.decode())
-                    except ValueError:
-                        raise RuntimeError("Invalid HTTP header value for content-length.") from None
+                    # RFC 9110 requires Content-Length to be 1*DIGIT; `int()`
+                    # also accepts a sign, underscores and whitespace.
+                    if not value.isdigit():
+                        raise RuntimeError("Invalid HTTP header value for content-length.")
+                    self.expected_content_length = int(value)
                 elif name == b"transfer-encoding":
                     # zttp only accepts a sole, final `chunked` coding - anything
                     # else raises, like h11 - and it frames the body itself, so


### PR DESCRIPTION
`send()` in the httptools implementation validates header names and values and
raises RuntimeError for anything malformed, then hands the content-length
straight to `int()`:

    if HEADER_VALUE_RE.search(value):
        raise RuntimeError("Invalid HTTP header value.")
    ...
    if name == b"content-length" and self.chunked_encoding is None:
        self.expected_content_length = int(value.decode())

HEADER_VALUE_RE only blocks control characters, so `content-length: abc` gets
through it and then blows up as `ValueError: invalid literal for int() with
base 10: 'abc'` from inside the protocol. The client just sees the connection
close — no 500, no response at all.

What made me look: the h11 implementation rejects the exact same value cleanly,
because h11 validates it with `_content_length_re` and raises
`LocalProtocolError: bad Content-Length`. So the two HTTP implementations
behave differently on identical input, and only one of them gives an error you
can act on.

Wrapped the conversion and raised the same RuntimeError already used two lines
above. Behaviour for valid values is unchanged.

Added a parametrised test covering "abc", "" and "1 2". It runs against both
implementations — h11 passes on main already, the three httptools cases fail
on main with the ValueError above. tests/protocols/test_http.py is 172 passed,
ruff check and format clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid `Content-Length` header values—including non-numeric, empty, whitespace, signed, negative, and underscore-containing values—are now rejected consistently.
  - Malformed requests no longer result in an internal server error.
  - Invalid header values now close the connection and are logged appropriately.
  - Protocol errors are reported as clear runtime errors instead of exposing raw parsing exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->