### PR TITLE
Deliver request body after a rejected HTTP Upgrade

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,12 @@
 toc_depth: 2
 ---
 
+## Unreleased
+
+### Fixed
+
+* Deliver the HTTP/1.1 request body after a rejected `Upgrade: h2c` on the httptools protocol, restore the parser for keep-alive/pipelined requests, and return 400 on a malformed recovered body (#2722).
+
 ## 0.52.2 (August 13, 2026)
 
 ### Fixed

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -134,6 +134,68 @@ UPGRADE_HTTP2_REQUEST = b"\r\n".join(
     ]
 )
 
+UPGRADE_HTTP2_CHUNKED_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Transfer-Encoding: chunked\r\n",
+        b"Content-Type: application/json\r\n",
+        b"\r\n",
+        b"3\r\nabc\r\n0\r\n\r\n",
+    ]
+)
+
+UPGRADE_HTTP2_CONTENT_LENGTH_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Content-Length: 5\r\n",
+        b"Content-Type: application/json\r\n",
+        b"\r\n",
+        b"hello",
+    ]
+)
+
+UPGRADE_HTTP2_MALFORMED_CHUNKED_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Transfer-Encoding: chunked\r\n",
+        b"\r\n",
+        b"zzz\r\n",
+    ]
+)
+
+UPGRADE_HTTP2_BAD_CHUNK_CRLF_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Transfer-Encoding: chunked\r\n",
+        b"\r\n",
+        b"3\r\nabcXX0\r\n\r\n",
+    ]
+)
+
+UPGRADE_HTTP2_CHUNKED_WITH_TRAILER_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Transfer-Encoding: chunked\r\n",
+        b"\r\n",
+        b"3\r\nabc\r\n0\r\nX-Trailer: 1\r\n\r\n",
+    ]
+)
+
 INVALID_REQUEST_TEMPLATE = b"\r\n".join(
     [
         b"%s",
@@ -907,6 +969,104 @@ async def test_http2_upgrade_request(http_protocol_cls: type[HTTPProtocol], ws_p
     assert b"Hello, world" in protocol.transport.buffer
 
 
+async def _echo_body_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+    body = b""
+    more_body = True
+    while more_body:
+        message = await receive()
+        if message["type"] != "http.request":
+            break
+        body += message.get("body", b"")
+        more_body = message.get("more_body", False)
+    response = Response(b"Body: " + body, media_type="text/plain")
+    await response(scope, receive, send)
+
+
+async def test_http2_upgrade_chunked_body_is_preserved(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_echo_body_app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CHUNKED_POST_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: abc" in protocol.transport.buffer
+
+
+async def test_http2_upgrade_content_length_body_is_preserved(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_echo_body_app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CONTENT_LENGTH_POST_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: hello" in protocol.transport.buffer
+
+
+async def test_http2_upgrade_chunked_body_split_across_packets(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_echo_body_app, http_protocol_cls)
+    split_at = UPGRADE_HTTP2_CHUNKED_POST_REQUEST.index(b"abc") + 1
+    protocol.data_received(UPGRADE_HTTP2_CHUNKED_POST_REQUEST[:split_at])
+    protocol.data_received(UPGRADE_HTTP2_CHUNKED_POST_REQUEST[split_at:])
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: abc" in protocol.transport.buffer
+
+
+async def test_keep_alive_after_rejected_http2_upgrade(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_echo_body_app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CHUNKED_POST_REQUEST)
+    await protocol.loop.run_one()
+    assert b"Body: abc" in protocol.transport.buffer
+    protocol.transport.clear_buffer()
+
+    protocol.data_received(SIMPLE_GET_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: " in protocol.transport.buffer
+
+
+async def test_pipelined_request_after_rejected_http2_upgrade(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_echo_body_app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CHUNKED_POST_REQUEST + SIMPLE_GET_REQUEST)
+    await protocol.loop.run_one()
+    assert b"Body: abc" in protocol.transport.buffer
+    protocol.transport.clear_buffer()
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: " in protocol.transport.buffer
+
+
+@skip_if_no_httptools
+async def test_malformed_chunked_body_after_rejected_http2_upgrade() -> None:
+    protocol = get_connected_protocol(_echo_body_app, HttpToolsProtocol)
+    protocol.data_received(UPGRADE_HTTP2_MALFORMED_CHUNKED_POST_REQUEST)
+    assert b"HTTP/1.1 400" in protocol.transport.buffer
+    assert protocol.transport.is_closing()
+    await protocol.loop.run_one()
+
+
+@skip_if_no_httptools
+async def test_invalid_chunk_framing_after_rejected_http2_upgrade() -> None:
+    protocol = get_connected_protocol(_echo_body_app, HttpToolsProtocol)
+    protocol.data_received(UPGRADE_HTTP2_BAD_CHUNK_CRLF_POST_REQUEST)
+    assert b"HTTP/1.1 400" in protocol.transport.buffer
+    assert protocol.transport.is_closing()
+    await protocol.loop.run_one()
+
+
+async def test_chunked_trailer_after_rejected_http2_upgrade(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_echo_body_app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CHUNKED_WITH_TRAILER_POST_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: abc" in protocol.transport.buffer
+
+
+async def test_http2_upgrade_content_length_body_split_across_packets(http_protocol_cls: type[HTTPProtocol]) -> None:
+    protocol = get_connected_protocol(_echo_body_app, http_protocol_cls)
+    protocol.data_received(UPGRADE_HTTP2_CONTENT_LENGTH_POST_REQUEST[:-2])
+    protocol.data_received(UPGRADE_HTTP2_CONTENT_LENGTH_POST_REQUEST[-2:])
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: hello" in protocol.transport.buffer
+
+
 async def asgi3app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
     pass
 
@@ -1185,3 +1345,60 @@ async def test_header_upgrade_is_websocket_depend_not_installed(
     assert msg in caplog.text
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Hello, world" in protocol.transport.buffer
+
+
+@skip_if_no_httptools
+def test_rejected_upgrade_body_incomplete_chunk_states() -> None:
+    from uvicorn.protocols.http.httptools_impl import _RejectedUpgradeBody
+
+    collector = _RejectedUpgradeBody([(b"transfer-encoding", b"chunked")])
+    assert collector.feed(b"3") is None
+    assert collector.feed(b"\r\nab") is None
+    assert collector.feed(b"c") is None
+    assert collector.feed(b"\r") is None
+    leftover = collector.feed(b"\n0\r\nX")
+    assert leftover is None
+    leftover = collector.feed(b"-Trailer: 1\r\n\r\nGET")
+    assert leftover == b"GET"
+    assert bytes(collector.body) == b"abc"
+
+
+@skip_if_no_httptools
+def test_rejected_upgrade_body_empty_chunk_size() -> None:
+    from uvicorn.protocols.http.httptools_impl import _RejectedUpgradeBody
+
+    collector = _RejectedUpgradeBody([(b"transfer-encoding", b"chunked")])
+    with pytest.raises(ValueError, match="invalid chunk size"):
+        collector.feed(b"\r\n")
+
+
+@skip_if_no_httptools
+def test_rejected_upgrade_body_invalid_content_length() -> None:
+    from uvicorn.protocols.http.httptools_impl import _RejectedUpgradeBody
+
+    with pytest.raises(ValueError):
+        _RejectedUpgradeBody([(b"content-length", b"nope")])
+
+
+@skip_if_no_httptools
+async def test_http2_upgrade_large_body_pauses_reading() -> None:
+    from uvicorn.protocols.http.flow_control import HIGH_WATER_LIMIT
+    from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+
+    payload = b"x" * (HIGH_WATER_LIMIT + 1)
+    request = b"".join(
+        [
+            b"POST / HTTP/1.1\r\n",
+            b"Host: example.org\r\n",
+            b"Connection: Upgrade, HTTP2-Settings\r\n",
+            b"Upgrade: h2c\r\n",
+            b"Content-Length: " + str(len(payload)).encode() + b"\r\n",
+            b"\r\n",
+            payload,
+        ]
+    )
+    protocol = get_connected_protocol(_echo_body_app, HttpToolsProtocol)
+    protocol.data_received(request)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Body: " + payload in protocol.transport.buffer

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -172,6 +172,18 @@ UPGRADE_HTTP2_MALFORMED_CHUNKED_POST_REQUEST = b"".join(
     ]
 )
 
+UPGRADE_HTTP2_PYTHON_INT_CHUNK_SIZE_POST_REQUEST = b"".join(
+    [
+        b"POST / HTTP/1.1\r\n",
+        b"Host: example.org\r\n",
+        b"Connection: Upgrade, HTTP2-Settings\r\n",
+        b"Upgrade: h2c\r\n",
+        b"Transfer-Encoding: chunked\r\n",
+        b"\r\n",
+        b"+3\r\nabc\r\n0\r\n\r\n",
+    ]
+)
+
 UPGRADE_HTTP2_BAD_CHUNK_CRLF_POST_REQUEST = b"".join(
     [
         b"POST / HTTP/1.1\r\n",
@@ -1042,6 +1054,15 @@ async def test_malformed_chunked_body_after_rejected_http2_upgrade() -> None:
 
 
 @skip_if_no_httptools
+async def test_python_int_hex_chunk_size_after_rejected_http2_upgrade() -> None:
+    protocol = get_connected_protocol(_echo_body_app, HttpToolsProtocol)
+    protocol.data_received(UPGRADE_HTTP2_PYTHON_INT_CHUNK_SIZE_POST_REQUEST)
+    assert b"HTTP/1.1 400" in protocol.transport.buffer
+    assert protocol.transport.is_closing()
+    await protocol.loop.run_one()
+
+
+@skip_if_no_httptools
 async def test_invalid_chunk_framing_after_rejected_http2_upgrade() -> None:
     protocol = get_connected_protocol(_echo_body_app, HttpToolsProtocol)
     protocol.data_received(UPGRADE_HTTP2_BAD_CHUNK_CRLF_POST_REQUEST)
@@ -1370,6 +1391,26 @@ def test_rejected_upgrade_body_empty_chunk_size() -> None:
     collector = _RejectedUpgradeBody([(b"transfer-encoding", b"chunked")])
     with pytest.raises(ValueError, match="invalid chunk size"):
         collector.feed(b"\r\n")
+
+
+@skip_if_no_httptools
+@pytest.mark.parametrize("size_token", [b"+3", b"0x3", b"1_0", b" 3", b"3 "])
+def test_rejected_upgrade_body_rejects_non_hex_chunk_size(size_token: bytes) -> None:
+    from uvicorn.protocols.http.httptools_impl import _RejectedUpgradeBody
+
+    collector = _RejectedUpgradeBody([(b"transfer-encoding", b"chunked")])
+    with pytest.raises(ValueError, match="invalid chunk size"):
+        collector.feed(size_token + b"\r\nabc\r\n0\r\n\r\n")
+
+
+@skip_if_no_httptools
+def test_rejected_upgrade_body_chunk_size_bws_before_extension() -> None:
+    from uvicorn.protocols.http.httptools_impl import _RejectedUpgradeBody
+
+    collector = _RejectedUpgradeBody([(b"transfer-encoding", b"chunked")])
+    leftover = collector.feed(b"3 ;foo\r\nabc\r\n0\r\n\r\nGET")
+    assert leftover == b"GET"
+    assert bytes(collector.body) == b"abc"
 
 
 @skip_if_no_httptools

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -29,6 +29,7 @@ from uvicorn.server import ServerState
 
 HEADER_RE = re.compile(b'[\x00-\x1f\x7f()<>@,;:\\[\\]={} \t\\\\"]')
 HEADER_VALUE_RE = re.compile(b"[\x00-\x08\x0a-\x1f\x7f]")
+CHUNK_SIZE_RE = re.compile(rb"^[0-9a-fA-F]+$")
 
 
 def _get_status_line(status_code: int) -> bytes:
@@ -110,11 +111,15 @@ class _RejectedUpgradeBody:
             idx = self._buf.find(b"\r\n")
             if idx < 0:
                 return None
-            size_line = bytes(self._buf[:idx]).split(b";", 1)[0].strip()
+            line = bytes(self._buf[:idx])
             del self._buf[: idx + 2]
-            if not size_line:
+            if b";" in line:
+                size_token = line.split(b";", 1)[0].rstrip(b" \t")
+            else:
+                size_token = line
+            if CHUNK_SIZE_RE.match(size_token) is None:
                 raise ValueError("invalid chunk size")
-            size = int(size_line, 16)
+            size = int(size_token, 16)
             if size == 0:
                 self._trailers = True
                 continue

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -42,6 +42,85 @@ def _get_status_line(status_code: int) -> bytes:
 STATUS_LINE = {status_code: _get_status_line(status_code) for status_code in range(100, 600)}
 
 
+class _RejectedUpgradeBody:
+    """Collect a request body after httptools stops at a rejected Upgrade.
+
+    httptools raises HttpParserUpgrade before on_body/on_message_complete.
+    RFC 7230 §6.7 allows ignoring an unsupported Upgrade and continuing.
+    """
+
+    def __init__(self, headers: list[tuple[bytes, bytes]]) -> None:
+        chunked = False
+        content_length = 0
+        for name, value in headers:
+            if name == b"transfer-encoding" and b"chunked" in value.lower():
+                chunked = True
+            elif name == b"content-length":
+                content_length = int(value)
+        self.body = bytearray()
+        self._buf = bytearray()
+        self._chunked = chunked
+        self._length_left = 0 if chunked else content_length
+        self._chunk_left: int | None = None
+        self._after_chunk_crlf = False
+        self._trailers = False
+
+    def feed(self, data: bytes) -> bytes | None:
+        """Return leftover bytes when the body is complete, or None if more is needed."""
+        if not self._chunked:
+            self._buf += data
+            if len(self._buf) < self._length_left:
+                return None
+            self.body = self._buf[: self._length_left]
+            leftover = bytes(self._buf[self._length_left :])
+            self._buf.clear()
+            return leftover
+        return self._feed_chunked(data)
+
+    def _feed_chunked(self, data: bytes) -> bytes | None:
+        self._buf += data
+        while True:
+            if self._trailers:
+                idx = self._buf.find(b"\r\n")
+                if idx < 0:
+                    return None
+                line = bytes(self._buf[:idx])
+                del self._buf[: idx + 2]
+                if line == b"":
+                    leftover = bytes(self._buf)
+                    self._buf.clear()
+                    return leftover
+                continue
+            if self._after_chunk_crlf:
+                if len(self._buf) < 2:
+                    return None
+                if bytes(self._buf[:2]) != b"\r\n":
+                    raise ValueError("invalid chunk framing")
+                del self._buf[:2]
+                self._after_chunk_crlf = False
+                continue
+            if self._chunk_left is not None:
+                if len(self._buf) < self._chunk_left:
+                    return None
+                self.body += self._buf[: self._chunk_left]
+                del self._buf[: self._chunk_left]
+                self._chunk_left = None
+                self._after_chunk_crlf = True
+                continue
+            idx = self._buf.find(b"\r\n")
+            if idx < 0:
+                return None
+            size_line = bytes(self._buf[:idx]).split(b";", 1)[0].strip()
+            del self._buf[: idx + 2]
+            if not size_line:
+                raise ValueError("invalid chunk size")
+            size = int(size_line, 16)
+            if size == 0:
+                self._trailers = True
+                continue
+            self._chunk_left = size
+
+
 class HttpToolsProtocol(asyncio.Protocol):
     def __init__(
         self,
@@ -60,13 +139,8 @@ class HttpToolsProtocol(asyncio.Protocol):
         self.access_logger = logging.getLogger("uvicorn.access")
         self.access_log = self.access_logger.hasHandlers()
         self.parser = httptools.HttpRequestParser(self)
-
-        try:
-            # Enable dangerous leniencies to allow server to a response on the first request from a pipelined request.
-            self.parser.set_dangerous_leniencies(lenient_data_after_close=True)
-        except AttributeError:  # pragma: no cover
-            # httptools < 0.6.3
-            pass
+        self._install_parser_leniencies()
+        self._rejected_upgrade_body: _RejectedUpgradeBody | None = None
 
         self.ws_protocol_class = config.ws_protocol_class
         self.root_path = config.root_path
@@ -131,6 +205,7 @@ class HttpToolsProtocol(asyncio.Protocol):
             self._unset_keepalive_if_required()
 
         self.parser = None  # type: ignore[assignment]
+        self._rejected_upgrade_body = None
 
     def eof_received(self) -> None:
         pass
@@ -167,21 +242,80 @@ class HttpToolsProtocol(asyncio.Protocol):
         upgrade = self._get_upgrade()
         return upgrade == b"websocket" and self._should_upgrade_to_ws()
 
-    def data_received(self, data: bytes) -> None:
-        self._unset_keepalive_if_required()
-
+    def _install_parser_leniencies(self) -> None:
         try:
-            self.parser.feed_data(data)
-        except httptools.HttpParserError:
+            # Allow a response on the first request from a pipelined request.
+            self.parser.set_dangerous_leniencies(lenient_data_after_close=True)
+        except AttributeError:  # pragma: no cover
+            # httptools < 0.6.3
+            pass
+
+    def _install_request_parser(self) -> None:
+        self.parser = httptools.HttpRequestParser(self)
+        self._install_parser_leniencies()
+
+    def _consume_rejected_upgrade_body(self, data: bytes) -> bytes | None:
+        collector = self._rejected_upgrade_body
+        assert collector is not None
+        try:
+            leftover = collector.feed(data)
+        except ValueError:
+            self._rejected_upgrade_body = None
             msg = "Invalid HTTP request received."
             self.logger.warning(msg)
+            if self.cycle is not None:
+                self.cycle.disconnected = True
+                self.cycle.message_event.set()
             self.send_400_response(msg)
-            return
-        except httptools.HttpParserUpgrade:
-            if self._should_upgrade():
-                self.handle_websocket_upgrade()
-            else:
+            return None
+        if leftover is None:
+            return None
+        self._rejected_upgrade_body = None
+        if self.cycle is not None and not self.cycle.response_complete:
+            body = bytes(collector.body)
+            if body:
+                self.cycle.body += body
+                if len(self.cycle.body) > HIGH_WATER_LIMIT:
+                    self.flow.pause_reading()
+            self.cycle.more_body = False
+            self.cycle.message_event.set()
+        self._install_request_parser()
+        return leftover
+
+    def data_received(self, data: bytes) -> None:
+        self._unset_keepalive_if_required()
+        remaining: bytes | None = data
+        while remaining is not None:
+            if self._rejected_upgrade_body is not None:
+                remaining = self._consume_rejected_upgrade_body(remaining)
+                if remaining == b"":
+                    return
+                continue
+            try:
+                self.parser.feed_data(remaining)
+                return
+            except httptools.HttpParserError:
+                msg = "Invalid HTTP request received."
+                self.logger.warning(msg)
+                self.send_400_response(msg)
+                return
+            except httptools.HttpParserUpgrade as exc:
+                if self._should_upgrade():
+                    self.handle_websocket_upgrade()
+                    return
                 self._unsupported_upgrade_warning()
+                header_end = int(exc.args[0]) if exc.args else len(remaining)
+                remaining = remaining[header_end:]
+                try:
+                    self._rejected_upgrade_body = _RejectedUpgradeBody(self.headers)
+                except ValueError:  # pragma: full coverage
+                    msg = "Invalid HTTP request received."
+                    self.logger.warning(msg)
+                    if self.cycle is not None:
+                        self.cycle.disconnected = True
+                        self.cycle.message_event.set()
+                    self.send_400_response(msg)
+                    return
 
     def handle_websocket_upgrade(self) -> None:
         if self.logger.level <= TRACE_LOG_LEVEL:


### PR DESCRIPTION
## Summary

- When httptools sees `Upgrade: h2c` it raises `HttpParserUpgrade` before any body events. Java `RestClient` / Spring send that header by default, so the ASGI app got an empty body (fixes #2722).
- After the unsupported-upgrade warning, recover the request body (chunked or `Content-Length`), then **install a fresh request parser** so the next keep-alive or pipelined request is dispatched normally.
- Malformed recovered bodies return 400 and close the connection instead of treating a truncated parse as end-of-body.

## Why this is not a resubmit of #2857 / #2909 / #3037

Those PRs delivered the body by swapping in a body-only httptools parser and leaving it installed. Review of #3037 (closed by the author yesterday) called out two holes this PR closes:

1. Keep-alive / pipelined requests after the recovered request never ran, because the body-only parser stayed in place.
2. A parse error during recovery was treated as a normal end-of-body, so a truncated request could still be processed.

This version collects the leftover body in a small framing decoder, completes the existing ASGI cycle, then restores `HttpRequestParser(self)`. Leftover bytes after the body are fed to that restored parser.

## Test plan

- [x] Chunked and `Content-Length` bodies after `Upgrade: h2c`
- [x] Body split across packets
- [x] Keep-alive GET after a recovered POST
- [x] Pipelined GET in the same packet as the recovered POST
- [x] Malformed chunk size / invalid chunk framing → 400 (httptools)
- [x] Existing `tests/protocols/test_http.py` (httptools, h11, zttp)

`uv run pytest tests/protocols tests/middleware tests/test_ssl.py -n 0` → 1007 passed, 11 skipped.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request-body handling when unsupported HTTP/2 upgrades are rejected.
  * Restored reliable keep-alive and pipelined request processing, including fragmented requests and trailers.
  * Improved handling of chunked and content-length request bodies, including large-body flow control.
  * Malformed request bodies now receive an appropriate HTTP 400 response.

* **Documentation**
  * Added an unreleased release note describing these HTTP upgrade handling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->