### PR TITLE
Version 0.52.3

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,12 @@
 toc_depth: 2
 ---
 
+## 0.52.3 (August 13, 2026)
+
+### Changed
+
+* Update `zttp` to 0.0.24 and use its combined receive path, improving HTTP/1.1 request parsing performance (#3067)
+
 ## 0.52.2 (August 13, 2026)
 
 ### Fixed

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.52.2"
+__version__ = "0.52.3"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## Summary

- Bump Uvicorn's version to 0.52.3.
- Add release notes for the zttp 0.0.24 combined receive path and HTTP/1.1 parsing performance improvement.

## Validation

- `scripts/check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.52.3.
  * Documented improved HTTP/1.1 request parsing performance.

* **Release**
  * Updated the application version to 0.52.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->