### PR TITLE
Fix inconsistent IPv6 dual-stack behavior between single-worker and multi-worker modes

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -262,6 +262,22 @@ def test_socket_bind() -> None:
     sock.close()
 
 
+def test_ipv6_socket_bind_is_dual_stack() -> None:
+    # Regression test for https://github.com/encode/uvicorn/issues/2945
+    # `bind_socket()` (used by the reload/multiprocess workers) must not rely
+    # on the OS default for `IPV6_V6ONLY` (e.g. the Linux `net.ipv6.bindv6only`
+    # sysctl), otherwise it ends up dual-stack or IPv6-only depending on the
+    # host. It should always bind dual-stack, matching the fixed single-worker
+    # path (see `test_run_ipv6_dual_stack_single_worker` in `test_main.py`).
+    config = Config(app=asgi_app, host="::", port=0)
+    config.load()
+    sock = config.bind_socket()
+    try:
+        assert sock.getsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY) == 0
+    finally:
+        sock.close()
+
+
 def test_ssl_config(
     tls_ca_certificate_pem_path: str,
     tls_ca_certificate_private_key_path: str,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ import yaml
 from pytest_mock import MockerFixture
 
 from tests.custom_loop_utils import CustomLoop
-from tests.utils import as_cwd, get_asyncio_default_loop_per_os
+from tests.utils import as_cwd, get_asyncio_default_loop_per_os, has_ipv6
 from uvicorn._types import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Environ, Scope, StartResponse
 from uvicorn.config import Config, LoopFactoryType, UvicornDeprecationWarning
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
@@ -262,6 +262,7 @@ def test_socket_bind() -> None:
     sock.close()
 
 
+@pytest.mark.skipif(not has_ipv6("::"), reason="IPV6 not enabled")
 def test_ipv6_socket_bind_is_dual_stack() -> None:
     # Regression test for https://github.com/encode/uvicorn/issues/2945
     # `bind_socket()` (used by the reload/multiprocess workers) must not rely

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,6 +61,18 @@ async def test_run(host, url: str, unused_tcp_port: int):
     assert response.status_code == 204
 
 
+@pytest.mark.skipif(not _has_ipv6("::"), reason="IPV6 not enabled")
+async def test_run_ipv6_dual_stack_single_worker(unused_tcp_port: int):
+    # Regression test for https://github.com/encode/uvicorn/issues/2945
+    # A single-worker server bound to an IPv6 wildcard host must also accept
+    # IPv4 connections (dual-stack), matching multi-worker/reload behavior.
+    config = Config(app=app, host="::", loop="asyncio", limit_max_requests=1, port=unused_tcp_port)
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+    assert response.status_code == 204
+
+
 async def test_run_multiprocess(unused_tcp_port: int):
     config = Config(app=app, loop="asyncio", workers=2, limit_max_requests=1, port=unused_tcp_port)
     async with run_server(config):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 
 import uvicorn.server
-from tests.utils import run_server
+from tests.utils import has_ipv6, run_server
 from uvicorn import Server
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.config import STARTUP_FAILURE, Config
@@ -25,21 +25,6 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     await send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
-def _has_ipv6(host: str):
-    sock = None
-    has_ipv6 = False
-    if socket.has_ipv6:
-        try:
-            sock = socket.socket(socket.AF_INET6)
-            sock.bind((host, 0))
-            has_ipv6 = True
-        except Exception:  # pragma: no cover
-            pass
-    if sock:
-        sock.close()
-    return has_ipv6
-
-
 @pytest.mark.parametrize(
     "host, url",
     [
@@ -49,7 +34,7 @@ def _has_ipv6(host: str):
             "::1",
             "http://[::1]",
             id="ipv6",
-            marks=pytest.mark.skipif(not _has_ipv6("::1"), reason="IPV6 not enabled"),
+            marks=pytest.mark.skipif(not has_ipv6("::1"), reason="IPV6 not enabled"),
         ),
     ],
 )
@@ -61,7 +46,7 @@ async def test_run(host, url: str, unused_tcp_port: int):
     assert response.status_code == 204
 
 
-@pytest.mark.skipif(not _has_ipv6("::"), reason="IPV6 not enabled")
+@pytest.mark.skipif(not has_ipv6("::"), reason="IPV6 not enabled")
 async def test_run_ipv6_dual_stack_single_worker(unused_tcp_port: int):
     # Regression test for https://github.com/encode/uvicorn/issues/2945
     # A single-worker server bound to an IPv6 wildcard host must also accept

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import signal
+import socket as socket_module
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, contextmanager
@@ -10,6 +11,21 @@ from pathlib import Path
 from socket import socket
 
 from uvicorn import Config, Server
+
+
+def has_ipv6(host: str) -> bool:
+    sock = None
+    ipv6_enabled = False
+    if socket_module.has_ipv6:
+        try:
+            sock = socket_module.socket(socket_module.AF_INET6)
+            sock.bind((host, 0))
+            ipv6_enabled = True
+        except Exception:  # pragma: no cover
+            pass
+    if sock:
+        sock.close()
+    return ipv6_enabled
 
 
 @asynccontextmanager

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ def has_ipv6(host: str) -> bool:
             sock = socket_module.socket(socket_module.AF_INET6)
             sock.bind((host, 0))
             ipv6_enabled = True
-        except Exception:  # pragma: no cover
+        except OSError:  # pragma: no cover
             pass
     if sock:
         sock.close()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -582,15 +582,15 @@ class Config:
 
             sock = socket.socket(family=family)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            if family == socket.AF_INET6:
-                # Explicitly enable dual-stack (IPv4-mapped) support instead of
-                # relying on the OS default (e.g. the Linux `net.ipv6.bindv6only`
-                # sysctl), so behaviour is consistent and deterministic across
-                # platforms. This also matches `Server.startup()`'s single-worker
-                # IPv6 path, which binds its own dual-stack socket rather than
-                # letting asyncio's `loop.create_server()` force IPv6-only.
-                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
             try:
+                if family == socket.AF_INET6:
+                    # Explicitly enable dual-stack (IPv4-mapped) support instead of
+                    # relying on the OS default (e.g. the Linux `net.ipv6.bindv6only`
+                    # sysctl), so behaviour is consistent and deterministic across
+                    # platforms. This also matches `Server.startup()`'s single-worker
+                    # IPv6 path, which binds its own dual-stack socket rather than
+                    # letting asyncio's `loop.create_server()` force IPv6-only.
+                    sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
                 sock.bind((self.host, self.port))
             except OSError as exc:  # pragma: full coverage
                 logger.error(exc)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -582,6 +582,14 @@ class Config:
 
             sock = socket.socket(family=family)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if family == socket.AF_INET6:
+                # Explicitly enable dual-stack (IPv4-mapped) support instead of
+                # relying on the OS default (e.g. the Linux `net.ipv6.bindv6only`
+                # sysctl), so behaviour is consistent and deterministic across
+                # platforms. This also matches `Server.startup()`'s single-worker
+                # IPv6 path, which binds its own dual-stack socket rather than
+                # letting asyncio's `loop.create_server()` force IPv6-only.
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
             try:
                 sock.bind((self.host, self.port))
             except OSError as exc:  # pragma: full coverage

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -167,6 +167,28 @@ class Server:
             listeners = server.sockets
             self.servers = [server]
 
+        elif config.host and ":" in config.host:  # pragma: full coverage
+            # Standard case for an IPv6 host. Bind the socket ourselves instead of
+            # letting `loop.create_server()` resolve host/port via `getaddrinfo()`,
+            # since asyncio unconditionally sets `IPV6_V6ONLY` on sockets it creates
+            # that way, forcing IPv6-only regardless of the platform default. This
+            # keeps single-worker mode consistent with `Config.bind_socket()`, used
+            # by the reload/multiprocess workers, which binds a dual-stack socket.
+            try:
+                sock = socket.socket(family=socket.AF_INET6)
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                sock.bind((config.host, config.port))
+                server = await loop.create_server(create_protocol, sock=sock, ssl=config.ssl, backlog=config.backlog)
+            except OSError as exc:
+                logger.error(exc)
+                await self.lifespan.shutdown()
+                sys.exit(STARTUP_FAILURE)
+
+            assert server.sockets is not None
+            listeners = server.sockets
+            self.servers = [server]
+
         else:
             # Standard case. Create a socket from a host/port pair.
             try:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -174,6 +174,7 @@ class Server:
             # that way, forcing IPv6-only regardless of the platform default. This
             # keeps single-worker mode consistent with `Config.bind_socket()`, used
             # by the reload/multiprocess workers, which binds a dual-stack socket.
+            sock: socket.socket | None = None
             try:
                 sock = socket.socket(family=socket.AF_INET6)
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -181,6 +182,8 @@ class Server:
                 sock.bind((config.host, config.port))
                 server = await loop.create_server(create_protocol, sock=sock, ssl=config.ssl, backlog=config.backlog)
             except OSError as exc:
+                if sock is not None:
+                    sock.close()
                 logger.error(exc)
                 await self.lifespan.shutdown()
                 sys.exit(STARTUP_FAILURE)

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -174,16 +174,18 @@ class Server:
             # that way, forcing IPv6-only regardless of the platform default. This
             # keeps single-worker mode consistent with `Config.bind_socket()`, used
             # by the reload/multiprocess workers, which binds a dual-stack socket.
-            sock: socket.socket | None = None
+            ipv6_sock: socket.socket | None = None
             try:
-                sock = socket.socket(family=socket.AF_INET6)
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-                sock.bind((config.host, config.port))
-                server = await loop.create_server(create_protocol, sock=sock, ssl=config.ssl, backlog=config.backlog)
+                ipv6_sock = socket.socket(family=socket.AF_INET6)
+                ipv6_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                ipv6_sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                ipv6_sock.bind((config.host, config.port))
+                server = await loop.create_server(
+                    create_protocol, sock=ipv6_sock, ssl=config.ssl, backlog=config.backlog
+                )
             except OSError as exc:
-                if sock is not None:
-                    sock.close()
+                if ipv6_sock is not None:
+                    ipv6_sock.close()
                 logger.error(exc)
                 await self.lifespan.shutdown()
                 sys.exit(STARTUP_FAILURE)


### PR DESCRIPTION
## Summary

Fixes #2945.

A server bound to an IPv6 wildcard host (`--host ::`) behaved inconsistently depending on how it was run:

- **Multi-worker / `--reload`**: `Config.bind_socket()` creates the socket manually and only sets `SO_REUSEADDR`. It never sets `IPV6_V6ONLY`, so dual-stack behavior silently depended on the OS default (e.g. Linux's `net.ipv6.bindv6only` sysctl, commonly `0` → dual-stack).
- **Single worker (default)**: `Server.startup()`'s "standard case" delegates to `asyncio.loop.create_server(host=..., port=...)`. Per [`asyncio/base_events.py`](https://github.com/python/cpython/blob/main/Lib/asyncio/base_events.py), asyncio *always* sets `IPV6_V6ONLY=True` on `AF_INET6` sockets it creates through this path, regardless of the platform — making the socket IPv6-only unconditionally.

The net effect: on a host where dual-stack is the OS default (e.g. Linux), a single-worker server bound to `::` silently drops IPv4 connectivity, while the same app run with `--workers 2` accepts IPv4 fine — or vice versa depending on the sysctl. This is confusing and, as reported, breaks real-world setups such as rootless Podman with pasta networking, which relies on the server accepting both address families.

## Root cause

- `uvicorn/config.py`, `Config.bind_socket()`: creates the IPv6 socket but never calls `setsockopt(IPPROTO_IPV6, IPV6_V6ONLY, ...)`.
- `uvicorn/server.py`, `Server.startup()` "standard case": relies on `loop.create_server(host=.., port=..)`, whose internal `getaddrinfo`-based socket creation in CPython unconditionally forces `IPV6_V6ONLY=True` for every `AF_INET6` socket, bypassing any platform default.

## Fix

Make both code paths agree on dual-stack-by-default, explicitly and deterministically (not relying on the OS default):

- `Config.bind_socket()` now explicitly sets `IPV6_V6ONLY=False` right after creating an `AF_INET6` socket.
- `Server.startup()`'s single-worker "standard case" now, for IPv6 hosts, binds its own socket (`SO_REUSEADDR` + `IPV6_V6ONLY=False`) and passes it to `loop.create_server(sock=...)` instead of `host=/port=`, bypassing asyncio's `getaddrinfo` path (and its hardcoded `IPV6_V6ONLY=True`) entirely. This is the same technique already used by the reload/multiprocess supervisors via `bind_socket()`.

Non-IPv6 hosts, UDS, and `--fd` paths are untouched.

## Testing

- Added `test_ipv6_socket_bind_is_dual_stack` in `tests/test_config.py`: binds via `Config.bind_socket()` with `host="::"` and asserts `IPV6_V6ONLY == 0`.
- Added `test_run_ipv6_dual_stack_single_worker` in `tests/test_main.py`: runs a real single-worker server bound to `::` and confirms an IPv4 (`127.0.0.1`) client can connect successfully — this is the exact regression from the issue.
- Verified both new tests **fail** without the fix (confirmed `httpx.ConnectError: All connection attempts failed` for the single-worker case, and `IPV6_V6ONLY == 1` for the `bind_socket()` case) and **pass** with it.
- Ran the full `tests/test_config.py`, `tests/test_main.py`, and `tests/test_server.py` slices locally (Windows): all passing, no regressions.
- `ruff format --check`, `ruff check`, and `mypy` all clean on the changed files (pre-existing `mypy` findings on Windows are unrelated stdlib-stub platform mismatches — e.g. `AF_UNIX`/`SIGHUP` not being present in the `win32` stubs — and not on any line touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 wildcard bindings now support dual-stack operation, allowing IPv4 and IPv6 connections through the same server socket.
  * Servers configured with an IPv6 host now start reliably and expose the correct listening socket.
  * Improved handling and reporting of IPv6 socket setup failures, including clean shutdown when startup cannot complete.
  * Added coverage to verify IPv4 and IPv6 connectivity for servers bound to IPv6 addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->