### PR TITLE
docs: correct release example PR number

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -164,7 +164,7 @@ Before releasing a new version, create a pull request that includes:
         - Keep it concise and to-the-point. 🎯
 - **A version bump**: see `__init__.py`.
 
-For an example, see [#1006](https://github.com/Kludex/uvicorn/pull/1107).
+For an example, see [#1107](https://github.com/Kludex/uvicorn/pull/1107).
 
 Once the release PR is merged, create a
 [new release](https://github.com/Kludex/uvicorn/releases/new) including:


### PR DESCRIPTION
## Problem

The releasing section said `see #1006` but linked to pull request 1107.

Verified on GitHub:

    #1006 is "coverage: pin higher coverage"
    #1107 is "Version 0.15.0" (the actual release example)

## Solution

Use `#1107` so the visible number matches the linked release PR.

## Verification

GET `https://github.com/Kludex/uvicorn/pull/1107` returns 200 and is the
Version 0.15.0 release pull request.

This is a documentation-only change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributing guide’s example release pull request link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->