### PR TITLE
Honor case-insensitive Connection close tokens

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -16,6 +16,7 @@ from uvicorn._types import ASGIApplication, ASGIReceiveCallable, ASGIReceiveEven
 from uvicorn.config import WS_PROTOCOLS, Config
 from uvicorn.lifespan.off import LifespanOff
 from uvicorn.lifespan.on import LifespanOn
+from uvicorn.protocols.http.flow_control import has_connection_close
 from uvicorn.protocols.http.h11_impl import H11Protocol
 from uvicorn.server import ServerState
 
@@ -55,6 +56,14 @@ SIMPLE_POST_REQUEST = b"\r\n".join(
 )
 
 CONNECTION_CLOSE_REQUEST = b"\r\n".join([b"GET / HTTP/1.1", b"Host: example.org", b"Connection: close", b"", b""])
+
+
+def test_has_connection_close() -> None:
+    assert has_connection_close([(b"host", b"example.org")]) is False
+    assert has_connection_close([(b"connection", b"keep-alive")]) is False
+    assert has_connection_close([(b"connection", b"close,")]) is True
+    assert has_connection_close([(b"Connection", b"keep-alive, Close")]) is True
+
 
 CONNECTION_CLOSE_POST_REQUEST = b"\r\n".join(
     [
@@ -1068,11 +1077,22 @@ async def test_huge_headers_h11_max_incomplete():
     assert b"Hello, world" in protocol.transport.buffer
 
 
-async def test_return_close_header(http_protocol_cls: type[HTTPProtocol]):
+@pytest.mark.parametrize(
+    "connection",
+    [
+        b"close",
+        b"Close",
+        b"CLOSE",
+        b"keep-alive, close",
+        b" close ",
+    ],
+)
+async def test_return_close_header(http_protocol_cls: type[HTTPProtocol], connection: bytes):
     app = Response("Hello, world", media_type="text/plain")
+    request = b"\r\n".join([b"GET / HTTP/1.1", b"Host: example.org", b"Connection: " + connection, b"", b""])
 
     protocol = get_connected_protocol(app, http_protocol_cls)
-    protocol.data_received(CONNECTION_CLOSE_REQUEST)
+    protocol.data_received(request)
     await protocol.loop.run_one()
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"content-type: text/plain" in protocol.transport.buffer
@@ -1080,6 +1100,17 @@ async def test_return_close_header(http_protocol_cls: type[HTTPProtocol]):
     # NOTE: We need to use `.lower()` because H11 implementation doesn't allow Uvicorn
     # to lowercase them. See: https://github.com/python-hyper/h11/issues/156
     assert b"connection: close" in protocol.transport.buffer.lower()
+    assert protocol.transport.is_closing()
+
+
+async def test_return_close_header_when_app_already_set_close(http_protocol_cls: type[HTTPProtocol]):
+    app = Response("Hello, world", media_type="text/plain", headers={"connection": "close"})
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(CONNECTION_CLOSE_REQUEST)
+    await protocol.loop.run_one()
+    assert protocol.transport.buffer.lower().count(b"connection: close") == 1
+    assert protocol.transport.is_closing()
 
 
 async def test_close_connection_with_multiple_requests(http_protocol_cls: type[HTTPProtocol]):

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -7,6 +7,21 @@ CLOSE_HEADER = (b"connection", b"close")
 HIGH_WATER_LIMIT = 65536
 
 
+def has_connection_close(headers: list[tuple[bytes, bytes]]) -> bool:
+    """Return True if a Connection header includes a close token.
+
+    Connection option tokens are case-insensitive and comma-separated
+    (RFC 9110 §7.6.1, RFC 9112 §9.6).
+    """
+    for name, value in headers:
+        if name.lower() != b"connection":
+            continue
+        for token in value.split(b","):
+            if token.strip().lower() == b"close":
+                return True
+    return False
+
+
 class FlowControl:
     def __init__(self, transport: asyncio.Transport) -> None:
         self._transport = transport

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Iterable
 
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 
@@ -7,7 +8,7 @@ CLOSE_HEADER = (b"connection", b"close")
 HIGH_WATER_LIMIT = 65536
 
 
-def has_connection_close(headers: list[tuple[bytes, bytes]]) -> bool:
+def has_connection_close(headers: Iterable[tuple[bytes, bytes]]) -> bool:
     """Return True if a Connection header includes a close token.
 
     Connection option tokens are case-insensitive and comma-separated

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    has_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -475,7 +481,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if has_connection_close(self.scope["headers"]) and not has_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    has_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -478,7 +484,7 @@ class RequestResponseCycle:
             status_code = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if has_connection_close(self.scope["headers"]) and not has_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -21,7 +21,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    has_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -423,7 +429,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if has_connection_close(self.scope["headers"]) and not has_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             bodyless = self.scope["method"] == "HEAD" or status in (204, 304) or status < 200


### PR DESCRIPTION
# Summary

Fixes #3074 (discussion: https://github.com/Kludex/uvicorn/discussions/3071).

`httptools` only treated `Connection: close` as close when the value was exactly lowercase `close`. `Connection: Close` and `Connection: keep-alive, close` left the TCP connection open. `h11` and `zttp` still closed via their parsers, but they also failed to echo `Connection: close` for those values (RFC 9112 §9.6 SHOULD).

The shared check was an exact tuple match on `CLOSE_HEADER`. This PR parses Connection as a comma-separated, case-insensitive token list — the same split/strip/lower pattern `_get_upgrade` already uses — in a helper next to `CLOSE_HEADER`, and uses it in httptools, h11, and zttp.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly. (No docs change: `docs/server-behavior.md` already says `Connection: Close` closes the connection.)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP `Connection: close` headers, including case-insensitive and comma-separated values.
  * Ensured connections close correctly when requested by clients.
  * Prevented duplicate `Connection: close` headers when applications already provide one.
  * Applied consistent connection-closing behavior across supported HTTP implementations.

* **Tests**
  * Added coverage for varied header capitalization, compound values, and response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->