### PR TITLE
Fix Connection: close multi-token and case insensitivity

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1185,3 +1185,22 @@ async def test_header_upgrade_is_websocket_depend_not_installed(
     assert msg in caplog.text
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Hello, world" in protocol.transport.buffer
+
+@pytest.mark.parametrize(
+    "connection_header", [b"close", b"Close", b"keep-alive, close"]
+)
+async def test_connection_close_variants(
+    http_protocol_cls: type[asyncio.Protocol], connection_header: bytes
+) -> None:
+    protocol = get_connected_protocol(
+        Response("Hello, world", media_type="text/plain"),
+        http_protocol_cls,
+        access_log=False,
+    )
+    req = b"GET / HTTP/1.1\r\nHost: example.org\r\nConnection: " + connection_header + b"\r\n\r\n"
+    protocol.data_received(req)
+    await protocol.loop.run_one()
+    buf = protocol.transport.buffer.lower()
+    
+    assert protocol.transport.is_closing()
+    assert b"connection: close" in buf

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1186,12 +1186,9 @@ async def test_header_upgrade_is_websocket_depend_not_installed(
     assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Hello, world" in protocol.transport.buffer
 
-@pytest.mark.parametrize(
-    "connection_header", [b"close", b"Close", b"keep-alive, close"]
-)
-async def test_connection_close_variants(
-    http_protocol_cls: type[asyncio.Protocol], connection_header: bytes
-) -> None:
+
+@pytest.mark.parametrize("connection_header", [b"close", b"Close", b"keep-alive, close"])
+async def test_connection_close_variants(http_protocol_cls: type[HTTPProtocol], connection_header: bytes) -> None:
     protocol = get_connected_protocol(
         Response("Hello, world", media_type="text/plain"),
         http_protocol_cls,
@@ -1201,6 +1198,6 @@ async def test_connection_close_variants(
     protocol.data_received(req)
     await protocol.loop.run_one()
     buf = protocol.transport.buffer.lower()
-    
+
     assert protocol.transport.is_closing()
     assert b"connection: close" in buf

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -4,6 +4,15 @@ from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 
 CLOSE_HEADER = (b"connection", b"close")
 
+
+def has_connection_close(headers: list[tuple[bytes, bytes]]) -> bool:
+    for name, value in headers:
+        if name.lower() == b"connection":
+            for token in value.split(b","):
+                if token.strip().lower() == b"close":
+                    return True
+    return False
+
 HIGH_WATER_LIMIT = 65536
 
 

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -13,6 +13,7 @@ def has_connection_close(headers: list[tuple[bytes, bytes]]) -> bool:
                     return True
     return False
 
+
 HIGH_WATER_LIMIT = 65536
 
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, has_connection_close, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    has_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -23,7 +23,7 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, has_connection_close, service_unavailable
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -475,7 +475,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if has_connection_close(self.scope["headers"]) and not has_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, has_connection_close, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    has_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -23,7 +23,7 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, has_connection_close, service_unavailable
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -478,7 +478,7 @@ class RequestResponseCycle:
             status_code = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if has_connection_close(self.scope["headers"]) and not has_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:
@@ -507,7 +507,7 @@ class RequestResponseCycle:
                 elif name == b"transfer-encoding" and value.lower() == b"chunked":
                     self.expected_content_length = 0
                     self.chunked_encoding = True
-                elif name == b"connection" and value.lower() == b"close":
+                elif name == b"connection" and has_connection_close([(name, value)]):
                     self.keep_alive = False
                 content.extend([name, b": ", value, b"\r\n"])
 

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -21,7 +21,7 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, has_connection_close, service_unavailable
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -423,7 +423,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if has_connection_close(self.scope["headers"]) and not has_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             bodyless = self.scope["method"] == "HEAD" or status in (204, 304) or status < 200

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -21,7 +21,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, has_connection_close, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    has_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 


### PR DESCRIPTION
Fixes #3074

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `Connection: close` headers regardless of capitalization, surrounding whitespace, or additional connection tokens.
  * Ensured transports close correctly and responses include the appropriate `connection: close` header across supported HTTP implementations.

* **Tests**
  * Added coverage for case-insensitive and compound `Connection: close` header values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->