### PR TITLE
Remove duplicate Date header from SansIO WebSocket handshakes

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -1252,7 +1252,8 @@ async def test_default_server_headers(
     config = Config(app=App, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
     async with run_server(config):
         headers = await open_connection(f"ws://127.0.0.1:{unused_tcp_port}")
-        assert headers.get("server") == "uvicorn" and "date" in headers
+        assert headers.get("server") == "uvicorn"
+        assert len(headers.get_all("date")) == 1
 
 
 async def test_no_server_headers(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
@@ -1278,8 +1279,7 @@ async def test_no_server_headers(ws_protocol_cls: WSProtocol, http_protocol_cls:
         assert "server" not in headers
 
 
-@skip_if_no_wsproto
-async def test_no_date_header_on_wsproto(http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
+async def test_no_date_header(ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int):
     class App(WebSocketResponse):
         async def websocket_connect(self, message: WebSocketConnectEvent):
             await self.send({"type": "websocket.accept"})
@@ -1291,7 +1291,7 @@ async def test_no_date_header_on_wsproto(http_protocol_cls: HTTPProtocol, unused
 
     config = Config(
         app=App,
-        ws=_WSProtocol,
+        ws=ws_protocol_cls,
         http=http_protocol_cls,
         lifespan="off",
         date_header=False,

--- a/uvicorn/protocols/websockets/websockets_sansio_impl.py
+++ b/uvicorn/protocols/websockets/websockets_sansio_impl.py
@@ -449,6 +449,7 @@ class WebSocketsSansIOProtocol(asyncio.Protocol):
                 accepted_subprotocol = message.get("subprotocol")
                 if accepted_subprotocol:
                     headers.append(("Sec-WebSocket-Protocol", accepted_subprotocol))
+                del self.response.headers["Date"]
                 self.response.headers.update(headers)
 
                 if not self.transport.is_closing():


### PR DESCRIPTION
The `websockets-sansio` protocol currently sends the `Date` header generated by `websockets` alongside Uvicorn's default `date` header. Remove the generated header before applying Uvicorn's configured headers.

This also makes `date_header=False` work with `websockets-sansio`.

Tests verify that accepted handshakes contain exactly one date header by default and none when disabled.

Refs: https://github.com/Kludex/uvicorn/discussions/3076

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - WebSocket handshake responses no longer include an automatically generated `Date` header.
  - WebSocket response headers now behave consistently across supported protocol implementations.
  - Configured and application-provided headers continue to be applied as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->