### PR TITLE
Version 0.52.4

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,12 @@
 toc_depth: 2
 ---
 
+## 0.52.4 (August 18, 2026)
+
+### Fixed
+
+* Remove duplicate `Date` headers from accepted WebSocket handshakes with `websockets-sansio` ([#3078](https://github.com/Kludex/uvicorn/pull/3078))
+
 ## 0.52.3 (August 13, 2026)
 
 ### Changed

--- a/uvicorn/__init__.py
+++ b/uvicorn/__init__.py
@@ -1,5 +1,5 @@
 from uvicorn.config import Config
 from uvicorn.main import Server, main, run
 
-__version__ = "0.52.3"
+__version__ = "0.52.4"
 __all__ = ["main", "run", "Config", "Server"]


### PR DESCRIPTION
## Summary

- Bump Uvicorn's version to 0.52.4.
- Add release notes for removing duplicate `Date` headers from `websockets-sansio` handshakes in [#3078](https://github.com/Kludex/uvicorn/pull/3078).

## Validation

- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate `Date` headers appearing in accepted WebSocket handshakes when using the Sans-IO WebSocket implementation.

* **Release**
  * Updated the application version to 0.52.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->