### PR TITLE
Restore Mermaid diagram rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,7 +93,6 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:


### PR DESCRIPTION
## Summary

Remove the duplicate `pymdownx.superfences` registration so the configured Mermaid fence handles diagrams.

## Testing

- `uv run zensical build --clean`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MkDocs configuration to streamline Markdown extension settings.
  * Existing enhanced code block formatting remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->