### PR TITLE
Use IPC for graceful Windows reloads

### DIFF
--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import signal
 import socket
+import subprocess
 import sys
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -26,7 +27,7 @@ except ImportError:  # pragma: no cover
 skip_non_linux = pytest.mark.skipif(sys.platform in ("darwin", "win32"), reason="Flaky on Windows and MacOS")
 
 
-def run(sockets: list[socket.socket] | None) -> None:
+def run(sockets: list[socket.socket] | None, _shutdown_event: object | None = None) -> None:
     pass  # pragma: no cover
 
 
@@ -399,6 +400,74 @@ def test_base_reloader_should_exit(tmp_path: Path):
     assert reloader.should_exit.is_set()
     with pytest.raises(StopIteration):
         reloader.pause()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only process creation mode")
+def test_reload_gracefully_stops_windowless_child(tmp_path: Path, unused_tcp_port: int) -> None:  # pragma: py-not-win32
+    app_path = tmp_path / "app.py"
+    app_path.write_text(
+        """\
+from __future__ import annotations
+
+async def app(scope, receive, send):
+    if scope["type"] != "lifespan":
+        return
+
+    while True:
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            await send({"type": "lifespan.startup.complete"})
+        elif message["type"] == "lifespan.shutdown":
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+"""
+    )
+    # Use StatReload so watcher behavior does not affect this process-shutdown test.
+    (tmp_path / "watchfiles.py").write_text("raise ImportError\n")
+    log_path = tmp_path / "uvicorn.log"
+
+    with log_path.open("w") as log:
+        process = subprocess.Popen(
+            [sys.executable, "-m", "uvicorn", "app:app", "--reload", "--port", str(unused_tcp_port)],
+            cwd=tmp_path,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            creationflags=0x08000000,  # CREATE_NO_WINDOW
+        )
+
+        try:
+            deadline = monotonic() + 15
+            while monotonic() < deadline:
+                output = log_path.read_text()
+                if "Application startup complete" in output or process.poll() is not None:
+                    break
+                sleep(0.1)
+
+            assert process.poll() is None, f"Uvicorn exited before startup:\n{output}"
+            assert "Application startup complete" in output, f"Uvicorn did not start:\n{output}"
+
+            sleep(1)
+            app_path.write_text(app_path.read_text() + "\n")
+
+            deadline = monotonic() + 15
+            while monotonic() < deadline:
+                output = log_path.read_text()
+                if output.count("Application startup complete") >= 2 or process.poll() is not None:
+                    break
+                sleep(0.1)
+
+            assert process.poll() is None, f"Uvicorn exited during reload:\n{output}"
+            assert output.count("Application startup complete") >= 2, f"Uvicorn did not reload:\n{output}"
+            assert "Application shutdown complete" in output
+        finally:
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            process.wait(timeout=5)
 
 
 def test_base_reloader_closes_sockets_on_shutdown():

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import multiprocessing
 import signal
 import socket
 import subprocess
 import sys
 from collections.abc import Callable, Generator
+from multiprocessing.synchronize import Event
 from pathlib import Path
 from threading import Thread
 from time import monotonic, sleep
@@ -27,8 +29,12 @@ except ImportError:  # pragma: no cover
 skip_non_linux = pytest.mark.skipif(sys.platform in ("darwin", "win32"), reason="Flaky on Windows and MacOS")
 
 
-def run(sockets: list[socket.socket] | None, _shutdown_event: object | None = None) -> None:
+def run(sockets: list[socket.socket] | None) -> None:
     pass  # pragma: no cover
+
+
+def create_shutdown_event() -> Event:
+    return multiprocessing.get_context("spawn").Event()
 
 
 def sleep_touch(*paths: Path):
@@ -63,8 +69,10 @@ class TestBaseReload:
     def _setup_reloader(self, config: Config) -> BaseReload:
         config.reload_delay = 0  # save time
 
-        reloader = self.reloader_class(config, target=run, sockets=[])
+        shutdown_event = create_shutdown_event()
+        reloader = self.reloader_class(config, target=run, sockets=[], shutdown_event=shutdown_event)
 
+        assert reloader.shutdown_event is shutdown_event
         assert config.should_reload
         reloader.startup()
         return reloader
@@ -320,7 +328,7 @@ def test_should_watch_cwd(mocker: MockerFixture, reload_directory_structure: Pat
     mock_watch = mocker.patch("uvicorn.supervisors.watchfilesreload.watch")
 
     config = Config(app="tests.test_config:asgi_app", reload=True, reload_dirs=[])
-    WatchFilesReload(config, target=run, sockets=[])
+    WatchFilesReload(config, target=run, sockets=[], shutdown_event=create_shutdown_event())
     mock_watch.assert_called_once()
     assert mock_watch.call_args[0] == (Path.cwd(),)
 
@@ -335,7 +343,7 @@ def test_should_watch_multiple_dirs(mocker: MockerFixture, reload_directory_stru
         reload=True,
         reload_dirs=[str(app_dir), str(app_first_dir)],
     )
-    WatchFilesReload(config, target=run, sockets=[])
+    WatchFilesReload(config, target=run, sockets=[], shutdown_event=create_shutdown_event())
     mock_watch.assert_called_once()
     assert set(mock_watch.call_args[0]) == {
         app_dir,
@@ -380,7 +388,7 @@ def test_base_reloader_run(tmp_path: Path):
                 raise StopIteration()
 
     config = Config(app="tests.test_config:asgi_app", reload=True)
-    reloader = CustomReload(config, target=run, sockets=[])
+    reloader = CustomReload(config, target=run, sockets=[], shutdown_event=create_shutdown_event())
     reloader.run()
 
     assert calls == ["startup", "restart", "shutdown"]
@@ -388,7 +396,7 @@ def test_base_reloader_run(tmp_path: Path):
 
 def test_base_reloader_should_exit(tmp_path: Path):
     config = Config(app="tests.test_config:asgi_app", reload=True)
-    reloader = BaseReload(config, target=run, sockets=[])
+    reloader = BaseReload(config, target=run, sockets=[], shutdown_event=create_shutdown_event())
     assert not reloader.should_exit.is_set()
     reloader.pause()
 
@@ -473,7 +481,7 @@ async def app(scope, receive, send):
 def test_base_reloader_closes_sockets_on_shutdown():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     config = Config(app="tests.test_config:asgi_app", reload=True)
-    reloader = BaseReload(config, target=run, sockets=[sock])
+    reloader = BaseReload(config, target=run, sockets=[sock], shutdown_event=create_shutdown_event())
     reloader.startup()
     assert sock.fileno() != -1
     reloader.shutdown()

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -475,11 +475,8 @@ async def app(scope, receive, send):
                 stderr=subprocess.DEVNULL,
                 check=False,
             )
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait()
+            process.kill()
+            process.wait()
 
 
 def test_base_reloader_closes_sockets_on_shutdown():

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -475,7 +475,11 @@ async def app(scope, receive, send):
                 stderr=subprocess.DEVNULL,
                 check=False,
             )
-            process.wait(timeout=5)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
 
 
 def test_base_reloader_closes_sockets_on_shutdown():

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -613,7 +613,7 @@ def run(
     try:
         if config.should_reload:
             sock = config.bind_socket()
-            ChangeReload(config, target=server.run, sockets=[sock]).run()
+            ChangeReload(config, target=server.run, sockets=[sock], shutdown_event=server.shutdown_event).run()
         elif config.workers > 1:
             sock = config.bind_socket()
             Multiprocess(config, sockets=[sock]).run()

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import functools
 import logging
+import multiprocessing
 import os
 import platform
 import random
@@ -76,12 +77,13 @@ class Server:
             return None
         return self.config.limit_max_requests + random.randint(0, self.config.limit_max_requests_jitter)
 
-    def run(
-        self,
-        sockets: list[socket.socket] | None = None,
-        _shutdown_event: Event | None = None,
-    ) -> None:
-        self._shutdown_event = _shutdown_event
+    @property
+    def shutdown_event(self) -> Event:
+        if self._shutdown_event is None:
+            self._shutdown_event = multiprocessing.get_context("spawn").Event()
+        return self._shutdown_event
+
+    def run(self, sockets: list[socket.socket] | None = None) -> None:
         return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
 
     async def serve(self, sockets: list[socket.socket] | None = None) -> None:

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -22,6 +22,8 @@ from uvicorn._compat import asyncio_run
 from uvicorn.config import STARTUP_FAILURE, Config
 
 if TYPE_CHECKING:
+    from multiprocessing.synchronize import Event
+
     from uvicorn.protocols.http.h11_impl import H11Protocol
     from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
     from uvicorn.protocols.http.zttp_impl import ZttpProtocol
@@ -66,6 +68,7 @@ class Server:
         self.last_notified = 0.0
 
         self._captured_signals: list[int] = []
+        self._shutdown_event: Event | None = None
 
     @functools.cached_property
     def limit_max_requests(self) -> int | None:
@@ -73,7 +76,12 @@ class Server:
             return None
         return self.config.limit_max_requests + random.randint(0, self.config.limit_max_requests_jitter)
 
-    def run(self, sockets: list[socket.socket] | None = None) -> None:
+    def run(
+        self,
+        sockets: list[socket.socket] | None = None,
+        _shutdown_event: Event | None = None,
+    ) -> None:
+        self._shutdown_event = _shutdown_event
         return asyncio_run(self.serve(sockets=sockets), loop_factory=self.config.get_loop_factory())
 
     async def serve(self, sockets: list[socket.socket] | None = None) -> None:
@@ -259,7 +267,7 @@ class Server:
                     await self.config.callback_notify()
 
         # Determine if we should exit.
-        if self.should_exit:
+        if self.should_exit or (self._shutdown_event is not None and self._shutdown_event.is_set()):
             return True
 
         max_requests = self.limit_max_requests

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import functools
 import logging
-import multiprocessing
 import os
 import signal
 import sys
@@ -35,14 +33,19 @@ class BaseReload:
         config: Config,
         target: Callable[[list[socket] | None], None],
         sockets: list[socket],
+        shutdown_event: Event,
     ) -> None:
         self.config = config
         self.target = target
         self.sockets = sockets
         self.should_exit = threading.Event()
         self.pid = os.getpid()
-        self.shutdown_event: Event | None = None
+        self._shutdown_event = shutdown_event
         self.reloader_name: str | None = None
+
+    @property
+    def shutdown_event(self) -> Event:
+        return self._shutdown_event
 
     def signal_handler(self, sig: int, frame: FrameType | None) -> None:  # pragma: full coverage
         """
@@ -87,28 +90,23 @@ class BaseReload:
         self.process = self._start_process()
 
     def _start_process(self) -> BaseProcess:
-        target = self.target
-        if sys.platform == "win32":  # pragma: py-not-win32
-            self.shutdown_event = multiprocessing.get_context("spawn").Event()
-            target = functools.partial(target, _shutdown_event=self.shutdown_event)
-
-        process = get_subprocess(config=self.config, target=target, sockets=self.sockets)
+        process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
         process.start()
         return process
 
     def restart(self) -> None:
         if sys.platform == "win32":  # pragma: py-not-win32
-            assert self.shutdown_event is not None
             self.shutdown_event.set()
         else:  # pragma: py-win32
             self.process.terminate()
         self.process.join()
 
+        if sys.platform == "win32":  # pragma: py-not-win32
+            self.shutdown_event.clear()
         self.process = self._start_process()
 
     def shutdown(self) -> None:
         if sys.platform == "win32":
-            assert self.shutdown_event is not None  # pragma: py-not-win32
             self.shutdown_event.set()  # pragma: py-not-win32
         else:
             self.process.terminate()  # pragma: py-win32

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -16,7 +16,6 @@ from uvicorn._subprocess import get_subprocess
 from uvicorn.config import Config
 
 if TYPE_CHECKING:
-    from multiprocessing.process import BaseProcess
     from multiprocessing.synchronize import Event
 
 HANDLED_SIGNALS = (
@@ -87,12 +86,8 @@ class BaseReload:
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.signal_handler)
 
-        self.process = self._start_process()
-
-    def _start_process(self) -> BaseProcess:
-        process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
-        process.start()
-        return process
+        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+        self.process.start()
 
     def restart(self) -> None:
         if sys.platform == "win32":  # pragma: py-not-win32
@@ -103,7 +98,8 @@ class BaseReload:
 
         if sys.platform == "win32":  # pragma: py-not-win32
             self.shutdown_event.clear()
-        self.process = self._start_process()
+        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+        self.process.start()
 
     def shutdown(self) -> None:
         if sys.platform == "win32":

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import functools
 import logging
+import multiprocessing
 import os
 import signal
 import sys
@@ -9,10 +11,15 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 from socket import socket
 from types import FrameType
+from typing import TYPE_CHECKING
 
 from uvicorn._ansi import style
 from uvicorn._subprocess import get_subprocess
 from uvicorn.config import Config
+
+if TYPE_CHECKING:
+    from multiprocessing.process import BaseProcess
+    from multiprocessing.synchronize import Event
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
@@ -34,17 +41,14 @@ class BaseReload:
         self.sockets = sockets
         self.should_exit = threading.Event()
         self.pid = os.getpid()
-        self.is_restarting = False
+        self.shutdown_event: Event | None = None
         self.reloader_name: str | None = None
 
     def signal_handler(self, sig: int, frame: FrameType | None) -> None:  # pragma: full coverage
         """
         A signal handler that is registered with the parent process.
         """
-        if sys.platform == "win32" and self.is_restarting:
-            self.is_restarting = False
-        else:
-            self.should_exit.set()
+        self.should_exit.set()
 
     def run(self) -> None:
         self.startup()
@@ -80,28 +84,32 @@ class BaseReload:
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.signal_handler)
 
-        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
-        self.process.start()
+        self.process = self._start_process()
+
+    def _start_process(self) -> BaseProcess:
+        target = self.target
+        if sys.platform == "win32":  # pragma: py-not-win32
+            self.shutdown_event = multiprocessing.get_context("spawn").Event()
+            target = functools.partial(target, _shutdown_event=self.shutdown_event)
+
+        process = get_subprocess(config=self.config, target=target, sockets=self.sockets)
+        process.start()
+        return process
 
     def restart(self) -> None:
         if sys.platform == "win32":  # pragma: py-not-win32
-            self.is_restarting = True
-            assert self.process.pid is not None
-            os.kill(self.process.pid, signal.CTRL_C_EVENT)
-
-            # This is a workaround to ensure the Ctrl+C event is processed
-            sys.stdout.write(" ")  # This has to be a non-empty string
-            sys.stdout.flush()
+            assert self.shutdown_event is not None
+            self.shutdown_event.set()
         else:  # pragma: py-win32
             self.process.terminate()
         self.process.join()
 
-        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
-        self.process.start()
+        self.process = self._start_process()
 
     def shutdown(self) -> None:
         if sys.platform == "win32":
-            self.should_exit.set()  # pragma: py-not-win32
+            assert self.shutdown_event is not None  # pragma: py-not-win32
+            self.shutdown_event.set()  # pragma: py-not-win32
         else:
             self.process.terminate()  # pragma: py-win32
         self.process.join()

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -4,9 +4,13 @@ import logging
 from collections.abc import Callable, Iterator
 from pathlib import Path
 from socket import socket
+from typing import TYPE_CHECKING
 
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
+
+if TYPE_CHECKING:
+    from multiprocessing.synchronize import Event
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -17,8 +21,9 @@ class StatReload(BaseReload):
         config: Config,
         target: Callable[[list[socket] | None], None],
         sockets: list[socket],
+        shutdown_event: Event,
     ) -> None:
-        super().__init__(config, target, sockets)
+        super().__init__(config, target, sockets, shutdown_event)
         self.reloader_name = "StatReload"
         self.mtimes: dict[Path, float] = {}
 

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 from socket import socket
+from typing import TYPE_CHECKING
 
 from watchfiles import watch
 
 from uvicorn.config import Config
 from uvicorn.supervisors.basereload import BaseReload
+
+if TYPE_CHECKING:
+    from multiprocessing.synchronize import Event
 
 
 class FileFilter:
@@ -58,8 +62,9 @@ class WatchFilesReload(BaseReload):
         config: Config,
         target: Callable[[list[socket] | None], None],
         sockets: list[socket],
+        shutdown_event: Event,
     ) -> None:
-        super().__init__(config, target, sockets)
+        super().__init__(config, target, sockets, shutdown_event)
         self.reloader_name = "WatchFiles"
         self.reload_dirs: list[Path] = []
         for directory in config.reload_dirs:


### PR DESCRIPTION
## Summary

- Replace `CTRL_C_EVENT` with a shared multiprocessing event for Windows reloads.
- Let the server finish lifespan shutdown before the reloader starts its replacement.
- Add a regression test for windowless Windows processes.

Closes #1972.

## Testing

- `scripts/test`
- Full test suite on Windows Server 2022 with Python 3.12
- 20 consecutive graceful reloads and an isolated `Ctrl+C` shutdown on Windows

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows reload behavior for more reliable application restarts.
  - Ensured reload and shutdown operations complete gracefully without leaving child processes running.
  - Improved cleanup after interrupted or completed reload sessions.
  - Preserved existing process termination behavior on non-Windows platforms.
  - Improved shutdown coordination during reload cycles to reduce stalled or orphaned processes.

- **Tests**
  - Added coverage for Windows startup, reload, graceful shutdown logging, and process-tree cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->