### PR TITLE
Control worker shutdown over IPC

### DIFF
--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import functools
 import os
 import signal
@@ -40,15 +41,45 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     pass  # pragma: no cover
 
 
+async def slow_startup_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+    assert scope["type"] == "lifespan"
+
+    while True:
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            await asyncio.sleep(0.5)
+            await send({"type": "lifespan.startup.complete"})
+        elif message["type"] == "lifespan.shutdown":
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+
+
+def start_supervisor(supervisor: Multiprocess) -> threading.Thread:
+    thread = threading.Thread(target=supervisor.run, daemon=True)
+    thread.start()
+    return thread
+
+
+def stop_supervisor(supervisor: Multiprocess, thread: threading.Thread, sig: int = signal.SIGINT) -> None:
+    supervisor.signal_queue.append(sig)
+    thread.join(10)
+    assert not thread.is_alive()
+
+
 def test_process_ping_pong() -> None:
     process = Process(Config(app=app), sockets=[])
-    threading.Thread(target=process.always_pong, daemon=True).start()
+    process.start()
+    assert process.wait_until_ready(5)
     assert process.ping()
+    process.terminate()
+    process.join()
 
 
 def test_process_ping_pong_timeout() -> None:
     process = Process(Config(app=app), sockets=[])
     assert not process.ping(0.1)
+    process.parent_conn.close()
+    process.child_conn.close()
 
 
 def test_process_ping_broken_pipe() -> None:
@@ -56,18 +87,30 @@ def test_process_ping_broken_pipe() -> None:
     process.parent_conn.close()
     process.child_conn.close()
     assert not process.ping(0.1)
+    process.terminate()
+
+
+def test_process_exits_when_control_pipe_closes() -> None:
+    process = Process(Config(app=app), sockets=[])
+    process.start()
+    assert process.wait_until_ready(5)
+
+    process.parent_conn.close()
+    process.join()
+
+    assert process.exitcode == 0
 
 
 def test_process_ready() -> None:
-    """`is_ready()` reflects whether the worker's server has finished startup."""
-    process = Process(Config(app=app), sockets=[])
-    threading.Thread(target=process.always_pong, daemon=True).start()
+    process = Process(Config(app=slow_startup_app), sockets=[])
+    process.start()
 
     assert process.ping()
     assert not process.is_ready()
+    assert process.wait_until_ready(5)
 
-    process.server.started = True
-    assert process.is_ready()
+    process.terminate()
+    process.join()
 
 
 @new_console_in_windows
@@ -80,9 +123,8 @@ def test_multiprocess_run() -> None:
     """
     config = Config(app=app, workers=2)
     supervisor = Multiprocess(config, sockets=[])
-    threading.Thread(target=supervisor.run, daemon=True).start()
-    supervisor.signal_queue.append(signal.SIGINT)
-    supervisor.join_all()
+    thread = start_supervisor(supervisor)
+    stop_supervisor(supervisor, thread)
 
 
 @new_console_in_windows
@@ -92,7 +134,7 @@ def test_multiprocess_health_check() -> None:
     """
     config = Config(app=app, workers=2)
     supervisor = Multiprocess(config, sockets=[])
-    threading.Thread(target=supervisor.run, daemon=True).start()
+    thread = start_supervisor(supervisor)
     time.sleep(1)
     process = supervisor.processes[0]
     process.kill()
@@ -101,8 +143,7 @@ def test_multiprocess_health_check() -> None:
     while not all(p.is_alive() for p in supervisor.processes):  # pragma: no cover
         assert time.monotonic() < deadline, "Timed out waiting for processes to be alive"
         time.sleep(0.1)
-    supervisor.signal_queue.append(signal.SIGINT)
-    supervisor.join_all()
+    stop_supervisor(supervisor, thread)
 
 
 @new_console_in_windows
@@ -120,6 +161,7 @@ def test_multiprocess_worker_dies_on_startup() -> None:
         assert time.monotonic() < deadline, "Timed out waiting for the supervisor to stop"
         time.sleep(0.1)
     thread.join()
+    assert not thread.is_alive()
 
 
 @new_console_in_windows
@@ -129,10 +171,9 @@ def test_multiprocess_sigterm() -> None:
     """
     config = Config(app=app, workers=2)
     supervisor = Multiprocess(config, sockets=[])
-    threading.Thread(target=supervisor.run, daemon=True).start()
+    thread = start_supervisor(supervisor)
     time.sleep(1)
-    supervisor.signal_queue.append(signal.SIGTERM)
-    supervisor.join_all()
+    stop_supervisor(supervisor, thread, signal.SIGTERM)
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGBREAK"), reason="platform unsupports SIGBREAK")
@@ -143,10 +184,9 @@ def test_multiprocess_sigbreak() -> None:  # pragma: py-not-win32
     """
     config = Config(app=app, workers=2)
     supervisor = Multiprocess(config, sockets=[])
-    threading.Thread(target=supervisor.run, daemon=True).start()
+    thread = start_supervisor(supervisor)
     time.sleep(1)
-    supervisor.signal_queue.append(getattr(signal, "SIGBREAK"))
-    supervisor.join_all()
+    stop_supervisor(supervisor, thread, getattr(signal, "SIGBREAK"))
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="platform unsupports SIGHUP")
@@ -156,7 +196,7 @@ def test_multiprocess_sighup() -> None:
     """
     config = Config(app=app, workers=2, timeout_worker_healthcheck=30)
     supervisor = Multiprocess(config, sockets=[])
-    threading.Thread(target=supervisor.run, daemon=True).start()
+    thread = start_supervisor(supervisor)
     time.sleep(1)
     pids = [p.pid for p in supervisor.processes]
     supervisor.signal_queue.append(signal.SIGHUP)
@@ -166,8 +206,7 @@ def test_multiprocess_sighup() -> None:
             break
         time.sleep(0.1)
     assert pids != [p.pid for p in supervisor.processes]
-    supervisor.signal_queue.append(signal.SIGINT)
-    supervisor.join_all()
+    stop_supervisor(supervisor, thread)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="test spawns real worker processes")
@@ -213,12 +252,11 @@ def test_multiprocess_sigttin() -> None:
     """
     config = Config(app=app, workers=2)
     supervisor = Multiprocess(config, sockets=[])
-    threading.Thread(target=supervisor.run, daemon=True).start()
+    thread = start_supervisor(supervisor)
     supervisor.signal_queue.append(signal.SIGTTIN)
     time.sleep(1)
     assert len(supervisor.processes) == 3
-    supervisor.signal_queue.append(signal.SIGINT)
-    supervisor.join_all()
+    stop_supervisor(supervisor, thread)
 
 
 @pytest.mark.skipif(not hasattr(signal, "SIGTTOU"), reason="platform unsupports SIGTTOU")
@@ -228,12 +266,11 @@ def test_multiprocess_sigttou() -> None:
     """
     config = Config(app=app, workers=2)
     supervisor = Multiprocess(config, sockets=[])
-    threading.Thread(target=supervisor.run, daemon=True).start()
+    thread = start_supervisor(supervisor)
     supervisor.signal_queue.append(signal.SIGTTOU)
     time.sleep(1)
     assert len(supervisor.processes) == 1
     supervisor.signal_queue.append(signal.SIGTTOU)
     time.sleep(1)
     assert len(supervisor.processes) == 1
-    supervisor.signal_queue.append(signal.SIGINT)
-    supervisor.join_all()
+    stop_supervisor(supervisor, thread)

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import functools
 import os
 import signal
@@ -41,19 +40,6 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
     pass  # pragma: no cover
 
 
-async def slow_startup_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
-    assert scope["type"] == "lifespan"
-
-    while True:
-        message = await receive()
-        if message["type"] == "lifespan.startup":
-            await asyncio.sleep(0.5)
-            await send({"type": "lifespan.startup.complete"})
-        elif message["type"] == "lifespan.shutdown":
-            await send({"type": "lifespan.shutdown.complete"})
-            return
-
-
 def start_supervisor(supervisor: Multiprocess) -> threading.Thread:
     thread = threading.Thread(target=supervisor.run, daemon=True)
     thread.start()
@@ -64,53 +50,6 @@ def stop_supervisor(supervisor: Multiprocess, thread: threading.Thread, sig: int
     supervisor.signal_queue.append(sig)
     thread.join(10)
     assert not thread.is_alive()
-
-
-def test_process_ping_pong() -> None:
-    process = Process(Config(app=app), sockets=[])
-    process.start()
-    assert process.wait_until_ready(5)
-    assert process.ping()
-    process.terminate()
-    process.join()
-
-
-def test_process_ping_pong_timeout() -> None:
-    process = Process(Config(app=app), sockets=[])
-    assert not process.ping(0.1)
-    process.parent_conn.close()
-    process.child_conn.close()
-
-
-def test_process_ping_broken_pipe() -> None:
-    process = Process(Config(app=app), sockets=[])
-    process.parent_conn.close()
-    process.child_conn.close()
-    assert not process.ping(0.1)
-    process.terminate()
-
-
-def test_process_exits_when_control_pipe_closes() -> None:
-    process = Process(Config(app=app), sockets=[])
-    process.start()
-    assert process.wait_until_ready(5)
-
-    process.parent_conn.close()
-    process.join()
-
-    assert process.exitcode == 0
-
-
-def test_process_ready() -> None:
-    process = Process(Config(app=slow_startup_app), sockets=[])
-    process.start()
-
-    assert process.ping()
-    assert not process.is_ready()
-    assert process.wait_until_ready(5)
-
-    process.terminate()
-    process.join()
 
 
 @new_console_in_windows
@@ -224,15 +163,6 @@ def test_multiprocess_restart_aborts_when_replacement_not_ready(monkeypatch: pyt
     assert all(process.is_alive() for process in supervisor.processes)
     supervisor.terminate_all()
     supervisor.join_all()
-
-
-def test_wait_until_ready_bails_on_shutdown_or_dead_worker() -> None:
-    process = Process(Config(app=app), sockets=[])
-
-    should_exit = threading.Event()
-    should_exit.set()
-    assert process.wait_until_ready(timeout=1, should_exit=should_exit) is False
-    assert process.wait_until_ready(timeout=0.5) is False
 
 
 def test_multiprocess_restart_stops_when_shutting_down() -> None:

--- a/tests/supervisors/test_process.py
+++ b/tests/supervisors/test_process.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from uvicorn import Config
+from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
+from uvicorn.supervisors.process import Process
+
+
+async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+    pass  # pragma: no cover
+
+
+async def slow_startup_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+    assert scope["type"] == "lifespan"
+
+    while True:
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            await asyncio.sleep(0.5)
+            await send({"type": "lifespan.startup.complete"})
+        elif message["type"] == "lifespan.shutdown":
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+
+
+def test_process_ping_pong() -> None:
+    process = Process(Config(app=app), sockets=[])
+    process.start()
+    assert process.wait_until_ready(5)
+    assert process.ping()
+    process.terminate()
+    process.join()
+
+
+def test_process_ping_pong_timeout() -> None:
+    process = Process(Config(app=app), sockets=[])
+    assert not process.ping(0.1)
+    process.parent_conn.close()
+    process.child_conn.close()
+
+
+def test_process_ping_broken_pipe() -> None:
+    process = Process(Config(app=app), sockets=[])
+    process.parent_conn.close()
+    process.child_conn.close()
+    assert not process.ping(0.1)
+    process.terminate()
+
+
+def test_process_exits_when_control_pipe_closes() -> None:
+    process = Process(Config(app=app), sockets=[])
+    process.start()
+    assert process.wait_until_ready(5)
+
+    process.parent_conn.close()
+    process.join()
+
+    assert process.exitcode == 0
+
+
+def test_process_ready() -> None:
+    process = Process(Config(app=slow_startup_app), sockets=[])
+    process.start()
+
+    assert process.ping()
+    assert not process.is_ready()
+    assert process.wait_until_ready(5)
+
+    process.terminate()
+    process.join()
+
+
+def test_wait_until_ready_bails_on_shutdown_or_dead_worker() -> None:
+    process = Process(Config(app=app), sockets=[])
+
+    should_exit = threading.Event()
+    should_exit.set()
+    assert process.wait_until_ready(timeout=1, should_exit=should_exit) is False
+    assert process.wait_until_ready(timeout=0.5) is False
+
+    process.parent_conn.close()
+    process.child_conn.close()

--- a/tests/supervisors/test_process.py
+++ b/tests/supervisors/test_process.py
@@ -73,10 +73,17 @@ def test_process_exits_when_control_pipe_closes() -> None:
         assert process.wait_until_ready(5)
 
         process.parent_conn.close()
-        process.terminate()
-        process.join()
+        process.join(5)
 
         assert process.exitcode == 0
+
+
+def test_process_terminate_broken_pipe() -> None:
+    process = Process(Config(app=app), sockets=[])
+    with managed_process(process):
+        assert process.wait_until_ready(5)
+        process.parent_conn.close()
+        process.terminate()
 
 
 def test_process_ready() -> None:

--- a/tests/supervisors/test_process.py
+++ b/tests/supervisors/test_process.py
@@ -104,7 +104,9 @@ def test_wait_until_ready_bails_on_shutdown_or_dead_worker() -> None:
 def test_wait_until_ready_times_out() -> None:
     process = Process(Config(app=app), sockets=[], target=sleeping_target)
     with managed_process(process):
+        started = time.monotonic()
         assert process.wait_until_ready(timeout=0.1) is False
+        assert time.monotonic() - started < 0.3
 
         process.join()
         assert process.exitcode == 0

--- a/tests/supervisors/test_process.py
+++ b/tests/supervisors/test_process.py
@@ -73,6 +73,7 @@ def test_process_exits_when_control_pipe_closes() -> None:
         assert process.wait_until_ready(5)
 
         process.parent_conn.close()
+        process.terminate()
         process.join()
 
         assert process.exitcode == 0

--- a/tests/supervisors/test_process.py
+++ b/tests/supervisors/test_process.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
+from socket import socket
 
 from uvicorn import Config
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
@@ -10,6 +12,10 @@ from uvicorn.supervisors.process import Process
 
 async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
     pass  # pragma: no cover
+
+
+def sleeping_target(sockets: list[socket] | None) -> None:
+    time.sleep(0.5)
 
 
 async def slow_startup_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -82,3 +88,13 @@ def test_wait_until_ready_bails_on_shutdown_or_dead_worker() -> None:
 
     process.parent_conn.close()
     process.child_conn.close()
+
+
+def test_wait_until_ready_times_out() -> None:
+    process = Process(Config(app=app), sockets=[], target=sleeping_target)
+    process.start()
+
+    assert process.wait_until_ready(timeout=0.1) is False
+
+    process.join()
+    assert process.exitcode == 0

--- a/tests/supervisors/test_process.py
+++ b/tests/supervisors/test_process.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from socket import socket
 
 from uvicorn import Config
@@ -16,6 +18,16 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 
 def sleeping_target(sockets: list[socket] | None) -> None:
     time.sleep(0.5)
+
+
+@contextmanager
+def managed_process(process: Process) -> Iterator[Process]:
+    process.start()
+    try:
+        yield process
+    finally:
+        process.kill()
+        process.join()
 
 
 async def slow_startup_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
@@ -33,11 +45,11 @@ async def slow_startup_app(scope: Scope, receive: ASGIReceiveCallable, send: ASG
 
 def test_process_ping_pong() -> None:
     process = Process(Config(app=app), sockets=[])
-    process.start()
-    assert process.wait_until_ready(5)
-    assert process.ping()
-    process.terminate()
-    process.join()
+    with managed_process(process):
+        assert process.wait_until_ready(5)
+        assert process.ping()
+        process.terminate()
+        process.join()
 
 
 def test_process_ping_pong_timeout() -> None:
@@ -57,25 +69,24 @@ def test_process_ping_broken_pipe() -> None:
 
 def test_process_exits_when_control_pipe_closes() -> None:
     process = Process(Config(app=app), sockets=[])
-    process.start()
-    assert process.wait_until_ready(5)
+    with managed_process(process):
+        assert process.wait_until_ready(5)
 
-    process.parent_conn.close()
-    process.join()
+        process.parent_conn.close()
+        process.join()
 
-    assert process.exitcode == 0
+        assert process.exitcode == 0
 
 
 def test_process_ready() -> None:
     process = Process(Config(app=slow_startup_app), sockets=[])
-    process.start()
+    with managed_process(process):
+        assert process.ping()
+        assert not process.is_ready()
+        assert process.wait_until_ready(5)
 
-    assert process.ping()
-    assert not process.is_ready()
-    assert process.wait_until_ready(5)
-
-    process.terminate()
-    process.join()
+        process.terminate()
+        process.join()
 
 
 def test_wait_until_ready_bails_on_shutdown_or_dead_worker() -> None:
@@ -92,9 +103,8 @@ def test_wait_until_ready_bails_on_shutdown_or_dead_worker() -> None:
 
 def test_wait_until_ready_times_out() -> None:
     process = Process(Config(app=app), sockets=[], target=sleeping_target)
-    process.start()
+    with managed_process(process):
+        assert process.wait_until_ready(timeout=0.1) is False
 
-    assert process.wait_until_ready(timeout=0.1) is False
-
-    process.join()
-    assert process.exitcode == 0
+        process.join()
+        assert process.exitcode == 0

--- a/tests/supervisors/test_reload.py
+++ b/tests/supervisors/test_reload.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import signal
 import socket
+import subprocess
 import sys
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -399,6 +400,75 @@ def test_base_reloader_should_exit(tmp_path: Path):
     assert reloader.should_exit.is_set()
     with pytest.raises(StopIteration):
         reloader.pause()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only process creation mode")
+def test_reload_gracefully_stops_windowless_child(tmp_path: Path, unused_tcp_port: int) -> None:  # pragma: py-not-win32
+    app_path = tmp_path / "app.py"
+    app_path.write_text(
+        """\
+from __future__ import annotations
+
+async def app(scope, receive, send):
+    if scope["type"] != "lifespan":
+        return
+
+    while True:
+        message = await receive()
+        if message["type"] == "lifespan.startup":
+            await send({"type": "lifespan.startup.complete"})
+        elif message["type"] == "lifespan.shutdown":
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+"""
+    )
+    # Use StatReload so watcher behavior does not affect this process-shutdown test.
+    (tmp_path / "watchfiles.py").write_text("raise ImportError\n")
+    log_path = tmp_path / "uvicorn.log"
+
+    with log_path.open("w") as log:
+        process = subprocess.Popen(
+            [sys.executable, "-m", "uvicorn", "app:app", "--reload", "--port", str(unused_tcp_port)],
+            cwd=tmp_path,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            creationflags=0x08000000,  # CREATE_NO_WINDOW
+        )
+
+        try:
+            deadline = monotonic() + 15
+            while monotonic() < deadline:
+                output = log_path.read_text()
+                if "Application startup complete" in output or process.poll() is not None:
+                    break
+                sleep(0.1)
+
+            assert process.poll() is None, f"Uvicorn exited before startup:\n{output}"
+            assert "Application startup complete" in output, f"Uvicorn did not start:\n{output}"
+
+            sleep(1)
+            app_path.write_text(app_path.read_text() + "\n")
+
+            deadline = monotonic() + 15
+            while monotonic() < deadline:
+                output = log_path.read_text()
+                if output.count("Application startup complete") >= 2 or process.poll() is not None:
+                    break
+                sleep(0.1)
+
+            assert process.poll() is None, f"Uvicorn exited during reload:\n{output}"
+            assert output.count("Application startup complete") >= 2, f"Uvicorn did not reload:\n{output}"
+            assert "Application shutdown complete" in output
+        finally:
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            process.kill()
+            process.wait()
 
 
 def test_base_reloader_closes_sockets_on_shutdown():

--- a/uvicorn/_subprocess.py
+++ b/uvicorn/_subprocess.py
@@ -28,8 +28,7 @@ def get_subprocess(
     The child is not yet started at this point.
 
     * config - The Uvicorn configuration instance.
-    * target - A callable that accepts a list of sockets. In practice this will
-               be the `Server.run()` method.
+    * target - A callable that accepts a list of sockets.
     * sockets - A list of sockets to pass to the server. Sockets are bound once
                 by the parent process, and then passed to the child processes.
     """
@@ -61,8 +60,7 @@ def subprocess_started(
     Called when the child process starts.
 
     * config - The Uvicorn configuration instance.
-    * target - A callable that accepts a list of sockets. In practice this will
-               be the `Server.run()` method.
+    * target - A callable that accepts a list of sockets.
     * sockets - A list of sockets to pass to the server. Sockets are bound once
                 by the parent process, and then passed to the child processes.
     * stdin_fileno - The file number of sys.stdin, so that it can be reattached
@@ -76,7 +74,6 @@ def subprocess_started(
     config.configure_logging()
 
     try:
-        # Now we can call into `Server.run(sockets=sockets)`
         target(sockets=sockets)
     except KeyboardInterrupt:  # pragma: no cover
         # suppress the exception to avoid a traceback from subprocess.Popen

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -608,16 +608,17 @@ def run(
     else:
         config.load_app()
 
-    server = Server(config=config)
+    server: Server | None = None
 
     try:
         if config.should_reload:
             sock = config.bind_socket()
-            ChangeReload(config, target=server.run, sockets=[sock]).run()
+            ChangeReload(config, target=None, sockets=[sock]).run()
         elif config.workers > 1:
             sock = config.bind_socket()
             Multiprocess(config, sockets=[sock]).run()
         else:
+            server = Server(config=config)
             server.run()
     except KeyboardInterrupt:  # pragma: full coverage
         pass
@@ -625,7 +626,7 @@ def run(
         if config.uds and os.path.exists(config.uds):
             os.remove(config.uds)  # pragma: py-win32
 
-    if not server.started and not config.should_reload and config.workers == 1:
+    if server is not None and not server.started:
         sys.exit(STARTUP_FAILURE)
 
 

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -339,11 +339,9 @@ class Server:
         for captured_signal in reversed(self._captured_signals):
             signal.raise_signal(captured_signal)
 
-    def request_shutdown(self, force: bool = False) -> None:
-        self.should_exit = True
-        if force:
-            self.force_exit = True  # pragma: full coverage
-
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
         self._captured_signals.append(sig)
-        self.request_shutdown(force=self.should_exit and sig == signal.SIGINT)
+        if self.should_exit and sig == signal.SIGINT:
+            self.force_exit = True  # pragma: full coverage
+        else:
+            self.should_exit = True

--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -339,9 +339,11 @@ class Server:
         for captured_signal in reversed(self._captured_signals):
             signal.raise_signal(captured_signal)
 
+    def request_shutdown(self, force: bool = False) -> None:
+        self.should_exit = True
+        if force:
+            self.force_exit = True  # pragma: full coverage
+
     def handle_exit(self, sig: int, frame: FrameType | None) -> None:
         self._captured_signals.append(sig)
-        if self.should_exit and sig == signal.SIGINT:
-            self.force_exit = True  # pragma: full coverage
-        else:
-            self.should_exit = True
+        self.request_shutdown(force=self.should_exit and sig == signal.SIGINT)

--- a/uvicorn/supervisors/basereload.py
+++ b/uvicorn/supervisors/basereload.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import os
 import signal
-import sys
 import threading
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -11,8 +10,8 @@ from socket import socket
 from types import FrameType
 
 from uvicorn._ansi import style
-from uvicorn._subprocess import get_subprocess
 from uvicorn.config import Config
+from uvicorn.supervisors.process import Process
 
 HANDLED_SIGNALS = (
     signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
@@ -26,7 +25,7 @@ class BaseReload:
     def __init__(
         self,
         config: Config,
-        target: Callable[[list[socket] | None], None],
+        target: Callable[[list[socket] | None], None] | None,
         sockets: list[socket],
     ) -> None:
         self.config = config
@@ -34,17 +33,13 @@ class BaseReload:
         self.sockets = sockets
         self.should_exit = threading.Event()
         self.pid = os.getpid()
-        self.is_restarting = False
         self.reloader_name: str | None = None
 
     def signal_handler(self, sig: int, frame: FrameType | None) -> None:  # pragma: full coverage
         """
         A signal handler that is registered with the parent process.
         """
-        if sys.platform == "win32" and self.is_restarting:
-            self.is_restarting = False
-        else:
-            self.should_exit.set()
+        self.should_exit.set()
 
     def run(self) -> None:
         self.startup()
@@ -80,30 +75,18 @@ class BaseReload:
         for sig in HANDLED_SIGNALS:
             signal.signal(sig, self.signal_handler)
 
-        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+        self.process = Process(config=self.config, target=self.target, sockets=self.sockets)
         self.process.start()
 
     def restart(self) -> None:
-        if sys.platform == "win32":  # pragma: py-not-win32
-            self.is_restarting = True
-            assert self.process.pid is not None
-            os.kill(self.process.pid, signal.CTRL_C_EVENT)
-
-            # This is a workaround to ensure the Ctrl+C event is processed
-            sys.stdout.write(" ")  # This has to be a non-empty string
-            sys.stdout.flush()
-        else:  # pragma: py-win32
-            self.process.terminate()
+        self.process.terminate()
         self.process.join()
 
-        self.process = get_subprocess(config=self.config, target=self.target, sockets=self.sockets)
+        self.process = Process(config=self.config, target=self.target, sockets=self.sockets)
         self.process.start()
 
     def shutdown(self) -> None:
-        if sys.platform == "win32":
-            self.should_exit.set()  # pragma: py-not-win32
-        else:
-            self.process.terminate()  # pragma: py-win32
+        self.process.terminate()
         self.process.join()
 
         for sock in self.sockets:

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 import logging
 import os
-import pickle
 import signal
 import threading
-import time
-from multiprocessing import Pipe
 from socket import socket
 
 from uvicorn._ansi import style
-from uvicorn._subprocess import get_subprocess
 from uvicorn.config import STARTUP_FAILURE, Config
-from uvicorn.server import Server
+from uvicorn.supervisors.process import Process
 
 SIGNALS = {
     getattr(signal, f"SIG{x}"): x
@@ -21,121 +17,6 @@ SIGNALS = {
 }
 
 logger = logging.getLogger("uvicorn.error")
-
-
-class Process:
-    def __init__(
-        self,
-        config: Config,
-        sockets: list[socket],
-    ) -> None:
-        self.config = config
-        self._server: Server | None = None
-
-        self.parent_conn, self.child_conn = Pipe()
-        self.process = get_subprocess(config, self.target, sockets)
-
-    def _healthcheck(self, timeout: float) -> bool | None:
-        """Receives a timeout and returns the worker's startup flag, or None if it does not answer in time."""
-        try:
-            self.parent_conn.send(b"ping")
-            if self.parent_conn.poll(timeout):
-                started: bool = self.parent_conn.recv()
-                return started
-            return None
-        except (OSError, EOFError, pickle.UnpicklingError):
-            return None
-
-    def ping(self, timeout: float = 5) -> bool:
-        """Receives a timeout and returns True if the worker answers a healthcheck in time."""
-        return self._healthcheck(timeout) is not None
-
-    def is_ready(self, timeout: float = 5) -> bool:
-        """Receives a timeout and returns True if the worker answers and its server has finished startup."""
-        return self._healthcheck(timeout) is True
-
-    def pong(self) -> None:
-        """Receives one healthcheck ping and replies with whether the server has finished startup."""
-        self.child_conn.recv()
-        self.child_conn.send(self.server.started)
-
-    def always_pong(self) -> None:
-        while True:
-            self.pong()
-
-    def target(self, sockets: list[socket] | None = None) -> None:  # pragma: no cover
-        if os.name == "nt":  # pragma: py-not-win32
-            # Windows doesn't support SIGTERM, so we use SIGBREAK instead.
-            # And then we raise SIGTERM when SIGBREAK is received.
-            # https://learn.microsoft.com/zh-cn/cpp/c-runtime-library/reference/signal?view=msvc-170
-            signal.signal(
-                signal.SIGBREAK,  # type: ignore[attr-defined]
-                lambda sig, frame: signal.raise_signal(signal.SIGTERM),
-            )
-
-        threading.Thread(target=self.always_pong, daemon=True).start()
-        self.server.run(sockets)
-
-    def is_alive(self, timeout: float = 5) -> bool:
-        if not self.process.is_alive():
-            return False  # pragma: full coverage
-
-        return self.ping(timeout)
-
-    def wait_until_ready(self, timeout: float, should_exit: threading.Event | None = None) -> bool:
-        """Receives a timeout and returns True if the worker starts serving, or False on exit, shutdown, or timeout."""
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if should_exit is not None and should_exit.is_set():
-                return False
-            if not self.process.is_alive():
-                return False
-            if self.is_ready(timeout=1):
-                return True
-            time.sleep(0.1)
-        return False
-
-    def start(self) -> None:
-        self.process.start()
-
-    def terminate(self) -> None:
-        if self.process.exitcode is None:  # Process is still running
-            assert self.process.pid is not None
-            if os.name == "nt":  # pragma: py-not-win32
-                # Windows doesn't support SIGTERM.
-                # So send SIGBREAK, and then in process raise SIGTERM.
-                os.kill(self.process.pid, signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
-            else:
-                os.kill(self.process.pid, signal.SIGTERM)
-            logger.info(f"Terminated child process [{self.process.pid}]")
-
-            self.parent_conn.close()
-            self.child_conn.close()
-
-    def kill(self) -> None:
-        # In Windows, the method will call `TerminateProcess` to kill the process.
-        # In Unix, the method will send SIGKILL to the process.
-        self.process.kill()
-        self.parent_conn.close()
-        self.child_conn.close()
-
-    def join(self) -> None:
-        logger.info(f"Waiting for child process [{self.process.pid}]")
-        self.process.join()
-
-    @property
-    def server(self) -> Server:
-        if self._server is None:
-            self._server = Server(config=self.config)
-        return self._server
-
-    @property
-    def pid(self) -> int | None:
-        return self.process.pid
-
-    @property
-    def exitcode(self) -> int | None:
-        return self.process.exitcode
 
 
 class Multiprocess:
@@ -213,19 +94,16 @@ class Multiprocess:
 
     def keep_subprocess_alive(self) -> None:
         if self.should_exit.is_set():
-            return  # parent process is exiting, no need to keep subprocess alive
+            return
 
         for idx, process in enumerate(self.processes):
             if process.is_alive(timeout=self.config.timeout_worker_healthcheck):
                 continue
 
-            process.kill()  # process is hung, kill it
+            process.kill()
             process.join()
 
             if process.exitcode == STARTUP_FAILURE:
-                # The worker failed before it started serving, so the app, TLS or socket
-                # bind is broken and would fail the same way on every restart.
-                # See https://github.com/encode/uvicorn/discussions/2440.
                 logger.error(f"Child process [{process.pid}] failed to start, stopping the parent process.")
                 self.should_exit.set()
                 return

--- a/uvicorn/supervisors/process.py
+++ b/uvicorn/supervisors/process.py
@@ -30,9 +30,9 @@ def _listen(child_conn: Connection, server: Server) -> None:
             if command == PING:
                 child_conn.send(server.started)
             elif command == SHUTDOWN:
-                server.request_shutdown()
+                server.should_exit = True
         except (OSError, EOFError):
-            server.request_shutdown()
+            server.should_exit = True
             return
 
 

--- a/uvicorn/supervisors/process.py
+++ b/uvicorn/supervisors/process.py
@@ -44,7 +44,7 @@ def _run(
     child_conn: Connection,
 ) -> None:
     parent_conn.close()
-    if target is not None:  # pragma: full coverage - exercised only in spawned reload test processes
+    if target is not None:
         target(sockets)
         return
 

--- a/uvicorn/supervisors/process.py
+++ b/uvicorn/supervisors/process.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import functools
+import logging
+import pickle
+import threading
+import time
+from collections.abc import Callable
+from multiprocessing import Pipe
+from socket import socket
+from typing import TYPE_CHECKING
+
+from uvicorn._subprocess import get_subprocess
+from uvicorn.config import Config
+from uvicorn.server import Server
+
+PING = b"ping"
+SHUTDOWN = b"shutdown"
+
+logger = logging.getLogger("uvicorn.error")
+
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
+
+def _listen(child_conn: Connection, server: Server) -> None:
+    while True:
+        try:
+            command = child_conn.recv()
+            if command == PING:
+                child_conn.send(server.started)
+            elif command == SHUTDOWN:
+                server.request_shutdown()
+        except (OSError, EOFError):
+            server.request_shutdown()
+            return
+
+
+def _run(
+    sockets: list[socket] | None,
+    config: Config,
+    target: Callable[[list[socket] | None], None] | None,
+    parent_conn: Connection,
+    child_conn: Connection,
+) -> None:
+    parent_conn.close()
+    if target is not None:  # pragma: full coverage - exercised only in spawned reload test processes
+        target(sockets)
+        return
+
+    server = Server(config=config)
+    threading.Thread(target=_listen, args=(child_conn, server), daemon=True).start()
+    server.run(sockets)
+
+
+class Process:
+    def __init__(
+        self,
+        config: Config,
+        sockets: list[socket],
+        target: Callable[[list[socket] | None], None] | None = None,
+    ) -> None:
+        self.config = config
+        self.target = target
+        self.parent_conn, self.child_conn = Pipe()
+        self._close_lock = threading.Lock()
+        self._parent_conn_closed = False
+        target_with_control = functools.partial(
+            _run,
+            config=config,
+            target=target,
+            parent_conn=self.parent_conn,
+            child_conn=self.child_conn,
+        )
+        self.process = get_subprocess(config, target_with_control, sockets)
+
+    def _healthcheck(self, timeout: float) -> bool | None:
+        try:
+            self.parent_conn.send(PING)
+            if self.parent_conn.poll(timeout):
+                started: bool = self.parent_conn.recv()
+                return started
+            return None
+        except (OSError, EOFError, pickle.UnpicklingError):
+            return None
+
+    def ping(self, timeout: float = 5) -> bool:
+        return self._healthcheck(timeout) is not None
+
+    def is_ready(self, timeout: float = 5) -> bool:
+        return self._healthcheck(timeout) is True
+
+    def is_alive(self, timeout: float = 5) -> bool:
+        if not self.process.is_alive():
+            return False  # pragma: full coverage
+        return self.ping(timeout)
+
+    def wait_until_ready(self, timeout: float, should_exit: threading.Event | None = None) -> bool:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if should_exit is not None and should_exit.is_set():
+                return False
+            if not self.process.is_alive():
+                return False
+            if self.is_ready(timeout=1):
+                return True
+            time.sleep(0.1)
+        return False
+
+    def start(self) -> None:
+        self.process.start()
+        self.child_conn.close()
+
+    def terminate(self) -> None:
+        if self.process.exitcode is None:
+            try:
+                if self.target is None:
+                    self.parent_conn.send(SHUTDOWN)
+                else:
+                    self.process.terminate()
+            except (OSError, EOFError):
+                pass
+            logger.info(f"Terminated child process [{self.process.pid}]")
+
+    def _close_parent_conn(self) -> None:
+        with self._close_lock:
+            if not self._parent_conn_closed:
+                self.parent_conn.close()
+                self._parent_conn_closed = True
+
+    def kill(self) -> None:
+        self.process.kill()
+        self._close_parent_conn()
+
+    def join(self) -> None:
+        logger.info(f"Waiting for child process [{self.process.pid}]")
+        self.process.join()
+        self._close_parent_conn()
+
+    @property
+    def pid(self) -> int | None:
+        return self.process.pid
+
+    @property
+    def exitcode(self) -> int | None:
+        return self.process.exitcode

--- a/uvicorn/supervisors/process.py
+++ b/uvicorn/supervisors/process.py
@@ -135,10 +135,11 @@ class Process:
         self.process.kill()
         self._close_parent_conn()
 
-    def join(self) -> None:
+    def join(self, timeout: float | None = None) -> None:
         logger.info(f"Waiting for child process [{self.process.pid}]")
-        self.process.join()
-        self._close_parent_conn()
+        self.process.join(timeout)
+        if not self.process.is_alive():
+            self._close_parent_conn()
 
     @property
     def pid(self) -> int | None:

--- a/uvicorn/supervisors/process.py
+++ b/uvicorn/supervisors/process.py
@@ -114,15 +114,16 @@ class Process:
         self.child_conn.close()
 
     def terminate(self) -> None:
-        if self.process.exitcode is None:
-            try:
-                if self.target is None:
-                    self.parent_conn.send(SHUTDOWN)
-                else:
-                    self.process.terminate()
-            except (OSError, EOFError):
-                pass
-            logger.info(f"Terminated child process [{self.process.pid}]")
+        if self.process.exitcode is not None or self.process.pid is None:
+            return
+        try:
+            if self.target is None:
+                self.parent_conn.send(SHUTDOWN)
+            else:
+                self.process.terminate()
+        except (OSError, EOFError):
+            return
+        logger.info(f"Terminated child process [{self.process.pid}]")
 
     def _close_parent_conn(self) -> None:
         with self._close_lock:

--- a/uvicorn/supervisors/process.py
+++ b/uvicorn/supervisors/process.py
@@ -97,15 +97,17 @@ class Process:
 
     def wait_until_ready(self, timeout: float, should_exit: threading.Event | None = None) -> bool:
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
             if should_exit is not None and should_exit.is_set():
                 return False
             if not self.process.is_alive():
                 return False
-            if self.is_ready(timeout=1):
+            if self.is_ready(timeout=min(1, remaining)):
                 return True
-            time.sleep(0.1)
-        return False
+            time.sleep(min(0.1, max(0, deadline - time.monotonic())))
 
     def start(self) -> None:
         self.process.start()

--- a/uvicorn/supervisors/statreload.py
+++ b/uvicorn/supervisors/statreload.py
@@ -15,7 +15,7 @@ class StatReload(BaseReload):
     def __init__(
         self,
         config: Config,
-        target: Callable[[list[socket] | None], None],
+        target: Callable[[list[socket] | None], None] | None,
         sockets: list[socket],
     ) -> None:
         super().__init__(config, target, sockets)

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -56,7 +56,7 @@ class WatchFilesReload(BaseReload):
     def __init__(
         self,
         config: Config,
-        target: Callable[[list[socket] | None], None],
+        target: Callable[[list[socket] | None], None] | None,
         sockets: list[socket],
     ) -> None:
         super().__init__(config, target, sockets)


### PR DESCRIPTION
## Summary

- Extract the worker process controller from the multiprocess supervisor.
- Use the existing process pipe for health checks and graceful shutdown commands.
- Create `Server` inside each child without exposing process-control APIs on it.
- Use the same process controller for reload and multiprocess workers.
- Add regression coverage for windowless Windows reloads.

This is an architectural alternative to [#3081](https://github.com/Kludex/uvicorn/pull/3081).

Closes #1972.

## Testing

- `scripts/test`
- 1,266 tests passed with 100% coverage

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.