### PR TITLE
Add connection diagrams and reverse proxy guidance to HTTP/2 docs

### DIFF
--- a/docs/concepts/http2.md
+++ b/docs/concepts/http2.md
@@ -198,7 +198,7 @@ Here's the state of proxy support at the time of writing:
 |-------|-----------------|--------------|------------|---------------|
 | **Envoy** | Yes | Yes | HTTP/2 protocol options on the cluster | [Connection Pooling Docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling) |
 | **Caddy** | Yes | Yes | `h2c://` upstream (experimental), or `versions 2` in the transport for TLS | [reverse_proxy Docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) |
-| **HAProxy** | Yes | Yes | `proto h2` on the server line | [HTTP/2 Docs](https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/) |
+| **HAProxy** | Yes | Yes | `proto h2` on the server line (cleartext), `ssl alpn h2,http/1.1` (TLS) | [HTTP/2 Docs](https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/) |
 | **Traefik** | Yes | Yes | `h2c://` service URL | [ServersTransport Docs](https://doc.traefik.io/traefik/routing/services/) |
 | **Apache** | Yes (2.4.19+) | No | `h2://` / `h2c://` in `ProxyPass` (no HTTP/1.1 fallback) | [mod_proxy_http2 Docs](https://httpd.apache.org/docs/current/mod/mod_proxy_http2.html) |
 | **Nginx** | Yes (1.29.4+) | No | `proxy_http_version 2;` (requires `ngx_http_v2_module`) | [ngx_http_proxy_module Docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version) |

--- a/docs/concepts/http2.md
+++ b/docs/concepts/http2.md
@@ -57,6 +57,30 @@ When using HTTPS, HTTP/2 is negotiated via **ALPN** (Application-Layer Protocol 
 during the TLS handshake. This is the most common way to use HTTP/2, and the only one web
 browsers support.
 
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: TLS Handshake with ALPN
+
+    Client->>Server: ClientHello
+    Note right of Client: ALPN: h2, http/1.1
+
+    Server->>Client: ServerHello
+    Note right of Server: ALPN: h2
+
+    Note over Client,Server: TLS Handshake Complete
+
+    Client->>Server: HTTP/2 Connection Preface
+    Server->>Client: HTTP/2 SETTINGS Frame
+
+    Note over Client,Server: HTTP/2 Connection Established
+
+    Client->>Server: HEADERS (Stream 1)
+    Server->>Client: HEADERS + DATA (Stream 1)
+```
+
 For testing it locally, you can generate a self-signed certificate:
 
 ```bash
@@ -87,7 +111,28 @@ curl -v --http2 -k https://localhost:8000/
 
 On cleartext connections, Uvicorn accepts clients that speak HTTP/2 directly - known as
 "prior knowledge" h2c. The client opens the connection with the HTTP/2 preface instead of an
-HTTP/1.1 request, and Uvicorn switches protocols on the spot. Using the same `main.py`:
+HTTP/1.1 request, and Uvicorn switches protocols on the spot.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Cleartext TCP Connection
+
+    Client->>Server: HTTP/2 Connection Preface
+    Note right of Client: PRI * HTTP/2.0
+
+    Server->>Client: HTTP/2 SETTINGS Frame
+    Client->>Server: HTTP/2 SETTINGS Frame
+
+    Note over Client,Server: HTTP/2 Connection Established
+
+    Client->>Server: HEADERS + DATA (Stream 1)
+    Server->>Client: HEADERS + DATA (Stream 1)
+```
+
+Using the same `main.py`:
 
 ```bash
 uvicorn main:app --http zttp
@@ -114,6 +159,57 @@ async def app(scope, receive, send):
     assert scope["type"] == "http"
     print(f"HTTP Version: {scope['http_version']}")  # "2" for HTTP/2
 ```
+
+## Using with Reverse Proxies
+
+In production, Uvicorn is typically deployed behind a reverse proxy like Nginx, Caddy, or HAProxy.
+The proxy can terminate TLS and serve HTTP/2 to clients, while talking either HTTP/1.1 or
+HTTP/2 to Uvicorn.
+
+```mermaid
+flowchart LR
+    Client <-->|HTTP/2 over TLS| Proxy
+    Proxy <-->|HTTP/1.1 or HTTP/2| Uvicorn
+
+    style Client fill:#e1f5fe
+    style Proxy fill:#fff3e0
+    style Uvicorn fill:#e8f5e9
+```
+
+### Proxy HTTP/2 Upstream Support
+
+**HTTP/2 upstream** refers to the protocol used between the proxy and Uvicorn. While all modern
+proxies support HTTP/2 for client connections, support for HTTP/2 to backend servers varies.
+
+**Multiplexing** is HTTP/2's ability to send multiple requests simultaneously over a single TCP
+connection. Some proxies support HTTP/2 upstream but open a new connection per request, which
+means they don't truly multiplex.
+
+Here's the current state of proxy support:
+
+| Proxy | HTTP/2 Upstream | Multiplexing | Documentation |
+|-------|-----------------|--------------|---------------|
+| **Envoy** | Yes | Yes | [Connection Pooling Docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling) |
+| **Caddy** | Yes | Yes | [reverse_proxy Docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) |
+| **HAProxy** | Yes | Yes | [HTTP/2 Docs](https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/) |
+| **Traefik** | Yes | Yes | [ServersTransport Docs](https://doc.traefik.io/traefik/routing/services/) |
+| **Apache** | Partial | No | [mod_proxy_http2 Docs](https://httpd.apache.org/docs/trunk/mod/mod_proxy_http2.html) |
+| **Nginx** | Limited | No | [Trac Ticket #923](https://trac.nginx.org/nginx/ticket/923) |
+
+Proxies that speak HTTP/2 upstream use prior-knowledge h2c (`h2c://` URLs), which Uvicorn
+supports - no TLS needed between the proxy and Uvicorn.
+
+### Performance Considerations
+
+HTTP/2 provides the most benefit when:
+
+- **High latency connections**: Multiplexing reduces round-trip overhead
+- **Many concurrent requests**: Multiple streams share a single connection
+- **Large headers**: HPACK compression reduces header overhead
+
+For internal, low-latency connections (like proxy to backend), HTTP/1.1 with keepalive often
+performs comparably to HTTP/2. It is simpler to configure and debug, which is why it remains the
+recommended default for most deployments.
 
 ## Current Limitations
 

--- a/docs/concepts/http2.md
+++ b/docs/concepts/http2.md
@@ -196,12 +196,12 @@ Here's the state of proxy support at the time of writing:
 
 | Proxy | HTTP/2 Upstream | Multiplexing | Enabled by | Documentation |
 |-------|-----------------|--------------|------------|---------------|
-| **Envoy** | Yes | Yes | `http2_protocol_options` on the cluster | [Connection Pooling Docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling) |
-| **Caddy** | Yes | Yes | `h2c://` upstream, or `versions` in the transport | [reverse_proxy Docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) |
+| **Envoy** | Yes | Yes | HTTP/2 protocol options on the cluster | [Connection Pooling Docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling) |
+| **Caddy** | Yes | Yes | `h2c://` upstream (experimental), or `versions 2` in the transport for TLS | [reverse_proxy Docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) |
 | **HAProxy** | Yes | Yes | `proto h2` on the server line | [HTTP/2 Docs](https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/) |
 | **Traefik** | Yes | Yes | `h2c://` service URL | [ServersTransport Docs](https://doc.traefik.io/traefik/routing/services/) |
-| **Apache** | Partial | No | `h2://` / `h2c://` in `ProxyPass` | [mod_proxy_http2 Docs](https://httpd.apache.org/docs/current/mod/mod_proxy_http2.html) |
-| **Nginx** | Yes (1.29.4+) | No | `proxy_http_version 2;` | [ngx_http_proxy_module Docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version) |
+| **Apache** | Yes (2.4.19+) | No | `h2://` / `h2c://` in `ProxyPass` (no HTTP/1.1 fallback) | [mod_proxy_http2 Docs](https://httpd.apache.org/docs/current/mod/mod_proxy_http2.html) |
+| **Nginx** | Yes (1.29.4+) | No | `proxy_http_version 2;` (requires `ngx_http_v2_module`) | [ngx_http_proxy_module Docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version) |
 
 Uvicorn supports both upstream flavors: cleartext prior-knowledge h2c, and HTTP/2 over TLS
 via ALPN when the proxy-to-Uvicorn hop uses TLS.

--- a/docs/concepts/http2.md
+++ b/docs/concepts/http2.md
@@ -72,8 +72,10 @@ sequenceDiagram
 
     Note over Client,Server: TLS Handshake Complete
 
-    Client->>Server: HTTP/2 Connection Preface
-    Server->>Client: HTTP/2 SETTINGS Frame
+    Client->>Server: Connection Preface
+    Note right of Client: PRI * HTTP/2.0
+    Client->>Server: Client SETTINGS Frame
+    Server->>Client: Server SETTINGS Frame
 
     Note over Client,Server: HTTP/2 Connection Established
 
@@ -120,11 +122,10 @@ sequenceDiagram
 
     Note over Client,Server: Cleartext TCP Connection
 
-    Client->>Server: HTTP/2 Connection Preface
+    Client->>Server: Connection Preface
     Note right of Client: PRI * HTTP/2.0
-
-    Server->>Client: HTTP/2 SETTINGS Frame
-    Client->>Server: HTTP/2 SETTINGS Frame
+    Client->>Server: Client SETTINGS Frame
+    Server->>Client: Server SETTINGS Frame
 
     Note over Client,Server: HTTP/2 Connection Established
 
@@ -142,8 +143,14 @@ uvicorn main:app --http zttp
 curl -v --http2-prior-knowledge http://localhost:8000/
 ```
 
-This is the mechanism proxies use for `h2c://` upstreams (e.g. Traefik and Envoy), so HTTP/2
-between a proxy and Uvicorn works without TLS.
+This is the mechanism proxies use for cleartext HTTP/2 upstreams, so HTTP/2 between a proxy
+and Uvicorn works without TLS. How you enable it is proxy-specific: Traefik and Caddy use
+`h2c://` upstream URLs, while Envoy configures HTTP/2 on the cluster.
+
+!!! warning "h2c is cleartext"
+    Prior-knowledge h2c provides no transport encryption or peer authentication. Limit it to
+    trusted private networks (e.g. the proxy-to-Uvicorn hop); use HTTP/2 over TLS for any
+    untrusted hop.
 
 !!! warning
     The HTTP/1.1 `Upgrade: h2c` mechanism is **not** supported: an upgrade request is served
@@ -185,19 +192,19 @@ proxies support HTTP/2 for client connections, support for HTTP/2 to backend ser
 connection. Some proxies support HTTP/2 upstream but open a new connection per request, which
 means they don't truly multiplex.
 
-Here's the current state of proxy support:
+Here's the state of proxy support at the time of writing:
 
-| Proxy | HTTP/2 Upstream | Multiplexing | Documentation |
-|-------|-----------------|--------------|---------------|
-| **Envoy** | Yes | Yes | [Connection Pooling Docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling) |
-| **Caddy** | Yes | Yes | [reverse_proxy Docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) |
-| **HAProxy** | Yes | Yes | [HTTP/2 Docs](https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/) |
-| **Traefik** | Yes | Yes | [ServersTransport Docs](https://doc.traefik.io/traefik/routing/services/) |
-| **Apache** | Partial | No | [mod_proxy_http2 Docs](https://httpd.apache.org/docs/trunk/mod/mod_proxy_http2.html) |
-| **Nginx** | Limited | No | [Trac Ticket #923](https://trac.nginx.org/nginx/ticket/923) |
+| Proxy | HTTP/2 Upstream | Multiplexing | Enabled by | Documentation |
+|-------|-----------------|--------------|------------|---------------|
+| **Envoy** | Yes | Yes | `http2_protocol_options` on the cluster | [Connection Pooling Docs](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/connection_pooling) |
+| **Caddy** | Yes | Yes | `h2c://` upstream, or `versions` in the transport | [reverse_proxy Docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy) |
+| **HAProxy** | Yes | Yes | `proto h2` on the server line | [HTTP/2 Docs](https://www.haproxy.com/documentation/hapee/latest/load-balancing/protocols/http-2/) |
+| **Traefik** | Yes | Yes | `h2c://` service URL | [ServersTransport Docs](https://doc.traefik.io/traefik/routing/services/) |
+| **Apache** | Partial | No | `h2://` / `h2c://` in `ProxyPass` | [mod_proxy_http2 Docs](https://httpd.apache.org/docs/current/mod/mod_proxy_http2.html) |
+| **Nginx** | Yes (1.29.4+) | No | `proxy_http_version 2;` | [ngx_http_proxy_module Docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version) |
 
-Proxies that speak HTTP/2 upstream use prior-knowledge h2c (`h2c://` URLs), which Uvicorn
-supports - no TLS needed between the proxy and Uvicorn.
+Uvicorn supports both upstream flavors: cleartext prior-knowledge h2c, and HTTP/2 over TLS
+via ALPN when the proxy-to-Uvicorn hop uses TLS.
 
 ### Performance Considerations
 


### PR DESCRIPTION
Ports the well-written parts of #2793's HTTP/2 docs to the current `zttp`-based implementation:

- Mermaid sequence diagrams for ALPN negotiation over TLS and prior-knowledge h2c (the latter redrawn, since #2793 documented the `Upgrade: h2c` flow we don't support).
- The reverse proxy section: flow diagram, the HTTP/2 upstream / multiplexing support table per proxy, and the HTTP/1.1-with-keepalive recommendation for low-latency internal hops.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated HTTP/2 sequence diagrams to show client and server prefaces and SETTINGS frames.
  * Expanded h2c guidance with proxy-specific configuration examples and a cleartext security warning.
  * Added reverse-proxy deployment guidance, proxy capability details, upstream protocol support, and performance considerations.
  * Documented HAProxy configuration for both cleartext HTTP/2 and TLS with ALPN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->