### PR TITLE
Replace httpx with httpx2 in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     "coverage>=7.14.1",
     "coverage-conditional-plugin==0.9.0",
     "coverage-enable-subprocess==1.0",
-    "httpx==0.28.1",
+    "httpx2",
     # check dist
     "twine==7.0.0",
     # Explicit optionals,

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, TypeAlias
 
-import httpx
+import httpx2
 import pytest
 from websockets.asyncio.client import connect
 from websockets.protocol import State
@@ -55,7 +55,7 @@ async def test_trace_logging(caplog: pytest.LogCaptureFixture, logging_config: d
     )
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         async with run_server(config):
-            async with httpx.AsyncClient() as client:
+            async with httpx2.AsyncClient() as client:
                 response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
         assert response.status_code == 204
         messages = [record.message for record in caplog.records if record.name == "uvicorn.asgi"]
@@ -77,7 +77,7 @@ async def test_trace_logging_on_http_protocol(http_protocol_cls, caplog, logging
     )
     with caplog_for_logger(caplog, "uvicorn.error"):
         async with run_server(config):
-            async with httpx.AsyncClient() as client:
+            async with httpx2.AsyncClient() as client:
                 response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
         assert response.status_code == 204
         messages = [record.message for record in caplog.records if record.name == "uvicorn.error"]
@@ -128,7 +128,7 @@ async def test_access_logging(
     config = Config(app=app, use_colors=use_colors, log_config=logging_config, port=unused_tcp_port)
     with caplog_for_logger(caplog, "uvicorn.access"):
         async with run_server(config):
-            async with httpx.AsyncClient() as client:
+            async with httpx2.AsyncClient() as client:
                 response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
 
         assert response.status_code == 204
@@ -143,7 +143,7 @@ async def test_default_logging(
     config = Config(app=app, use_colors=use_colors, log_config=logging_config, port=unused_tcp_port)
     with caplog_for_logger(caplog, "uvicorn.access"):
         async with run_server(config):
-            async with httpx.AsyncClient() as client:
+            async with httpx2.AsyncClient() as client:
                 response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
         assert response.status_code == 204
         messages = [record.message for record in caplog.records if "uvicorn" in record.name]
@@ -191,7 +191,7 @@ async def test_unknown_status_code(caplog: pytest.LogCaptureFixture, unused_tcp_
     config = Config(app=app, port=unused_tcp_port)
     with caplog_for_logger(caplog, "uvicorn.access"):
         async with run_server(config):
-            async with httpx.AsyncClient() as client:
+            async with httpx2.AsyncClient() as client:
                 response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
 
         assert response.status_code == 599

--- a/tests/middleware/test_message_logger.py
+++ b/tests/middleware/test_message_logger.py
@@ -1,4 +1,4 @@
-import httpx
+import httpx2
 import pytest
 
 from tests.middleware.test_logging import caplog_for_logger
@@ -18,8 +18,8 @@ async def test_message_logger(caplog: pytest.LogCaptureFixture) -> None:
         caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
         caplog.set_level(TRACE_LOG_LEVEL)
 
-        transport = httpx.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        transport = httpx2.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
+        async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
             response = await client.get("/")
         assert response.status_code == 200
         messages = [record.msg % record.args for record in caplog.records]
@@ -38,8 +38,8 @@ async def test_message_logger_exc(caplog: pytest.LogCaptureFixture) -> None:
     with caplog_for_logger(caplog, "uvicorn.asgi"):
         caplog.set_level(TRACE_LOG_LEVEL, logger="uvicorn.asgi")
         caplog.set_level(TRACE_LOG_LEVEL)
-        transport = httpx.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        transport = httpx2.ASGITransport(MessageLoggerMiddleware(app))  # type: ignore
+        async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
             with pytest.raises(RuntimeError):
                 await client.get("/")
         messages = [record.msg % record.args for record in caplog.records]

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -4,7 +4,7 @@ import contextlib
 import ipaddress
 from typing import TYPE_CHECKING
 
-import httpx
+import httpx2
 import pytest
 from websockets.asyncio.client import connect
 
@@ -40,10 +40,10 @@ async def default_app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISend
     await response(scope, receive, send)
 
 
-def make_httpx_client(
+def make_httpx2_client(
     trusted_hosts: str | list[str],
     client: tuple[str, int] = ("127.0.0.1", 123),
-) -> httpx.AsyncClient:
+) -> httpx2.AsyncClient:
     """Create async client for use in test cases.
 
     Args:
@@ -52,8 +52,8 @@ def make_httpx_client(
     """
 
     app = ProxyHeadersMiddleware(default_app, trusted_hosts)
-    transport = httpx.ASGITransport(app=app, client=client)  # type: ignore
-    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+    transport = httpx2.ASGITransport(app=app, client=client)  # type: ignore
+    return httpx2.AsyncClient(transport=transport, base_url="http://testserver")
 
 
 # Note: we vary the format here to also test some of the functionality
@@ -370,7 +370,7 @@ def test_forwarded_hosts(init_hosts: str | list[str], test_host: str, expected: 
     ],
 )
 async def test_proxy_headers_trusted_hosts(trusted_hosts: str | list[str], expected: str) -> None:
-    async with make_httpx_client(trusted_hosts) as client:
+    async with make_httpx2_client(trusted_hosts) as client:
         headers = {X_FORWARDED_FOR: "1.2.3.4", X_FORWARDED_PROTO: "https"}
         response = await client.get("/", headers=headers)
     assert response.status_code == 200
@@ -397,7 +397,7 @@ async def test_proxy_headers_trusted_hosts_malformed(
     forwarded_proto: str | None,
     expected: str,
 ) -> None:
-    async with make_httpx_client("127.0.0.1, 10.0.0.0/8") as client:
+    async with make_httpx2_client("127.0.0.1, 10.0.0.0/8") as client:
         headers = {X_FORWARDED_FOR: forwarded_for}
         if forwarded_proto is not None:
             headers[X_FORWARDED_PROTO] = forwarded_proto
@@ -423,7 +423,7 @@ async def test_proxy_headers_trusted_hosts_malformed(
     ],
 )
 async def test_proxy_headers_multiple_proxies(trusted_hosts: str | list[str], expected: str) -> None:
-    async with make_httpx_client(trusted_hosts) as client:
+    async with make_httpx2_client(trusted_hosts) as client:
         headers = {X_FORWARDED_FOR: "1.2.3.4, 10.0.2.1, 192.168.0.2", X_FORWARDED_PROTO: "https"}
         response = await client.get("/", headers=headers)
     assert response.status_code == 200
@@ -445,7 +445,7 @@ async def test_proxy_headers_multiple_proxies(trusted_hosts: str | list[str], ex
     ],
 )
 async def test_proxy_headers_multiple_proxies_with_ports(trusted_hosts: str | list[str], expected: str) -> None:
-    async with make_httpx_client(trusted_hosts) as client:
+    async with make_httpx2_client(trusted_hosts) as client:
         headers = {
             X_FORWARDED_FOR: "1.2.3.4:1234, [2001:db8::1]:8080, 192.168.0.2:9000",
             X_FORWARDED_PROTO: "https",
@@ -457,8 +457,8 @@ async def test_proxy_headers_multiple_proxies_with_ports(trusted_hosts: str | li
 
 @pytest.mark.anyio
 async def test_proxy_headers_invalid_x_forwarded_for() -> None:
-    async with make_httpx_client("*") as client:
-        headers = httpx.Headers(
+    async with make_httpx2_client("*") as client:
+        headers = httpx2.Headers(
             {
                 X_FORWARDED_FOR: "1.2.3.4, \xf0\xfd\xfd\xfd, unix:, ::1",
                 X_FORWARDED_PROTO: "https",
@@ -495,7 +495,7 @@ async def test_proxy_headers_invalid_x_forwarded_for() -> None:
     ],
 )
 async def test_proxy_headers_x_forwarded_for_port_shapes(forwarded_for: str, expected: str) -> None:
-    async with make_httpx_client("*") as client:
+    async with make_httpx2_client("*") as client:
         headers = {X_FORWARDED_FOR: forwarded_for, X_FORWARDED_PROTO: "https"}
         response = await client.get("/", headers=headers)
     assert response.status_code == 200
@@ -549,7 +549,7 @@ async def test_proxy_headers_websocket_x_forwarded_proto(
 async def test_proxy_headers_empty_x_forwarded_for() -> None:
     # fallback to the default behavior if x-forwarded-for is an empty list
     # https://github.com/Kludex/uvicorn/issues/1068#issuecomment-855371576
-    async with make_httpx_client("*") as client:
+    async with make_httpx2_client("*") as client:
         headers = {X_FORWARDED_FOR: "", X_FORWARDED_PROTO: "https"}
         response = await client.get("/", headers=headers)
     assert response.status_code == 200

--- a/tests/middleware/test_wsgi.py
+++ b/tests/middleware/test_wsgi.py
@@ -5,7 +5,7 @@ import sys
 from collections.abc import AsyncGenerator, Callable
 
 import a2wsgi
-import httpx
+import httpx2
 import pytest
 
 from uvicorn._types import Environ, HTTPRequestEvent, HTTPScope, StartResponse
@@ -59,8 +59,8 @@ def wsgi_middleware(request: pytest.FixtureRequest) -> Callable:
 
 @pytest.mark.anyio
 async def test_wsgi_get(wsgi_middleware: Callable) -> None:
-    transport = httpx.ASGITransport(wsgi_middleware(hello_world))
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    transport = httpx2.ASGITransport(wsgi_middleware(hello_world))
+    async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.get("/")
     assert response.status_code == 200
     assert response.text == "Hello World!\n"
@@ -68,8 +68,8 @@ async def test_wsgi_get(wsgi_middleware: Callable) -> None:
 
 @pytest.mark.anyio
 async def test_wsgi_post(wsgi_middleware: Callable) -> None:
-    transport = httpx.ASGITransport(wsgi_middleware(echo_body))
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    transport = httpx2.ASGITransport(wsgi_middleware(echo_body))
+    async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.post("/", json={"example": 123})
     assert response.status_code == 200
     assert response.text == '{"example":123}'
@@ -81,8 +81,8 @@ async def test_wsgi_put_more_body(wsgi_middleware: Callable) -> None:
         for _ in range(1024):
             yield b"123456789abcdef\n" * 64
 
-    transport = httpx.ASGITransport(wsgi_middleware(echo_body))
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    transport = httpx2.ASGITransport(wsgi_middleware(echo_body))
+    async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.put("/", content=generate_body())
     assert response.status_code == 200
     assert response.text == "123456789abcdef\n" * 64 * 1024
@@ -92,8 +92,8 @@ async def test_wsgi_put_more_body(wsgi_middleware: Callable) -> None:
 async def test_wsgi_exception(wsgi_middleware: Callable) -> None:
     # Note that we're testing the WSGI app directly here.
     # The HTTP protocol implementations would catch this error and return 500.
-    transport = httpx.ASGITransport(wsgi_middleware(raise_exception))
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    transport = httpx2.ASGITransport(wsgi_middleware(raise_exception))
+    async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
         with pytest.raises(RuntimeError):
             await client.get("/")
 
@@ -101,11 +101,11 @@ async def test_wsgi_exception(wsgi_middleware: Callable) -> None:
 @pytest.mark.anyio
 async def test_wsgi_exc_info(wsgi_middleware: Callable) -> None:
     app = wsgi_middleware(return_exc_info)
-    transport = httpx.ASGITransport(
+    transport = httpx2.ASGITransport(
         app=app,
         raise_app_exceptions=False,
     )
-    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+    async with httpx2.AsyncClient(transport=transport, base_url="http://testserver") as client:
         response = await client.get("/")
     assert response.status_code == 500
     assert response.text == "Internal Server Error"

--- a/tests/protocols/test_http2.py
+++ b/tests/protocols/test_http2.py
@@ -5,7 +5,7 @@ import ssl
 from collections.abc import Callable
 from typing import Any, ClassVar
 
-import httpx
+import httpx2
 import pytest
 
 from tests.response import Response
@@ -992,7 +992,7 @@ async def test_server_installs_auto_zttp_protocol(unused_tcp_port: int):
     app = Response("Hello, world", media_type="text/plain")
     config = Config(app=app, http="zttp", loop="asyncio", limit_max_requests=1, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 200
     assert response.text == "Hello, world"

--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -4,7 +4,7 @@ import asyncio
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict
 
-import httpx
+import httpx2
 import pytest
 import websockets.exceptions
 from websockets import __version__ as websockets_version
@@ -82,7 +82,7 @@ async def wsresponse(url: str):
         "Sec-WebSocket-Key": "x3JJHMbDL1EzLkh9GBhXDw==",
         "Sec-WebSocket-Version": "13",
     }
-    async with httpx.AsyncClient() as client:
+    async with httpx2.AsyncClient() as client:
         return await client.get(url, headers=headers)
 
 
@@ -92,7 +92,7 @@ async def test_invalid_upgrade(ws_protocol_cls: WSProtocol, http_protocol_cls: H
 
     config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(
                 f"http://127.0.0.1:{unused_tcp_port}",
                 headers={
@@ -603,7 +603,7 @@ async def test_connection_lost_before_handshake_complete(
         disconnect_message = await receive()  # type: ignore
 
     async def websocket_session(uri: str):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             await client.get(
                 f"http://127.0.0.1:{unused_tcp_port}",
                 headers={

--- a/tests/supervisors/test_signal.py
+++ b/tests/supervisors/test_signal.py
@@ -2,7 +2,7 @@ import asyncio
 import signal
 from asyncio import Event
 
-import httpx
+import httpx2
 import pytest
 
 from tests.utils import assert_signal, run_server
@@ -34,12 +34,12 @@ async def test_sigint_finish_req(unused_tcp_port: int):
     config = Config(app=wait_app, reload=False, port=unused_tcp_port, timeout_graceful_shutdown=1)
     server: Server
     with assert_signal(signal.SIGINT):
-        async with run_server(config) as server, httpx.AsyncClient() as client:
+        async with run_server(config) as server, httpx2.AsyncClient() as client:
             req = asyncio.create_task(client.get(f"http://127.0.0.1:{unused_tcp_port}"))
             await request_started.wait()
             server.handle_exit(sig=signal.SIGINT, frame=None)  # exit
             server_event.set()  # continue request
-            # ensure httpx has processed the response and result is complete
+            # ensure httpx2 has processed the response and result is complete
             await req
             assert req.result().status_code == 200
             await asyncio.sleep(0.1)  # ensure shutdown is complete
@@ -53,7 +53,7 @@ async def test_sigint_abort_req(unused_tcp_port: int, caplog):
     3. Shutdown sequence start
     4. Request is _NOT_ finished before timeout_graceful_shutdown=1
 
-    Result: Request is cancelled mid-execution, and httpx will raise a
+    Result: Request is cancelled mid-execution, and httpx2 will raise a
         `RemoteProtocolError`.
     """
 
@@ -71,12 +71,12 @@ async def test_sigint_abort_req(unused_tcp_port: int, caplog):
     config = Config(app=forever_app, reload=False, port=unused_tcp_port, timeout_graceful_shutdown=1)
     server: Server
     with assert_signal(signal.SIGINT):
-        async with run_server(config) as server, httpx.AsyncClient() as client:
+        async with run_server(config) as server, httpx2.AsyncClient() as client:
             req = asyncio.create_task(client.get(f"http://127.0.0.1:{unused_tcp_port}"))
             await request_started.wait()
             # trigger exit, this request should time out in ~1 sec
             server.handle_exit(sig=signal.SIGINT, frame=None)
-            with pytest.raises(httpx.RemoteProtocolError):
+            with pytest.raises(httpx2.RemoteProtocolError):
                 await req
 
     message = "Cancel 1 running task(s), timeout graceful shutdown exceeded"
@@ -105,9 +105,9 @@ async def test_sigint_deny_request_after_triggered(unused_tcp_port: int, caplog)
     config = Config(app=app, reload=False, port=unused_tcp_port, timeout_graceful_shutdown=1)
     server: Server
     with assert_signal(signal.SIGINT):
-        async with run_server(config) as server, httpx.AsyncClient() as client:
+        async with run_server(config) as server, httpx2.AsyncClient() as client:
             # exit and ensure we do not accept more requests
             server.handle_exit(sig=signal.SIGINT, frame=None)
             await asyncio.sleep(0.1)  # next tick
-            with pytest.raises(httpx.ConnectError):
+            with pytest.raises(httpx2.ConnectError):
                 await client.get(f"http://127.0.0.1:{unused_tcp_port}")

--- a/tests/test_default_headers.py
+++ b/tests/test_default_headers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 
 from tests.utils import run_server
@@ -19,7 +19,7 @@ async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
 async def test_default_default_headers(unused_tcp_port: int):
     config = Config(app=app, loop="asyncio", limit_max_requests=1, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert response.headers["server"] == "uvicorn" and response.headers["date"]
 
@@ -28,7 +28,7 @@ async def test_override_server_header(unused_tcp_port: int):
     headers: list[tuple[str, str]] = [("Server", "over-ridden")]
     config = Config(app=app, loop="asyncio", limit_max_requests=1, headers=headers, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert response.headers["server"] == "over-ridden" and response.headers["date"]
 
@@ -36,7 +36,7 @@ async def test_override_server_header(unused_tcp_port: int):
 async def test_disable_default_server_header(unused_tcp_port: int):
     config = Config(app=app, loop="asyncio", limit_max_requests=1, server_header=False, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert "server" not in response.headers
 
@@ -45,7 +45,7 @@ async def test_override_server_header_multiple_times(unused_tcp_port: int):
     headers: list[tuple[str, str]] = [("Server", "over-ridden"), ("Server", "another-value")]
     config = Config(app=app, loop="asyncio", limit_max_requests=1, headers=headers, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert response.headers["server"] == "over-ridden, another-value" and response.headers["date"]
 
@@ -54,7 +54,7 @@ async def test_add_additional_header(unused_tcp_port: int):
     headers: list[tuple[str, str]] = [("X-Additional", "new-value")]
     config = Config(app=app, loop="asyncio", limit_max_requests=1, headers=headers, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert response.headers["x-additional"] == "new-value"
             assert response.headers["server"] == "uvicorn"
@@ -64,6 +64,6 @@ async def test_add_additional_header(unused_tcp_port: int):
 async def test_disable_default_date_header(unused_tcp_port: int):
     config = Config(app=app, loop="asyncio", limit_max_requests=1, date_header=False, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
             assert "date" not in response.headers

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ import sys
 from logging import WARNING
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 
 import uvicorn.server
@@ -56,7 +56,7 @@ def _has_ipv6(host: str):
 async def test_run(host, url: str, unused_tcp_port: int):
     config = Config(app=app, host=host, loop="asyncio", limit_max_requests=1, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"{url}:{unused_tcp_port}")
     assert response.status_code == 204
 
@@ -64,7 +64,7 @@ async def test_run(host, url: str, unused_tcp_port: int):
 async def test_run_multiprocess(unused_tcp_port: int):
     config = Config(app=app, loop="asyncio", workers=2, limit_max_requests=1, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
@@ -72,7 +72,7 @@ async def test_run_multiprocess(unused_tcp_port: int):
 async def test_run_reload(unused_tcp_port: int):
     config = Config(app=app, loop="asyncio", reload=True, limit_max_requests=1, port=unused_tcp_port)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ import sys
 from collections.abc import Callable, Generator
 from contextlib import AbstractContextManager
 
-import httpx
+import httpx2
 import pytest
 
 from tests.protocols.test_http import SIMPLE_GET_REQUEST
@@ -143,7 +143,7 @@ async def test_request_than_limit_max_requests_warn_log(
     caplog.set_level(logging.INFO, logger="uvicorn.error")
     config = Config(app=app, limit_max_requests=1, port=unused_tcp_port, http=http_protocol_cls)
     async with run_server(config):
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             tasks = [client.get(f"http://127.0.0.1:{unused_tcp_port}") for _ in range(2)]
             responses = await asyncio.gather(*tasks)
             assert len(responses) == 2
@@ -161,7 +161,7 @@ async def test_limit_max_requests_jitter(
         limit = server.limit_max_requests
         assert limit is not None
         assert 1 <= limit <= 3
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             tasks = [client.get(f"http://127.0.0.1:{unused_tcp_port}") for _ in range(limit + 1)]
             await asyncio.gather(*tasks)
     assert f"Maximum request limit of {limit} exceeded. Terminating process." in caplog.text

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -4,7 +4,7 @@ import ssl
 from collections.abc import Callable
 from typing import TypeAlias
 
-import httpx
+import httpx2
 import pytest
 
 from tests.utils import run_server
@@ -37,7 +37,7 @@ async def test_run(
         port=unused_tcp_port,
     )
     async with run_server(config):
-        async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
+        async with httpx2.AsyncClient(verify=tls_ca_ssl_context) as client:
             response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
@@ -58,7 +58,7 @@ async def test_run_chain(
         port=unused_tcp_port,
     )
     async with run_server(config):
-        async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
+        async with httpx2.AsyncClient(verify=tls_ca_ssl_context) as client:
             response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
@@ -73,7 +73,7 @@ async def test_run_chain_only(tls_ca_ssl_context, tls_certificate_key_and_chain_
         port=unused_tcp_port,
     )
     async with run_server(config):
-        async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
+        async with httpx2.AsyncClient(verify=tls_ca_ssl_context) as client:
             response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
@@ -97,7 +97,7 @@ async def test_run_password(
         port=unused_tcp_port,
     )
     async with run_server(config):
-        async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
+        async with httpx2.AsyncClient(verify=tls_ca_ssl_context) as client:
             response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
@@ -124,7 +124,7 @@ async def test_run_ssl_context_factory_default(
         port=unused_tcp_port,
     )
     async with run_server(config):
-        async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
+        async with httpx2.AsyncClient(verify=tls_ca_ssl_context) as client:
             response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 
@@ -151,7 +151,7 @@ async def test_run_ssl_context_factory_custom(
         port=unused_tcp_port,
     )
     async with run_server(config):
-        async with httpx.AsyncClient(verify=tls_ca_ssl_context) as client:
+        async with httpx2.AsyncClient(verify=tls_ca_ssl_context) as client:
             response = await client.get(f"https://127.0.0.1:{unused_tcp_port}")
     assert response.status_code == 204
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,8 +12,8 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-zttp = "2026-08-15T00:00:00Z"
-httptools = "2026-05-27T00:00:00Z"
+zttp = "2026-08-14T22:00:00Z"
+httptools = "2026-05-26T22:00:00Z"
 
 [[package]]
 name = "a2wsgi"
@@ -611,16 +611,16 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
 ]
 
 [[package]]
@@ -674,18 +674,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
     { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -702,11 +713,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1703,6 +1714,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "twine"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1784,7 +1804,7 @@ dev = [
     { name = "coverage-conditional-plugin" },
     { name = "coverage-enable-subprocess" },
     { name = "cryptography" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-codspeed" },
@@ -1825,7 +1845,7 @@ dev = [
     { name = "coverage-conditional-plugin", specifier = "==0.9.0" },
     { name = "coverage-enable-subprocess", specifier = "==1.0" },
     { name = "cryptography", specifier = ">=44.0.3" },
-    { name = "httpx", specifier = "==0.28.1" },
+    { name = "httpx2" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-codspeed", specifier = ">=4.1.1" },


### PR DESCRIPTION
## Summary

Replaces the `httpx` test dependency with `httpx2`. All test imports and usages updated accordingly.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development test environment to use the `httpx2` package.
* **Tests**
  * Migrated HTTP client usage across middleware, protocol, server, supervisor, SSL, and application tests.
  * Preserved existing test scenarios, assertions, error handling, and request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->