### PR TITLE
Run zttp tests on Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     permissions:
       contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     # Explicit optionals,
     "a2wsgi==1.10.10",
     "wsproto==1.3.2",
-    "zttp==0.0.24",
+    "zttp==0.0.24; sys_platform != 'win32' or python_version >= '3.12'",
 ]
 docs = [
     "zensical==0.0.53",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     # Explicit optionals,
     "a2wsgi==1.10.10",
     "wsproto==1.3.2",
-    "zttp==0.0.24; python_version >= '3.12'",
+    "zttp==0.0.24",
 ]
 docs = [
     "zensical==0.0.53",

--- a/uv.lock
+++ b/uv.lock
@@ -1817,7 +1817,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "wsproto" },
-    { name = "zttp" },
+    { name = "zttp", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
 ]
 docs = [
     { name = "mkdocstrings-python" },
@@ -1858,7 +1858,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "wsproto", specifier = "==1.3.2" },
-    { name = "zttp", specifier = "==0.0.24" },
+    { name = "zttp", marker = "python_full_version >= '3.12' or sys_platform != 'win32'", specifier = "==0.0.24" },
 ]
 docs = [
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1817,7 +1817,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "wsproto" },
-    { name = "zttp", marker = "python_full_version >= '3.12'" },
+    { name = "zttp" },
 ]
 docs = [
     { name = "mkdocstrings-python" },
@@ -1858,7 +1858,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "wsproto", specifier = "==1.3.2" },
-    { name = "zttp", marker = "python_full_version >= '3.12'", specifier = "==0.0.24" },
+    { name = "zttp", specifier = "==0.0.24" },
 ]
 docs = [
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },


### PR DESCRIPTION
## Summary

`zttp` ships wheels for CPython 3.10+ on Linux, macOS, and Windows, but the dev dependency was gated to `python_version >= '3.12'`, so the zttp and HTTP/2 tests were silently skipped on 3.10 and 3.11. This removes the marker so the whole CI matrix exercises them.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependency installation requirements for Windows.
  * Non-Windows platforms continue to require Python 3.12 or newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->