### PR TITLE
Debug zttp hang on Windows Python 3.10 (do not merge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 20
+    timeout-minutes: 10
 
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     name: "Python ${{ matrix.python-version }} ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     permissions:
       contents: read
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        python-version: ["3.10"]
+        os: [windows-latest]
 
     steps:
       - uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
@@ -45,7 +45,7 @@ jobs:
         shell: bash
 
       - name: "Run tests"
-        run: scripts/test
+        run: scripts/test --timeout 90 --timeout-method thread
         shell: bash
 
       - name: "Enforce coverage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     # Explicit optionals,
     "a2wsgi==1.10.10",
     "wsproto==1.3.2",
-    "zttp==0.0.24",
+    "zttp==0.0.24; sys_platform != 'win32' or python_version >= '3.12'",
 ]
 docs = [
     "zensical==0.0.53",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
     # Explicit optionals,
     "a2wsgi==1.10.10",
     "wsproto==1.3.2",
-    "zttp==0.0.24; python_version >= '3.12'",
+    "zttp==0.0.24",
 ]
 docs = [
     "zensical==0.0.53",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ dev = [
     # Explicit optionals,
     "a2wsgi==1.10.10",
     "wsproto==1.3.2",
-    "zttp==0.0.24; sys_platform != 'win32' or python_version >= '3.12'",
+    "zttp==0.0.24",
+    "pytest-timeout>=2.3",
 ]
 docs = [
     "zensical==0.0.53",

--- a/uv.lock
+++ b/uv.lock
@@ -1817,7 +1817,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "wsproto" },
-    { name = "zttp" },
+    { name = "zttp", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
 ]
 docs = [
     { name = "mkdocstrings-python" },
@@ -1858,7 +1858,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "wsproto", specifier = "==1.3.2" },
-    { name = "zttp", specifier = "==0.0.24" },
+    { name = "zttp", marker = "python_full_version >= '3.12' or sys_platform != 'win32'", specifier = "==0.0.24" },
 ]
 docs = [
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1817,7 +1817,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "wsproto" },
-    { name = "zttp", marker = "python_full_version >= '3.12'" },
+    { name = "zttp" },
 ]
 docs = [
     { name = "mkdocstrings-python" },
@@ -1858,7 +1858,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "wsproto", specifier = "==1.3.2" },
-    { name = "zttp", marker = "python_full_version >= '3.12'", specifier = "==0.0.24" },
+    { name = "zttp", specifier = "==0.0.24" },
 ]
 docs = [
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1413,6 +1413,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1809,6 +1821,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-codspeed" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "ruff" },
     { name = "trustme" },
@@ -1817,7 +1830,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "wsproto" },
-    { name = "zttp", marker = "python_full_version >= '3.12' or sys_platform != 'win32'" },
+    { name = "zttp" },
 ]
 docs = [
     { name = "mkdocstrings-python" },
@@ -1850,6 +1863,7 @@ dev = [
     { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-codspeed", specifier = ">=4.1.1" },
     { name = "pytest-mock", specifier = "==3.15.1" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = "==3.8.0" },
     { name = "ruff", specifier = ">=0.15.15" },
     { name = "trustme", specifier = "==1.2.1" },
@@ -1858,7 +1872,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
     { name = "uvicorn", extras = ["standard"] },
     { name = "wsproto", specifier = "==1.3.2" },
-    { name = "zttp", marker = "python_full_version >= '3.12' or sys_platform != 'win32'", specifier = "==0.0.24" },
+    { name = "zttp", specifier = "==0.0.24" },
 ]
 docs = [
     { name = "mkdocstrings-python", specifier = ">=2.0.3" },


### PR DESCRIPTION
Temporary CI-debug PR to capture per-test failures for the zttp cp310 Windows hang, with pytest-timeout. Will be closed without merging.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution reliability by allowing longer-running test jobs.
  * Added timeout handling to prevent stalled tests from running indefinitely.
  * Updated test environment coverage for Windows with Python 3.10.

* **Chores**
  * Updated development tooling to support broader Python versions.
  * Added test timeout support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->