### PR TITLE
fix(http): handle case-insensitive and multi-token Connection: close headers

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1082,6 +1082,30 @@ async def test_return_close_header(http_protocol_cls: type[HTTPProtocol]):
     assert b"connection: close" in protocol.transport.buffer.lower()
 
 
+@pytest.mark.parametrize(
+    "connection_header",
+    [
+        b"Connection: close",
+        b"Connection: Close",
+        b"Connection: keep-alive, close",
+        b"Connection: close, keep-alive",
+        b"Connection:   CLOSE  ",
+    ],
+)
+async def test_close_connection_with_different_connection_headers(
+    http_protocol_cls: type[HTTPProtocol], connection_header: bytes
+):
+    app = Response("Hello, world", media_type="text/plain")
+    request = b"\r\n".join([b"GET / HTTP/1.1", b"Host: example.org", connection_header, b"", b""])
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(request)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"connection: close" in protocol.transport.buffer.lower()
+    assert protocol.transport.is_closing()
+
+
 async def test_close_connection_with_multiple_requests(http_protocol_cls: type[HTTPProtocol]):
     app = Response("Hello, world", media_type="text/plain")
 

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,10 +1,20 @@
 import asyncio
+from collections.abc import Iterable
 
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 
 CLOSE_HEADER = (b"connection", b"close")
 
 HIGH_WATER_LIMIT = 65536
+
+
+def is_connection_close(headers: Iterable[tuple[bytes, bytes]]) -> bool:
+    for name, value in headers:
+        if name.lower() == b"connection":
+            tokens = [token.strip().lower() for token in value.split(b",")]
+            if b"close" in tokens:
+                return True
+    return False
 
 
 class FlowControl:

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    is_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -475,7 +481,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if is_connection_close(self.scope["headers"]) and not is_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    is_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -478,7 +484,7 @@ class RequestResponseCycle:
             status_code = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if is_connection_close(self.scope["headers"]) and not is_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:
@@ -507,7 +513,7 @@ class RequestResponseCycle:
                 elif name == b"transfer-encoding" and value.lower() == b"chunked":
                     self.expected_content_length = 0
                     self.chunked_encoding = True
-                elif name == b"connection" and value.lower() == b"close":
+                elif name == b"connection" and b"close" in [token.strip().lower() for token in value.split(b",")]:
                     self.keep_alive = False
                 content.extend([name, b": ", value, b"\r\n"])
 

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -21,7 +21,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    is_connection_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -423,7 +429,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if is_connection_close(self.scope["headers"]) and not is_connection_close(headers):
                 headers = headers + [CLOSE_HEADER]
 
             bodyless = self.scope["method"] == "HEAD" or status in (204, 304) or status < 200


### PR DESCRIPTION
## Problem

When clients send `Connection: Close` (mixed/upper case) or multiple comma-separated tokens such as `Connection: keep-alive, close`, `HttpToolsProtocol` does not close the connection after sending the response. Additionally, HTTP protocols (`httptools`, `h11`, `zttp`) fail to echo `connection: close` in the response headers.

## Root Cause

1. Response header construction checked `CLOSE_HEADER in self.scope["headers"]` using exact tuple matching against `(b"connection", b"close")`. This failed when header values contained uppercase characters or multiple tokens.
2. In `HttpToolsProtocol`, `self.keep_alive = False` was only triggered if `value.lower() == b"close"` exact match, ignoring multi-token values.

## Fix

- Add `is_connection_close` helper to check for case-insensitive `close` tokens in comma-separated `Connection` headers.
- Use `is_connection_close` across `httptools`, `h11`, and `zttp` when determining whether to echo `CLOSE_HEADER` in the response.
- Update `HttpToolsProtocol` response header loop to parse comma-separated `Connection` tokens when updating `self.keep_alive`.

## Testing

- Added parameterized unit tests in `tests/protocols/test_http.py` covering `Connection: close`, `Connection: Close`, `Connection: keep-alive, close`, `Connection: close, keep-alive`, and padded whitespace.
- Verified all protocol unit tests pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `Connection: close` headers across HTTP protocol implementations.
  * Header matching now supports case variations, extra whitespace, and comma-separated values.
  * Applies consistently to incoming requests and outgoing responses.
  * Connections are reliably closed when the header requests it.

* **Tests**
  * Added coverage for multiple valid `Connection: close` header formats and verified successful responses and transport closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->