### PR TITLE
Treat the request Connection header as a token list

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -1082,6 +1082,36 @@ async def test_return_close_header(http_protocol_cls: type[HTTPProtocol]):
     assert b"connection: close" in protocol.transport.buffer.lower()
 
 
+@pytest.mark.parametrize(
+    "connection_value",
+    [
+        pytest.param(b"Close", id="mixed-case"),
+        pytest.param(b"CLOSE", id="upper-case"),
+        pytest.param(b"keep-alive, close", id="token-list"),
+        pytest.param(b"keep-alive, Close", id="token-list-mixed-case"),
+        pytest.param(b"close ", id="trailing-space"),
+    ],
+)
+async def test_return_close_header_is_case_and_token_insensitive(
+    http_protocol_cls: type[HTTPProtocol], connection_value: bytes
+):
+    """Connection is a comma separated list of case insensitive tokens.
+
+    RFC 9110 7.6.1 for the tokens, RFC 9112 9.6 for the close semantics.
+    """
+    request = b"\r\n".join([b"GET / HTTP/1.1", b"Host: example.org", b"Connection: " + connection_value, b"", b""])
+    app = Response("Hello, world", media_type="text/plain")
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(request)
+    await protocol.loop.run_one()
+
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    # NOTE: `.lower()` because H11 does not let Uvicorn lowercase these.
+    assert b"connection: close" in protocol.transport.buffer.lower()
+    assert protocol.transport.is_closing()
+
+
 async def test_close_connection_with_multiple_requests(http_protocol_cls: type[HTTPProtocol]):
     app = Response("Hello, world", media_type="text/plain")
 

--- a/uvicorn/protocols/http/flow_control.py
+++ b/uvicorn/protocols/http/flow_control.py
@@ -1,8 +1,26 @@
+from __future__ import annotations
+
 import asyncio
+from collections.abc import Iterable
 
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 
 CLOSE_HEADER = (b"connection", b"close")
+
+
+def request_wants_close(headers: Iterable[tuple[bytes, bytes]]) -> bool:
+    """Whether the request asked for the connection to be closed.
+
+    Connection carries a comma separated list of case insensitive tokens
+    (RFC 9110 7.6.1), so `Close` and `keep-alive, close` both ask for a close.
+    """
+    for name, value in headers:
+        if name.lower() != b"connection":
+            continue
+        if any(token.strip().lower() == b"close" for token in value.split(b",")):
+            return True
+    return False
+
 
 HIGH_WATER_LIMIT = 65536
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    request_wants_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -475,7 +481,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if request_wants_close(self.scope["headers"]) and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -23,7 +23,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    request_wants_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -478,7 +484,7 @@ class RequestResponseCycle:
             status_code = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if request_wants_close(self.scope["headers"]) and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
 
             if self.access_log:

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -21,7 +21,13 @@ from uvicorn._types import (
 )
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
-from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
+from uvicorn.protocols.http.flow_control import (
+    CLOSE_HEADER,
+    HIGH_WATER_LIMIT,
+    FlowControl,
+    request_wants_close,
+    service_unavailable,
+)
 from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
@@ -423,7 +429,7 @@ class RequestResponseCycle:
             status = message["status"]
             headers = self.default_headers + list(message.get("headers", []))
 
-            if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
+            if request_wants_close(self.scope["headers"]) and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
 
             bodyless = self.scope["method"] == "HEAD" or status in (204, 304) or status < 200


### PR DESCRIPTION
Closes #3074.

`Connection: Close` and `Connection: keep-alive, close` left the connection open
on httptools. The echo check was an exact tuple match against
`(b"connection", b"close")`. httptools lowercases the header name but keeps the
value as sent, so a capitalised or multi-token value never matched. Without the
echo the response carried no `close`, and the response-side check that clears
`keep_alive` never fired either, so the socket stayed open.

Connection carries a comma separated list of case insensitive tokens
(RFC 9110 7.6.1), and a server that receives `close` must close after the final
response and should echo it (RFC 9112 9.6). `request_wants_close` does that
tokenisation, matching what `_get_upgrade` already does for the upgrade token.

One correction to the issue: h11 is not actually affected. It normalises
Connection values before they reach the scope, so it already echoes and closes
on all the cases below. I still routed it through the same helper, since the
exact-match check was wrong there for the same reason and only h11's own
normalisation was covering it. All three implementations now share one
definition.

Tests are parametrized over `Close`, `CLOSE`, `keep-alive, close`,
`keep-alive, Close` and a trailing space, across every implementation, and
assert both the echo and that the transport actually closes. 9 of the 15 fail
on main.

`scripts/check` is clean (ruff format, mypy, ruff check). Full suite goes from
1312 to 1327 passing with no new failures.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

