### PR TITLE
Accept absolute-form request targets

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -110,6 +110,12 @@ HTTP10_GET_REQUEST = b"\r\n".join([b"GET / HTTP/1.0", b"Host: example.org", b"",
 
 GET_REQUEST_WITH_RAW_PATH = b"\r\n".join([b"GET /one%2Ftwo HTTP/1.1", b"Host: example.org", b"", b""])
 
+ABSOLUTE_FORM_REQUEST = b"\r\n".join([b"GET http://example.org/one/two?a=1 HTTP/1.1", b"Host: example.org", b"", b""])
+
+ABSOLUTE_FORM_EMPTY_PATH_REQUEST = b"\r\n".join(
+    [b"GET http://example.org?a=1 HTTP/1.1", b"Host: example.org", b"", b""]
+)
+
 UPGRADE_REQUEST = b"\r\n".join(
     [
         b"GET / HTTP/1.1",
@@ -762,6 +768,44 @@ async def test_raw_path(http_protocol_cls: type[HTTPProtocol]):
     protocol = get_connected_protocol(app, http_protocol_cls, root_path="/app")
     protocol.data_received(GET_REQUEST_WITH_RAW_PATH)
     await protocol.loop.run_one()
+    assert b"Done" in protocol.transport.buffer
+
+
+async def test_absolute_form_request_target(http_protocol_cls: type[HTTPProtocol]):
+    """RFC 9112, section 3.2.2: a server must accept the absolute-form request target."""
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "http"
+        assert scope["path"] == "/one/two"
+        assert scope["raw_path"] == b"/one/two"
+        assert scope["query_string"] == b"a=1"
+
+        response = Response("Done", media_type="text/plain")
+        await response(scope, receive, send)
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(ABSOLUTE_FORM_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
+    assert b"Done" in protocol.transport.buffer
+
+
+async def test_absolute_form_request_target_with_empty_path(http_protocol_cls: type[HTTPProtocol]):
+    """RFC 9112, section 3.2.1: an absolute-form target with an empty path means `/`."""
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
+        assert scope["type"] == "http"
+        assert scope["path"] == "/"
+        assert scope["raw_path"] == b"/"
+        assert scope["query_string"] == b"a=1"
+
+        response = Response("Done", media_type="text/plain")
+        await response(scope, receive, send)
+
+    protocol = get_connected_protocol(app, http_protocol_cls)
+    protocol.data_received(ABSOLUTE_FORM_EMPTY_PATH_REQUEST)
+    await protocol.loop.run_one()
+    assert b"HTTP/1.1 200 OK" in protocol.transport.buffer
     assert b"Done" in protocol.transport.buffer
 
 

--- a/tests/protocols/test_utils.py
+++ b/tests/protocols/test_utils.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_remote_addr
+from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_origin_form_path, get_remote_addr
 
 
 class MockSocket:
@@ -90,3 +90,27 @@ def test_get_remote_addr():
 )
 def test_get_client_addr(scope: Any, expected_client: str):
     assert get_client_addr(scope) == expected_client
+
+
+@pytest.mark.parametrize(
+    "raw_path, expected",
+    [
+        # origin-form is already what the scope wants
+        (b"/", b"/"),
+        (b"/one/two", b"/one/two"),
+        (b"/one%2Ftwo", b"/one%2Ftwo"),
+        # absolute-form, which servers must accept (RFC 9112, section 3.2.2)
+        (b"http://example.org/one/two", b"/one/two"),
+        (b"https://example.org:8443/one/two", b"/one/two"),
+        (b"https://user:pass@example.org:8443/one/two", b"/one/two"),
+        (b"HTTP://EXAMPLE.ORG/One", b"/One"),
+        (b"http://example.org/", b"/"),
+        # an absolute-form target with an empty path means "/"
+        (b"http://example.org", b"/"),
+        # asterisk-form and authority-form are left alone
+        (b"*", b"*"),
+        (b"example.org:443", b"example.org:443"),
+    ],
+)
+def test_get_origin_form_path(raw_path: bytes, expected: bytes) -> None:
+    assert get_origin_form_path(raw_path) == expected

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -24,7 +24,14 @@ from uvicorn._types import (
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
-from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
+from uvicorn.protocols.utils import (
+    get_client_addr,
+    get_local_addr,
+    get_origin_form_path,
+    get_path_with_query_string,
+    get_remote_addr,
+    is_ssl,
+)
 from uvicorn.server import ServerState
 
 
@@ -199,6 +206,7 @@ class H11Protocol(asyncio.Protocol):
             elif isinstance(event, h11.Request):
                 self.headers = [(key.lower(), value) for key, value in event.headers]
                 raw_path, _, query_string = event.target.partition(b"?")
+                raw_path = get_origin_form_path(raw_path)
                 path = unquote(raw_path.decode("ascii"))
                 full_path = self.root_path + path
                 full_raw_path = self.root_path.encode("ascii") + raw_path

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -254,7 +254,8 @@ class HttpToolsProtocol(asyncio.Protocol):
         if self.parser.should_upgrade() and self._should_upgrade():
             return
         parsed_url = httptools.parse_url(self.url)
-        raw_path = parsed_url.path
+        # An absolute-form target with an empty path parses to `None`, and means `/`.
+        raw_path = parsed_url.path or b"/"
         path = raw_path.decode("ascii")
         if "%" in path:
             path = urllib.parse.unquote(path)

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -22,7 +22,14 @@ from uvicorn._types import (
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
-from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
+from uvicorn.protocols.utils import (
+    get_client_addr,
+    get_local_addr,
+    get_origin_form_path,
+    get_path_with_query_string,
+    get_remote_addr,
+    is_ssl,
+)
 from uvicorn.server import ServerState
 
 
@@ -147,11 +154,12 @@ class ZttpProtocol(asyncio.Protocol):
             if isinstance(event, zttp.Request):
                 assert isinstance(event.headers, zttp.HeaderBlock)
                 self.headers = event.headers.to_list(lowercase_names=True)
-                path = event.path.decode("ascii")
+                raw_path = get_origin_form_path(event.path)
+                path = raw_path.decode("ascii")
                 if "%" in path:
                     path = unquote(path)
                 full_path = self.root_path + path
-                full_raw_path = self.root_path.encode("ascii") + event.path
+                full_raw_path = self.root_path.encode("ascii") + raw_path
                 self.scope = {
                     "type": "http",
                     "asgi": {"version": self.asgi_version, "spec_version": "2.3"},

--- a/uvicorn/protocols/utils.py
+++ b/uvicorn/protocols/utils.py
@@ -48,6 +48,29 @@ def is_ssl(transport: asyncio.Transport) -> bool:
     return bool(transport.get_extra_info("sslcontext"))
 
 
+def get_origin_form_path(raw_path: bytes) -> bytes:
+    """Reduce a request target to the origin-form path expected in the ASGI scope.
+
+    HTTP/1.1 servers are required to accept the absolute-form request target
+    (RFC 9112, section 3.2.2), e.g. ``GET http://example.org/foo HTTP/1.1``.
+    Only the path is meaningful to the application, so strip the scheme and
+    authority. An absolute-form target with an empty path means ``/``
+    (RFC 9112, section 3.2.1).
+
+    The origin-form (``/foo``), asterisk-form (``*``) and authority-form
+    (``example.org:443``, used by CONNECT) targets are returned unchanged.
+    """
+    if raw_path.startswith(b"/") or raw_path == b"*":
+        return raw_path
+
+    _, separator, rest = raw_path.partition(b"://")
+    if not separator:
+        return raw_path
+
+    _, slash, remainder = rest.partition(b"/")
+    return slash + remainder if slash else b"/"
+
+
 def get_client_addr(scope: WWWScope) -> str:
     client = scope.get("client")
     if not client:


### PR DESCRIPTION
# Summary

RFC 9112, section 3.2.2 requires an HTTP/1.1 server to accept the **absolute-form** request target:

> a server MUST accept the absolute-form in requests, even though HTTP/1.1 clients will only send absolute-form to a proxy

None of the HTTP implementations handle it today, and the two default ones fail in different ways.

**`h11` and `zttp`** put the entire target into the scope, so the application routes on a path that is not a path:

```
GET http://example.org/one/two HTTP/1.1
Host: example.org
```

```python
scope["path"]      == "http://example.org/one/two"   # expected "/one/two"
scope["raw_path"]  == b"http://example.org/one/two"  # expected b"/one/two"
```

The application 404s a route it does have. With `root_path="/api"` the two are concatenated into `"/apihttp://example.org/one/two"`.

**`httptools`** resolves the path correctly, but an absolute-form target with an *empty* path is parsed by `httptools.parse_url()` into `path=None`, and the `raw_path.decode("ascii")` that follows raises `AttributeError: 'NoneType' object has no attribute 'decode'` inside the parser callback. httptools re-raises that as `HttpParserCallbackError`, which subclasses `HttpParserError`, so `data_received()` catches it in the branch meant for malformed input and answers a valid request with `400` plus a misleading `Invalid HTTP request received` warning:

```
GET http://example.org?a=1 HTTP/1.1
Host: example.org
```

```
HTTP/1.1 400 Bad Request
```

# Changes

`get_origin_form_path()` in `uvicorn/protocols/utils.py` reduces a target to its origin-form path, and is used by the `h11` and `zttp` implementations. An absolute-form target with an empty path becomes `/`, per RFC 9112, section 3.2.1. `httptools` already strips the scheme and authority, so it only needed the empty-path case.

Origin-form (`/foo`), asterisk-form (`*`, `OPTIONS *`) and authority-form (`example.org:443`, `CONNECT`) targets are returned unchanged, so existing behaviour is untouched.

All three implementations now agree, which the parametrized `http_protocol_cls` tests check.

# Tests

`test_absolute_form_request_target` and `test_absolute_form_request_target_with_empty_path` in `tests/protocols/test_http.py` run against `httptools`, `h11` and `zttp`, plus a unit test for the helper covering every target form.

On `main` the new tests are `5 failed, 1 passed` (the one pass is `httptools` with a non-empty path, the only combination that was already correct); with this change `6 passed`. `tests/protocols/` is green at `321 passed`, and `ruff format`, `ruff check` and the branch coverage of the new helper are clean.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly. No documentation change: this makes the implementations follow the RFC and each other, and no documented behaviour changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

