### PR TITLE
Add support for zuvloop

### DIFF
--- a/docs/concepts/event-loop.md
+++ b/docs/concepts/event-loop.md
@@ -1,9 +1,9 @@
 # Event Loop
 
-Uvicorn provides two event loop implementations that you can choose from using the [`--loop`](../settings.md#implementation) option:
+Uvicorn provides three event loop implementations that you can choose from using the [`--loop`](../settings.md#implementation) option:
 
 ```bash
-uvicorn main:app --loop <auto|asyncio|uvloop>
+uvicorn main:app --loop <auto|asyncio|uvloop|zuvloop>
 ```
 
 By default, Uvicorn uses `--loop auto`, which automatically selects:
@@ -18,6 +18,30 @@ When running with `--reload` or multiple workers, it uses [`SelectorEventLoop`][
 
 ??? info "Why can `ProactorEventLoop` fail with multiple processes on Windows?"
     If you want to know more about it, you can read the issue [#cpython/122240](https://github.com/python/cpython/issues/122240).
+
+## zuvloop
+
+[`zuvloop`](https://zuvloop.marcelotryle.com/) is an `asyncio` event loop powered by libuv and written in Zig.
+It requires CPython 3.14 or newer.
+
+Install `zuvloop` separately:
+
+=== "pip"
+    ```bash
+    pip install zuvloop
+    ```
+=== "uv"
+    ```bash
+    uv add zuvloop
+    ```
+
+Then select it explicitly:
+
+```bash
+uvicorn main:app --loop zuvloop
+```
+
+Uvicorn does not include `zuvloop` in the `standard` extra or select it with `--loop auto`.
 
 ## Custom Event Loop
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -91,7 +91,7 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 
 ## Implementation
 
-* `--loop <str>` - Set the event loop implementation. The uvloop implementation provides greater performance, but is not compatible with Windows or PyPy. **Options:** *'auto', 'asyncio', 'uvloop'.* **Default:** *'auto'*.
+* `--loop <str>` - Set the event loop implementation. The uvloop implementation provides greater performance, but is not compatible with Windows or PyPy. The zuvloop implementation requires CPython 3.14 or newer and must be installed separately. **Options:** *'auto', 'asyncio', 'uvloop', 'zuvloop'.* **Default:** *'auto'*.
 * `--http <str>` - Set the [HTTP protocol implementation](concepts/http-protocols.md). The httptools implementation provides greater performance, but is not compatible with PyPy. The zttp implementations are experimental and require the `zttp` package (`pip install zttp`): `zttp` serves both HTTP/1.1 and HTTP/2 (negotiated via ALPN over TLS, or via prior knowledge on cleartext connections), `zttp1` serves HTTP/1.1 only, and `zttp2` serves HTTP/2 only. See the [HTTP/2 documentation](concepts/http2.md) for details. **Options:** *'auto', 'h11', 'httptools', 'zttp', 'zttp1', 'zttp2'.* **Default:** *'auto'*.
 * `--ws <str>` - Set the WebSockets protocol implementation. Either of the `websockets` and `wsproto` packages are supported. There are two versions of `websockets` supported: `websockets` and `websockets-sansio`. Use `'none'` to ignore all websocket requests. **Options:** *'auto', 'none', 'websockets', 'websockets-sansio', 'wsproto'.* **Default:** *'auto'*.
 * `--ws-max-size <int>` - Set the WebSockets max message size, in bytes. **Default:** *16777216* (16 MB).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,8 @@ omit = [
     "uvicorn/workers.py",
     "uvicorn/__main__.py",
     "uvicorn/_compat.py",
+    # Optional integration covered by zuvloop's Uvicorn compatibility suite.
+    "uvicorn/loops/zuvloop.py",
     # Deprecated legacy websockets implementation, no longer tested.
     "uvicorn/protocols/websockets/websockets_impl.py",
     "tests/benchmarks/*",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import configparser
 import io
 import json
@@ -635,18 +634,6 @@ def test_get_loop_factory(loop_type: LoopFactoryType, expected_loop_factory: Any
         with closing(loop):
             assert loop is not None
             assert isinstance(loop, expected_loop_factory)
-
-
-def test_get_zuvloop_factory(monkeypatch: pytest.MonkeyPatch) -> None:
-    zuvloop = MagicMock(new_event_loop=asyncio.new_event_loop)
-    monkeypatch.setitem(sys.modules, "zuvloop", zuvloop)
-    sys.modules.pop("uvicorn.loops.zuvloop", None)
-
-    try:
-        config = Config(app=asgi_app, loop="zuvloop")
-        assert config.get_loop_factory() is asyncio.new_event_loop
-    finally:
-        sys.modules.pop("uvicorn.loops.zuvloop", None)
 
 
 def test_custom_loop__importable_custom_loop_setup_function() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import configparser
 import io
 import json
@@ -634,6 +635,18 @@ def test_get_loop_factory(loop_type: LoopFactoryType, expected_loop_factory: Any
         with closing(loop):
             assert loop is not None
             assert isinstance(loop, expected_loop_factory)
+
+
+def test_get_zuvloop_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    zuvloop = MagicMock(new_event_loop=asyncio.new_event_loop)
+    monkeypatch.setitem(sys.modules, "zuvloop", zuvloop)
+    sys.modules.pop("uvicorn.loops.zuvloop", None)
+
+    try:
+        config = Config(app=asgi_app, loop="zuvloop")
+        assert config.get_loop_factory() is asyncio.new_event_loop
+    finally:
+        sys.modules.pop("uvicorn.loops.zuvloop", None)
 
 
 def test_custom_loop__importable_custom_loop_setup_function() -> None:

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -38,7 +38,7 @@ class UvicornDeprecationWarning(UserWarning):
 HTTPProtocolType = Literal["auto", "h11", "httptools", "zttp", "zttp1", "zttp2"]
 WSProtocolType = Literal["auto", "none", "websockets", "websockets-sansio", "wsproto"]
 LifespanType = Literal["auto", "on", "off"]
-LoopFactoryType = Literal["none", "auto", "asyncio", "uvloop"]
+LoopFactoryType = Literal["none", "auto", "asyncio", "uvloop", "zuvloop"]
 InterfaceType = Literal["auto", "asgi3", "asgi2", "wsgi"]
 
 LOG_LEVELS: dict[str, int] = {
@@ -74,6 +74,7 @@ LOOP_FACTORIES: dict[str, str | None] = {
     "auto": "uvicorn.loops.auto:auto_loop_factory",
     "asyncio": "uvicorn.loops.asyncio:asyncio_loop_factory",
     "uvloop": "uvicorn.loops.uvloop:uvloop_loop_factory",
+    "zuvloop": "uvicorn.loops.zuvloop:zuvloop_loop_factory",
 }
 INTERFACES: list[InterfaceType] = ["auto", "asgi3", "asgi2", "wsgi"]
 

--- a/uvicorn/loops/zuvloop.py
+++ b/uvicorn/loops/zuvloop.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import zuvloop
+
+
+def zuvloop_loop_factory(use_subprocess: bool = False) -> Callable[[], asyncio.AbstractEventLoop]:
+    return zuvloop.new_event_loop


### PR DESCRIPTION
## Summary

- Add `zuvloop` as an explicit event loop factory.
- Document installation and `--loop zuvloop` usage.
- Cover the configuration path without requiring Python 3.14 in every test environment.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

