### PR TITLE
Unset the keep-alive timer when upgrading to WebSocket

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -451,6 +451,30 @@ async def test_keepalive_timeout_with_pipelined_requests(http_protocol_cls: type
     assert protocol.timeout_keep_alive_task is not None
 
 
+async def test_keepalive_timeout_with_pipelined_websocket_upgrade(
+    http_protocol_cls: type[HTTPProtocol], ws_protocol_cls: type[WSProtocol]
+):
+    if http_protocol_cls.__name__ == "HttpToolsProtocol":
+        # httptools upgrades only from within data_received(), which always
+        # unsets the timer first, and it arms the timer only when its pipeline
+        # is empty. The state under test is unreachable there.
+        pytest.skip("httptools never upgrades with the keep-alive timer armed")
+
+    app = Response("Hello, world", media_type="text/plain")
+
+    protocol = get_connected_protocol(app, http_protocol_cls, ws=ws_protocol_cls)
+    # The upgrade request is pipelined behind a plain request, so it is still
+    # buffered when the first response completes and is picked up by the
+    # handle_events() call made from on_response_complete().
+    protocol.data_received(SIMPLE_GET_REQUEST + UPGRADE_REQUEST)
+    await protocol.loop.run_one()
+
+    # The connection now belongs to the WebSocket protocol. A keep-alive timer
+    # left armed on it fires against a request cycle that never completes, and
+    # closing the transport from there would drop a live WebSocket.
+    assert protocol.timeout_keep_alive_task is None
+
+
 async def test_close(http_protocol_cls: type[HTTPProtocol]):
     app = Response(b"", status_code=204, headers={"connection": "close"})
 

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -287,6 +287,12 @@ class H11Protocol(asyncio.Protocol):
             prefix = "%s:%d - " % self.client if self.client else ""
             self.logger.log(TRACE_LOG_LEVEL, "%sUpgrading to WebSocket", prefix)
 
+        # The transport is handed over to the WebSocket protocol, so the HTTP
+        # keep-alive timer must not outlive the upgrade. A pipelined upgrade is
+        # picked up from on_response_complete(), after the timer was armed and
+        # without passing the _unset_keepalive_if_required() below.
+        self._unset_keepalive_if_required()
+
         self.connections.discard(self)
         output = [event.method, b" ", event.target, b" HTTP/1.1\r\n"]
         for name, value in self.headers:

--- a/uvicorn/protocols/http/zttp_impl.py
+++ b/uvicorn/protocols/http/zttp_impl.py
@@ -235,6 +235,10 @@ class ZttpProtocol(asyncio.Protocol):
             prefix = "%s:%d - " % self.client if self.client else ""
             self.logger.log(TRACE_LOG_LEVEL, "%sUpgrading to WebSocket", prefix)
 
+        # The transport is handed over to the WebSocket protocol, so the HTTP
+        # keep-alive timer must not outlive the upgrade.
+        self._unset_keepalive_if_required()
+
         self.connections.discard(self)
         output = bytearray(event.method + b" " + event.target + b" HTTP/1.1\r\n")
         for name, value in self.headers:


### PR DESCRIPTION
# Summary

`handle_websocket_upgrade()` returns before the `_unset_keepalive_if_required()` that guards ordinary requests, so a WebSocket upgrade pipelined behind a plain request leaves the HTTP keep-alive timer armed on a transport that now belongs to the WebSocket protocol.

The upgrade is picked up by the `handle_events()` call at the end of `on_response_complete()` — that is, immediately after the timer was armed — so it never goes through `data_received()`, which would have unset it.

### Reproducing

Send a plain request and an upgrade in one segment, then hold the WebSocket open past `timeout_keep_alive`:

```
GET / HTTP/1.1\r\nHost: example.org\r\n\r\nGET /ws HTTP/1.1\r\nHost: example.org\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: <key>\r\nSec-WebSocket-Version: 13\r\n\r\n
```

```
Exception in callback H11Protocol.timeout_keep_alive_handler()
h11._util.LocalProtocolError: can't handle event type ConnectionClosed when role=SERVER and state=SEND_RESPONSE
```

That is the message reported in #1637 and discussed in #1984; both stalled for want of a reproducer, so this is at least one concrete path to it.

### Why not simply catch the error

Because the raise is load-bearing today:

```python
if not self.transport.is_closing():
    event = h11.ConnectionClosed()
    self.conn.send(event)     # raises
    self.transport.close()    # never reached
```

Wrapping the `send` in `try/except h11.LocalProtocolError` and letting `transport.close()` run turns a noisy log line into dropped connections — I measured the live WebSocket being closed `timeout_keep_alive` seconds after the upgrade. Releasing the timer at the hand-over keeps both properties: no exception, and the WebSocket stays up.

### Scope

`h11_impl` and `zttp_impl` both reach `handle_websocket_upgrade()` from `on_response_complete()`.

`httptools_impl` is deliberately left unchanged: it upgrades only from within `data_received()`, which unsets the timer first, and it arms the timer only when its pipeline is empty, so the state is unreachable there. The test skips it with that reason.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

