### PR TITLE
Treat a pipe closed between poll() and recv() as a failed healthcheck

### DIFF
--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -58,6 +58,27 @@ def test_process_ping_broken_pipe() -> None:
     assert not process.ping(0.1)
 
 
+def test_process_ping_pipe_closed_between_poll_and_recv() -> None:
+    """A worker being replaced can have its pipe closed after poll() reported data.
+
+    CPython's Connection._recv() has cleared its handle by then and calls
+    os.read(None, size), which raises TypeError rather than OSError.
+    """
+    process = Process(Config(app=app), sockets=[])
+
+    class ClosedDuringRecv:
+        def send(self, data: bytes) -> None: ...
+
+        def poll(self, timeout: float) -> bool:
+            return True
+
+        def recv(self) -> bool:
+            raise TypeError("'NoneType' object cannot be interpreted as an integer")
+
+    process.parent_conn = ClosedDuringRecv()  # type: ignore[assignment]
+    assert not process.ping(0.1)
+
+
 def test_process_ready() -> None:
     """`is_ready()` reflects whether the worker's server has finished startup."""
     process = Process(Config(app=app), sockets=[])

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -45,6 +45,11 @@ class Process:
             return None
         except (OSError, EOFError, pickle.UnpicklingError):
             return None
+        except TypeError:
+            # The pipe can be closed by another thread between poll() and recv().
+            # Connection._recv() then reads the already-cleared handle, and calls
+            # os.read(None, size), which raises TypeError rather than OSError.
+            return None
 
     def ping(self, timeout: float = 5) -> bool:
         """Receives a timeout and returns True if the worker answers a healthcheck in time."""


### PR DESCRIPTION
# Summary

Patch for #3109, which carries the full analysis.

`Process._healthcheck()` propagates `TypeError` when a worker's pipe is closed by another thread between `poll()` and `recv()`. `Connection.close()` clears `_handle`, so `Connection._recv()` calls `os.read(None, size)` and CPython raises `TypeError` rather than `OSError`.

Seen on CI (`Python 3.12 ubuntu-latest`), during `test_multiprocess_health_check`:

```
uvicorn/supervisors/multiprocess.py:43: in _healthcheck
    started: bool = self.parent_conn.recv()
/usr/lib/python3.12/multiprocessing/connection.py:437: in _recv_bytes
    return self._recv(size)
>           chunk = read(handle, remaining)
E           TypeError: 'NoneType' object cannot be interpreted as an integer
```

This is the same class of failure #2975 handled for `EOFError` / `UnpicklingError` — a pipe torn down concurrently is "the worker did not answer", which is what `_healthcheck()` documents `None` for. Only the moment of teardown differs, and with it the exception CPython raises.

The new test sits next to `test_process_ping_broken_pipe` and uses a fake connection, so it is deterministic: without the change it fails with the exact message above.

Verified with the full suite green (1329 passed, 17 skipped) and `tests/supervisors/test_multiprocess.py` run 20x with no failures.

I opened this directly rather than waiting on #3109, since the change is small and the discussion holds the reasoning. Happy to close it or convert it to a draft if you would rather settle #3109 first.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

