### PR TITLE
Document duplicate pull request policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,9 @@
+# AI Policy
+
+You may use AI tools when contributing to Uvicorn. You remain responsible for every contribution you submit.
+
+Before you open a pull request, search the open and closed pull requests, issues, and discussions. Do not open a pull
+request when the same change has already been proposed or is already in progress.
+
+Duplicate pull requests waste maintainer time and create unnecessary review work. Contributors who submit duplicate
+pull requests will be banned from the project.


### PR DESCRIPTION
## Summary

- Add an AI contribution policy.
- Require contributors to check for existing work before opening a pull request.
- Warn that duplicate pull requests will result in a ban.

## Testing

Not run. This change only adds documentation.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I have reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

