### PR TITLE
feat(middleware): support X-Forwarded-Host and X-Forwarded-Port in ProxyHeadersMiddleware

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -672,3 +672,23 @@ async def test_proxy_headers_x_forwarded_host_and_port() -> None:
     scope3 = _make_http_scope([(b"x-forwarded-host", b"example.com"), (b"x-forwarded-proto", b"https")], scheme="http")
     await middleware(scope3, _noop_receive, _noop_send)
     assert captured["server"] == ("example.com", 443)
+
+    # Comma-separated X-Forwarded-Host from multiple proxies (takes first)
+    scope4 = _make_http_scope([(b"x-forwarded-host", b"client.example.com, proxy.example.com")], scheme="http")
+    await middleware(scope4, _noop_receive, _noop_send)
+    assert captured["server"] == ("client.example.com", 80)
+
+    # Port in host takes precedence over separate X-Forwarded-Port
+    scope5 = _make_http_scope([(b"x-forwarded-host", b"example.com:8443"), (b"x-forwarded-port", b"9000")], scheme="http")
+    await middleware(scope5, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 8443)
+
+    # Invalid / non-numeric X-Forwarded-Port falls back to scheme default
+    scope6 = _make_http_scope([(b"x-forwarded-host", b"example.com"), (b"x-forwarded-port", b"not-a-number")], scheme="http")
+    await middleware(scope6, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 80)
+
+    # Out-of-range port falls back to scheme default
+    scope7 = _make_http_scope([(b"x-forwarded-host", b"example.com"), (b"x-forwarded-port", b"99999")], scheme="http")
+    await middleware(scope7, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 80)

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -646,3 +646,29 @@ async def test_proxy_headers_haproxy_behind_alb() -> None:
     await middleware(scope, _noop_receive, _noop_send)
     assert captured["client"] == ("1.2.3.4", 0)
     assert captured["scheme"] == "https"
+
+
+@pytest.mark.anyio
+async def test_proxy_headers_x_forwarded_host_and_port() -> None:
+    captured: dict[str, object] = {}
+
+    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable) -> None:
+        assert scope["type"] == "http"
+        captured["server"] = scope.get("server")
+
+    middleware = ProxyHeadersMiddleware(app, trusted_hosts="127.0.0.1")
+
+    # Host with explicit port in header
+    scope = _make_http_scope([(b"x-forwarded-host", b"example.com:8080")], scheme="http")
+    await middleware(scope, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 8080)
+
+    # Host with separate X-Forwarded-Port
+    scope2 = _make_http_scope([(b"x-forwarded-host", b"example.com"), (b"x-forwarded-port", b"9000")], scheme="http")
+    await middleware(scope2, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 9000)
+
+    # Host only, HTTPS default
+    scope3 = _make_http_scope([(b"x-forwarded-host", b"example.com"), (b"x-forwarded-proto", b"https")], scheme="http")
+    await middleware(scope3, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 443)

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -679,12 +679,16 @@ async def test_proxy_headers_x_forwarded_host_and_port() -> None:
     assert captured["server"] == ("client.example.com", 80)
 
     # Port in host takes precedence over separate X-Forwarded-Port
-    scope5 = _make_http_scope([(b"x-forwarded-host", b"example.com:8443"), (b"x-forwarded-port", b"9000")], scheme="http")
+    scope5 = _make_http_scope(
+        [(b"x-forwarded-host", b"example.com:8443"), (b"x-forwarded-port", b"9000")], scheme="http"
+    )
     await middleware(scope5, _noop_receive, _noop_send)
     assert captured["server"] == ("example.com", 8443)
 
     # Invalid / non-numeric X-Forwarded-Port falls back to scheme default
-    scope6 = _make_http_scope([(b"x-forwarded-host", b"example.com"), (b"x-forwarded-port", b"not-a-number")], scheme="http")
+    scope6 = _make_http_scope(
+        [(b"x-forwarded-host", b"example.com"), (b"x-forwarded-port", b"not-a-number")], scheme="http"
+    )
     await middleware(scope6, _noop_receive, _noop_send)
     assert captured["server"] == ("example.com", 80)
 
@@ -692,3 +696,36 @@ async def test_proxy_headers_x_forwarded_host_and_port() -> None:
     scope7 = _make_http_scope([(b"x-forwarded-host", b"example.com"), (b"x-forwarded-port", b"99999")], scheme="http")
     await middleware(scope7, _noop_receive, _noop_send)
     assert captured["server"] == ("example.com", 80)
+
+    # Repeated X-Forwarded-Host headers (preserves first across all fields)
+    scope8 = _make_http_scope(
+        [(b"x-forwarded-host", b"client.example.com"), (b"x-forwarded-host", b"proxy.example.com")],
+        scheme="http",
+    )
+    await middleware(scope8, _noop_receive, _noop_send)
+    assert captured["server"] == ("client.example.com", 80)
+
+    # Comma-separated X-Forwarded-Host with leading empty elements
+    scope9 = _make_http_scope(
+        [(b"x-forwarded-host", b", client.example.com, proxy.example.com")],
+        scheme="http",
+    )
+    await middleware(scope9, _noop_receive, _noop_send)
+    assert captured["server"] == ("client.example.com", 80)
+
+    # Out-of-range port in host string falls back to scheme default or separate X-Forwarded-Port
+    scope10 = _make_http_scope([(b"x-forwarded-host", b"example.com:99999")], scheme="http")
+    await middleware(scope10, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 80)
+
+    scope11 = _make_http_scope(
+        [(b"x-forwarded-host", b"example.com:99999"), (b"x-forwarded-port", b"8080")],
+        scheme="http",
+    )
+    await middleware(scope11, _noop_receive, _noop_send)
+    assert captured["server"] == ("example.com", 8080)
+
+    # Out-of-range port in bracketed IPv6 host falls back to scheme default
+    scope12 = _make_http_scope([(b"x-forwarded-host", b"[2001:db8::1]:99999")], scheme="http")
+    await middleware(scope12, _noop_receive, _noop_send)
+    assert captured["server"] == ("2001:db8::1", 80)

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -35,7 +35,7 @@ class ProxyHeadersMiddleware:
         if client_host in self.trusted_hosts:
             x_forwarded_proto_value: bytes | None = None
             x_forwarded_for_values: list[bytes] = []
-            x_forwarded_host_value: bytes | None = None
+            x_forwarded_host_values: list[bytes] = []
             x_forwarded_port_value: bytes | None = None
             for name, value in scope["headers"]:
                 if name == b"x-forwarded-proto":
@@ -43,7 +43,7 @@ class ProxyHeadersMiddleware:
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
                 elif name == b"x-forwarded-host":
-                    x_forwarded_host_value = value
+                    x_forwarded_host_values.append(value)
                 elif name == b"x-forwarded-port":
                     x_forwarded_port_value = value
 
@@ -66,12 +66,20 @@ class ProxyHeadersMiddleware:
                     # See: https://github.com/Kludex/uvicorn/issues/1068
                     scope["client"] = (host, port)
 
-            if x_forwarded_host_value is not None:
-                raw_host_str = x_forwarded_host_value.decode("latin1").strip()
-                if raw_host_str:
-                    # When multiple proxies append to X-Forwarded-Host, take the first (client-facing) host
-                    host_str = raw_host_str.split(",")[0].strip()
+            if x_forwarded_host_values:
+                raw_host_str = b", ".join(x_forwarded_host_values).decode("latin1")
+                # When multiple proxies append to X-Forwarded-Host or repeated headers exist,
+                # select the first non-empty (client-facing) host.
+                host_str = ""
+                for item in _parse_raw_hosts(raw_host_str):
+                    if item:
+                        host_str = item
+                        break
+
+                if host_str:
                     server_host, server_port = _parse_host_port(host_str)
+                    if not (0 < server_port <= 65535):
+                        server_port = 0
                     if server_port == 0 and x_forwarded_port_value is not None:
                         try:
                             parsed_port = int(x_forwarded_port_value.decode("latin1").strip())

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -35,11 +35,17 @@ class ProxyHeadersMiddleware:
         if client_host in self.trusted_hosts:
             x_forwarded_proto_value: bytes | None = None
             x_forwarded_for_values: list[bytes] = []
+            x_forwarded_host_value: bytes | None = None
+            x_forwarded_port_value: bytes | None = None
             for name, value in scope["headers"]:
                 if name == b"x-forwarded-proto":
                     x_forwarded_proto_value = value
                 elif name == b"x-forwarded-for":
                     x_forwarded_for_values.append(value)
+                elif name == b"x-forwarded-host":
+                    x_forwarded_host_value = value
+                elif name == b"x-forwarded-port":
+                    x_forwarded_port_value = value
 
             if x_forwarded_proto_value is not None:
                 x_forwarded_proto = x_forwarded_proto_value.decode("latin1").strip()
@@ -59,6 +65,21 @@ class ProxyHeadersMiddleware:
                     # Only set the client if we actually got something usable.
                     # See: https://github.com/Kludex/uvicorn/issues/1068
                     scope["client"] = (host, port)
+
+            if x_forwarded_host_value is not None:
+                host_str = x_forwarded_host_value.decode("latin1").strip()
+                if host_str:
+                    server_host, server_port = _parse_host_port(host_str)
+                    if x_forwarded_port_value is not None:
+                        try:
+                            server_port = int(x_forwarded_port_value.decode("latin1").strip())
+                        except ValueError:
+                            pass
+                    elif server_port == 0:
+                        current_scheme = scope.get("scheme", "http")
+                        server_port = 443 if current_scheme in ("https", "wss") else 80
+
+                    scope["server"] = (server_host, server_port)
 
         return await self.app(scope, receive, send)
 

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -67,15 +67,20 @@ class ProxyHeadersMiddleware:
                     scope["client"] = (host, port)
 
             if x_forwarded_host_value is not None:
-                host_str = x_forwarded_host_value.decode("latin1").strip()
-                if host_str:
+                raw_host_str = x_forwarded_host_value.decode("latin1").strip()
+                if raw_host_str:
+                    # When multiple proxies append to X-Forwarded-Host, take the first (client-facing) host
+                    host_str = raw_host_str.split(",")[0].strip()
                     server_host, server_port = _parse_host_port(host_str)
-                    if x_forwarded_port_value is not None:
+                    if server_port == 0 and x_forwarded_port_value is not None:
                         try:
-                            server_port = int(x_forwarded_port_value.decode("latin1").strip())
+                            parsed_port = int(x_forwarded_port_value.decode("latin1").strip())
+                            if 0 < parsed_port <= 65535:
+                                server_port = parsed_port
                         except ValueError:
                             pass
-                    elif server_port == 0:
+
+                    if server_port == 0:
                         current_scheme = scope.get("scheme", "http")
                         server_port = 443 if current_scheme in ("https", "wss") else 80
 


### PR DESCRIPTION
Fixes #965

### Summary
Adds support for `X-Forwarded-Host` and `X-Forwarded-Port` headers in `ProxyHeadersMiddleware` so that when reverse proxies (e.g. NGINX, Cloudflare, Traefik, ALB) proxy traffic to Uvicorn, ASGI applications receive the correct external server address in `scope["server"]`.

### Changes
- Updated `ProxyHeadersMiddleware` in `uvicorn/middleware/proxy_headers.py` to parse `X-Forwarded-Host` and `X-Forwarded-Port` headers when requests originate from a trusted proxy host.
- Correctly parses `host:port` from the header string or falls back to `X-Forwarded-Port` / scheme default (443 for https/wss, 80 for http/ws).
- Added comprehensive unit tests in `tests/middleware/test_proxy_headers.py`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

