### PR TITLE
docs: fix truncated reload-check help and a that/than swap

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -106,7 +106,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     type=float,
     default=0.25,
     show_default=True,
-    help="Delay between previous and next check if application needs to be. Defaults to 0.25s.",
+    help="Delay between previous and next check if application needs to be reloaded. Defaults to 0.25s.",
 )
 @click.option(
     "--workers",

--- a/uvicorn/middleware/proxy_headers.py
+++ b/uvicorn/middleware/proxy_headers.py
@@ -14,7 +14,7 @@ class ProxyHeadersMiddleware:
     `X-Forwarded-For` headers with the connecting client information.
 
     Modifies the `client` and `scheme` information so that they reference
-    the connecting client, rather that the connecting proxy.
+    the connecting client, rather than the connecting proxy.
 
     References:
     - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#Proxies>


### PR DESCRIPTION
Two wording typos:

- `uvicorn/main.py`: the `--reload-delay` help string printed by `uvicorn --help` was truncated — "if application needs to be." — the predicate "reloaded" is missing (`docs/settings.md` has the full text). Restored.
- `uvicorn/middleware/proxy_headers.py`: "rather **that** the connecting proxy" → "rather than".

Both typo-class (no prior discussion needed per the PR template).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

