### PR TITLE
Preserve existing UDS permissions with reload and workers

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -45,7 +45,7 @@ uvicorn itself.
 
 * `--host <str>` - Bind socket to this host. Use `--host 0.0.0.0` to make the application available on your local network. IPv6 addresses are supported, for example: `--host '::'`. **Default:** *'127.0.0.1'*.
 * `--port <int>` - Bind to a socket with this port. If set to 0, an available port will be picked. **Default:** *8000*.
-* `--uds <path>` - Bind to a UNIX domain socket, for example `--uds /tmp/uvicorn.sock`. Useful if you want to run Uvicorn behind a reverse proxy. If a socket already exists at that path, it is replaced while preserving its permissions, including with `--reload` or `--workers`.
+* `--uds <path>` - Bind to a UNIX domain socket, for example `--uds /tmp/uvicorn.sock`. Useful if you want to run Uvicorn behind a reverse proxy. If the path refers directly to an existing UNIX socket, the socket path is replaced while preserving its permissions, including with `--reload` or `--workers`. This also applies when another process is still using that socket; Uvicorn does not check whether it is active.
 * `--fd <int>` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.
 
 ## Development

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -45,7 +45,7 @@ uvicorn itself.
 
 * `--host <str>` - Bind socket to this host. Use `--host 0.0.0.0` to make the application available on your local network. IPv6 addresses are supported, for example: `--host '::'`. **Default:** *'127.0.0.1'*.
 * `--port <int>` - Bind to a socket with this port. If set to 0, an available port will be picked. **Default:** *8000*.
-* `--uds <path>` - Bind to a UNIX domain socket, for example `--uds /tmp/uvicorn.sock`. Useful if you want to run Uvicorn behind a reverse proxy.
+* `--uds <path>` - Bind to a UNIX domain socket, for example `--uds /tmp/uvicorn.sock`. Useful if you want to run Uvicorn behind a reverse proxy. If a socket already exists at that path, it is replaced while preserving its permissions, including with `--reload` or `--workers`.
 * `--fd <int>` - Bind to socket from this file descriptor. Useful if you want to run Uvicorn within a process manager.
 
 ## Development

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -573,6 +573,36 @@ def test_bind_unix_socket_does_not_remove_other_files(
         assert path.read_text() == "keep this file"
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
+def test_bind_unix_socket_does_not_replace_symlink_to_socket(
+    short_socket_name: str, mocker: MockerFixture
+) -> None:  # pragma: py-win32
+    target = Path(short_socket_name)
+    with closing(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)) as existing_socket:
+        existing_socket.bind(short_socket_name)
+    target.chmod(0o600)
+    original_target_inode = target.stat().st_ino
+
+    path = target.with_name("link")
+    path.symlink_to(target)
+    original_link_inode = path.lstat().st_ino
+    config = Config(app=asgi_app, uds=str(path))
+
+    with closing(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)) as sock:
+        mocker.patch("uvicorn.config.socket.socket", return_value=sock)
+        with pytest.raises(SystemExit) as exc_info:
+            config.bind_socket()
+
+    assert exc_info.value.code == STARTUP_FAILURE
+    assert path.is_symlink()
+    assert path.readlink() == target
+    assert path.lstat().st_ino == original_link_inode
+    target_stat = target.stat()
+    assert stat.S_ISSOCK(target_stat.st_mode)
+    assert target_stat.st_ino == original_target_inode
+    assert stat.S_IMODE(target_stat.st_mode) == 0o600
+
+
 @pytest.mark.parametrize(
     "reload, workers",
     [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import socket
+import stat
 import sys
 from collections.abc import Callable, Iterator
 from contextlib import closing
@@ -20,7 +21,7 @@ from pytest_mock import MockerFixture
 from tests.custom_loop_utils import CustomLoop
 from tests.utils import as_cwd, get_asyncio_default_loop_per_os
 from uvicorn._types import ASGIApplication, ASGIReceiveCallable, ASGISendCallable, Environ, Scope, StartResponse
-from uvicorn.config import Config, LoopFactoryType, UvicornDeprecationWarning
+from uvicorn.config import STARTUP_FAILURE, Config, LoopFactoryType, UvicornDeprecationWarning
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from uvicorn.middleware.wsgi import WSGIMiddleware
 from uvicorn.protocols.http.h11_impl import H11Protocol
@@ -527,16 +528,49 @@ def test_ws_max_queue() -> None:
     ids=["--reload=True --workers=1", "--reload=False --workers=2"],
 )
 @pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
+@pytest.mark.parametrize("existing_permissions", [None, 0o600, 0o760])
 def test_bind_unix_socket_works_with_reload_or_workers(
-    tmp_path: Path, reload: bool, workers: int, short_socket_name: str
-):  # pragma: py-win32
+    reload: bool, workers: int, short_socket_name: str, existing_permissions: int | None
+) -> None:  # pragma: py-win32
+    if existing_permissions is not None:
+        with closing(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)) as existing_socket:
+            existing_socket.bind(short_socket_name)
+        os.chmod(short_socket_name, existing_permissions)
+
     config = Config(app=asgi_app, uds=short_socket_name, reload=reload, workers=workers)
     config.load()
-    sock = config.bind_socket()
-    assert isinstance(sock, socket.socket)
-    assert sock.family == socket.AF_UNIX
-    assert sock.getsockname() == short_socket_name
-    sock.close()
+    with closing(config.bind_socket()) as sock:
+        assert sock.family == socket.AF_UNIX
+        assert sock.getsockname() == short_socket_name
+        assert sock.get_inheritable()
+        expected_permissions = 0o666 if existing_permissions is None else existing_permissions
+        assert stat.S_IMODE(os.stat(short_socket_name).st_mode) == expected_permissions
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="require unix-like system")
+@pytest.mark.parametrize("is_directory", [False, True])
+def test_bind_unix_socket_does_not_remove_other_files(
+    short_socket_name: str, is_directory: bool, mocker: MockerFixture
+) -> None:  # pragma: py-win32
+    path = Path(short_socket_name)
+    if is_directory:
+        path.mkdir()
+    else:
+        path.write_text("keep this file")
+    original_inode = path.stat().st_ino
+    config = Config(app=asgi_app, uds=short_socket_name)
+
+    with closing(socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)) as sock:
+        mocker.patch("uvicorn.config.socket.socket", return_value=sock)
+        with pytest.raises(SystemExit) as exc_info:
+            config.bind_socket()
+
+    assert exc_info.value.code == STARTUP_FAILURE
+    assert path.stat().st_ino == original_inode
+    if is_directory:
+        assert path.is_dir()
+    else:
+        assert path.read_text() == "keep this file"
 
 
 @pytest.mark.parametrize(

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -8,6 +8,7 @@ import logging.config
 import os
 import socket
 import ssl
+import stat
 import sys
 from collections.abc import Awaitable, Callable
 from configparser import RawConfigParser
@@ -564,8 +565,16 @@ class Config:
             path = self.uds
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             try:
-                sock.bind(path)
                 uds_perms = 0o666
+                try:
+                    uds_stat = os.stat(path)
+                except FileNotFoundError:
+                    pass
+                else:
+                    if stat.S_ISSOCK(uds_stat.st_mode):
+                        uds_perms = stat.S_IMODE(uds_stat.st_mode)
+                        os.remove(path)
+                sock.bind(path)
                 os.chmod(self.uds, uds_perms)
             except OSError as exc:  # pragma: full coverage
                 logger.error(exc)

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -567,7 +567,7 @@ class Config:
             try:
                 uds_perms = 0o666
                 try:
-                    uds_stat = os.stat(path)
+                    uds_stat = os.lstat(path)
                 except FileNotFoundError:
                     pass
                 else:


### PR DESCRIPTION
# Summary

Fixes #2731.

Starting with `--uds` can reuse an existing Unix socket and retain its permissions, but adding `--reload` (or using multiple workers) fails with `Address already in use`. The supervisor's `Config.bind_socket()` binds directly to the existing pathname, unlike the normal server startup path.

Replace an existing socket before binding in `Config`, preserving its permission bits. New sockets keep the existing `0666` default. Regular files and directories still fail through the existing bind error handling, and `Config.bind_socket()` uses `lstat()` to avoid replacing a symlink to an existing socket. The settings documentation also makes clear that an existing socket path is replaced even when another process is still using it.

Validation on Python 3.13:

- The four existing-socket regression cases fail on the original code on both macOS and Linux; the additional symlink-to-socket regression fails on the initial PR commit on both platforms. All nine focused cases pass with this change.
- `scripts/test -n 2` (including formatting, mypy, lint, and coverage): macOS 1,335 passed / 17 skipped; Linux 1,342 passed / 10 skipped. Both meet the configured 100% coverage threshold.
- `scripts/build`: package, distribution checks, and documentation build pass on both platforms.
- Local Unix-socket HTTP smoke checks pass for normal startup, `--reload`, and two workers, retaining `0760` permissions on both platforms.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/uvicorn/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

